### PR TITLE
Feat docker papi

### DIFF
--- a/dash/scripts/docker-testing/dockerfile
+++ b/dash/scripts/docker-testing/dockerfile
@@ -22,6 +22,6 @@ RUN           cd papi*/src/                                  \
               && make                                        \
               && make install
 ENV           PAPI_BASE=/opt/papi
-
+ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib
 # Set workdir to dash home
 WORKDIR       /opt/dash

--- a/dash/scripts/docker-testing/dockerfile
+++ b/dash/scripts/docker-testing/dockerfile
@@ -8,3 +8,20 @@ RUN           apt-get install -y cmake libhwloc-plugins libhwloc-dev \
                           libopenmpi-dev openmpi-bin openmpi-common \
                           libhdf5-openmpi-dev \
                           git build-essential
+
+# Install PAPI 5.5.0 from source
+WORKDIR       /tmp
+
+# Latest version of PAPI is not compatible
+# ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.5.0.tar.gz papi.tgz
+
+ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.1.tar.gz papi.tgz
+RUN           tar -xf papi.tgz
+RUN           cd papi*/src/                                  \
+              && ./configure --prefix=/opt/papi --with-ffsll \
+              && make                                        \
+              && make install
+ENV           PAPI_BASE=/opt/papi
+
+# Set workdir to dash home
+WORKDIR       /opt/dash


### PR DESCRIPTION
Build PAPI from source before running integration tests to enable DASH's PAPI feature. Changes are only related to CI.
