### PR TITLE
Limit maximum number of parallel builds on CircleCI

### DIFF
--- a/dash/scripts/circleci/run-docker.sh
+++ b/dash/scripts/circleci/run-docker.sh
@@ -2,7 +2,7 @@
 
 echo "Starting docker container ..."
 
-docker run -v $PWD:/opt/dash dash/testing /bin/sh -c "export DASH_MAX_UNITS='2'; export GTEST_TOTAL_SHARDS=${CIRCLE_NODE_TOTAL}; export GTEST_SHARD_INDEX=${CIRCLE_NODE_INDEX}; sh dash/scripts/dash-ci.sh | grep -v 'LOG =' | tee dash-ci.log 2> dash-ci.err;"
+docker run -v $PWD:/opt/dash dash/testing /bin/sh -c "export DASH_MAKE_PROCS='4'; export DASH_MAX_UNITS='2'; export GTEST_TOTAL_SHARDS=${CIRCLE_NODE_TOTAL}; export GTEST_SHARD_INDEX=${CIRCLE_NODE_INDEX}; sh dash/scripts/dash-ci.sh | grep -v 'LOG =' | tee dash-ci.log 2> dash-ci.err;"
 
 TARGETS=`ls -d ./build-ci/*/* | xargs -n1 basename`
 for TARGET in $TARGETS; do

--- a/dash/scripts/dash-ci-deploy.sh
+++ b/dash/scripts/dash-ci-deploy.sh
@@ -12,6 +12,13 @@ INSTALL_PATH=""
 BUILD_TYPE="Release"
 MAKE_TARGET=""
 MAKE_PROCS=`cat /proc/cpuinfo | grep --count 'processor'`
+if ! [ "$DASH_MAKE_PROCS" = "" ]; then
+  if [ "$MAKE_PROCS" -gt "4" ]; then
+    echo "Use at most $MAKE_PROCS processors for building"
+    MAKE_PROCS="4"
+  fi
+fi
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -f)    FORCE_BUILD=true;

--- a/dash/scripts/dash-ci-deploy.sh
+++ b/dash/scripts/dash-ci-deploy.sh
@@ -13,9 +13,9 @@ BUILD_TYPE="Release"
 MAKE_TARGET=""
 MAKE_PROCS=`cat /proc/cpuinfo | grep --count 'processor'`
 if ! [ "$DASH_MAKE_PROCS" = "" ]; then
-  if [ "$MAKE_PROCS" -gt "4" ]; then
+  if [ "$MAKE_PROCS" -gt "$DASH_MAKE_PROCS" ]; then
     echo "Use at most $MAKE_PROCS processors for building"
-    MAKE_PROCS="4"
+    MAKE_PROCS="$DASH_MAKE_PROCS"
   fi
 fi
 


### PR DESCRIPTION
Fixes sporadic build failures on CircleCI.
Sample log output:

```
c++: internal compiler error: Killed (program cc1plus)
Please submit a full bug report, with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-5/README.Bugs> for instructions.
```
