### PR TITLE
Fixes memory leaks reported by valgrind

### DIFF
--- a/dart-impl/base/src/internal/domain_locality.c
+++ b/dart-impl/base/src/internal/domain_locality.c
@@ -201,7 +201,7 @@ dart_ret_t dart__base__locality__domain__copy(
    */
   for (int sd = 0; sd < domain_src->num_domains; sd++) {
     const dart_domain_locality_t * subdomain_src = domain_src->domains + sd;
-    dart_domain_locality_t * subdomain_dst       = domain_dst->domains + sd;
+    dart_domain_locality_t       * subdomain_dst = domain_dst->domains + sd;
 
     ret = dart__base__locality__domain__copy(
             subdomain_src,
@@ -525,27 +525,29 @@ dart_ret_t dart__base__locality__domain__create_subdomains(
                  "num_nodes:%d", num_nodes);
 
   /* Child domains of root are at node level: */
-  global_domain->num_cores      = 0;
-  global_domain->num_domains    = num_nodes;
-  global_domain->scope          = DART_LOCALITY_SCOPE_GLOBAL;
-  global_domain->level          = 0;
-  global_domain->global_index   = 0;
-  global_domain->relative_index = 0;
-  global_domain->domains        = malloc(num_nodes *
-                                         sizeof(dart_domain_locality_t));
+  global_domain->num_cores        = 0;
+  global_domain->num_domains      = num_nodes;
+  global_domain->scope            = DART_LOCALITY_SCOPE_GLOBAL;
+  global_domain->level            = 0;
+  global_domain->shared_mem_bytes = 0;
+  global_domain->global_index     = 0;
+  global_domain->relative_index   = 0;
+  global_domain->domains          = malloc(num_nodes *
+                                           sizeof(dart_domain_locality_t));
   strcpy(global_domain->domain_tag, ".");
 
   for (int n = 0; n < num_nodes; n++) {
     dart_domain_locality_t * node_domain = &global_domain->domains[n];
     dart__base__locality__domain__init(node_domain);
 
-    node_domain->scope          = DART_LOCALITY_SCOPE_NODE;
-    node_domain->level          = global_domain->level + 1;
-    node_domain->global_index   = n;
-    node_domain->relative_index = n;
-    node_domain->parent         = global_domain;
-    node_domain->team           = global_domain->team;
-    node_domain->num_units      = 0;
+    node_domain->scope            = DART_LOCALITY_SCOPE_NODE;
+    node_domain->level            = global_domain->level + 1;
+    node_domain->shared_mem_bytes = -1;
+    node_domain->global_index     = n;
+    node_domain->relative_index   = n;
+    node_domain->parent           = global_domain;
+    node_domain->team             = global_domain->team;
+    node_domain->num_units        = 0;
     sprintf(node_domain->domain_tag, ".%d", node_domain->relative_index);
 
     const char * node_hostname;
@@ -612,12 +614,13 @@ dart_ret_t dart__base__locality__domain__create_node_subdomains(
     dart_domain_locality_t * module_domain = &node_domain->domains[m];
     dart__base__locality__domain__init(module_domain);
 
-    module_domain->scope          = DART_LOCALITY_SCOPE_MODULE;
-    module_domain->level          = node_domain->level + 1;
-    module_domain->global_index   = m;
-    module_domain->relative_index = m;
-    module_domain->parent         = node_domain;
-    module_domain->team           = node_domain->team;
+    module_domain->scope            = DART_LOCALITY_SCOPE_MODULE;
+    module_domain->level            = node_domain->level + 1;
+    module_domain->shared_mem_bytes = -1;
+    module_domain->global_index     = m;
+    module_domain->relative_index   = m;
+    module_domain->parent           = node_domain;
+    module_domain->team             = node_domain->team;
     sprintf(module_domain->domain_tag, "%s.%d",
             node_domain->domain_tag,
             module_domain->relative_index);

--- a/dart-impl/base/src/internal/unit_locality.c
+++ b/dart-impl/base/src/internal/unit_locality.c
@@ -164,7 +164,13 @@ dart_ret_t dart__base__unit_locality__destruct(
   DART_LOG_DEBUG("dart__base__unit_locality__destruct() team: %d",
                  unit_mapping->team);
 
-  free(unit_mapping->unit_localities);
+  if (NULL != unit_mapping) {
+    if (NULL != unit_mapping->unit_localities) {
+      free(unit_mapping->unit_localities);
+      unit_mapping->unit_localities = NULL;
+    }
+    free(unit_mapping);
+  }
 
   DART_LOG_DEBUG("dart__base__unit_locality__destruct >");
   return DART_OK;
@@ -219,8 +225,8 @@ dart_ret_t dart__base__unit_locality__local_unit_new(
     dart_team_myid(team, &myid),
     DART_OK);
 
-  dart_hwinfo_t * hwinfo = malloc(sizeof(dart_hwinfo_t));
-  DART_ASSERT_RETURNS(dart_hwinfo(hwinfo), DART_OK);
+  dart_hwinfo_t hwinfo;
+  DART_ASSERT_RETURNS(dart_hwinfo(&hwinfo), DART_OK);
 
 #if 1 || __TODO__CLARIFY__
   /* Is this call required? */
@@ -232,7 +238,7 @@ dart_ret_t dart__base__unit_locality__local_unit_new(
 
   uloc->unit   = myid;
   uloc->team   = team;
-  uloc->hwinfo = *hwinfo;
+  uloc->hwinfo = hwinfo;
 
 #if defined(DART__BASE__LOCALITY__SIMULATE_MICS)
   /* Assigns every second unit to a MIC host name.

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -262,7 +262,6 @@ dart_ret_t dart__base__locality__delete(
     }
     DART_LOG_DEBUG("dart__base__locality__delete: "
                    "free(dart__base__locality__unit_mapping_[%d])", team);
-    free(dart__base__locality__unit_mapping_[team]);
     dart__base__locality__unit_mapping_[team] = NULL;
   }
 

--- a/dart-impl/mpi/src/dart_communication.c
+++ b/dart-impl/mpi/src/dart_communication.c
@@ -1100,7 +1100,10 @@ dart_ret_t dart_waitall_local(
   dart_handle_t * handle,
   size_t          num_handles)
 {
-  size_t i, r_n = 0;
+  size_t     i,
+             r_n = 0;
+  dart_ret_t ret = DART_OK;
+
   DART_LOG_DEBUG("dart_waitall_local()");
   if (num_handles == 0) {
     DART_LOG_DEBUG("dart_waitall_local > number of handles = 0");
@@ -1171,9 +1174,8 @@ dart_ret_t dart_waitall_local(
             DART_LOG_TRACE("dart_waitall_local: -- MPI_Request_free");
             if (MPI_Request_free(&mpi_req[r_n]) != MPI_SUCCESS) {
               DART_LOG_TRACE("dart_waitall_local ! MPI_Request_free failed");
-              free(mpi_req);
-              free(mpi_sta);
-              return DART_ERR_INVAL;
+              ret = DART_ERR_INVAL;
+              break;
             }
           } else {
             DART_LOG_TRACE("dart_waitall_local: cannot free request %zu "
@@ -1186,7 +1188,9 @@ dart_ret_t dart_waitall_local(
         }
         DART_LOG_DEBUG("dart_waitall_local: free handle[%zu] %p",
                        i, (void*)(handle[i]));
-        free(handle[i]);
+        if (NULL != handle[i]) {
+          free(handle[i]);
+        }
         handle[i] = NULL;
         r_n++;
       }
@@ -1196,8 +1200,8 @@ dart_ret_t dart_waitall_local(
     DART_LOG_TRACE("dart_waitall_local: free MPI_Status temporaries");
     free(mpi_sta);
   }
-  DART_LOG_DEBUG("dart_waitall_local > finished");
-  return DART_OK;
+  DART_LOG_DEBUG("dart_waitall_local > %d", ret);
+  return ret;
 }
 
 dart_ret_t dart_waitall(

--- a/dash/include/dash/GlobMem.h
+++ b/dash/include/dash/GlobMem.h
@@ -462,8 +462,8 @@ private:
   allocator_type          _allocator;
   dart_gptr_t             _begptr     = DART_GPTR_NULL;
   dart_team_t             _teamid     = DART_TEAM_NULL;
-  size_type               _nunits     = 0;
   size_type               _nlelem     = 0;
+  size_type               _nunits     = 0;
   ElementType           * _lbegin     = nullptr;
   ElementType           * _lend       = nullptr;
 };

--- a/dash/scripts/travisci/run-docker.sh
+++ b/dash/scripts/travisci/run-docker.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
-echo "Starting docker container ..."
+BUILD_TYPE=$1
 
-docker run -v $PWD:/opt/dash dashproject/ci:openmpi /bin/sh -c "export DASH_MAX_UNITS='2'; sh dash/scripts/dash-ci.sh | grep -v 'LOG =' | tee dash-ci.log 2> dash-ci.err;"
+echo "Starting docker container for build target $BUILD_TYPE ..."
+
+docker run -v $PWD:/opt/dash dashproject/ci:openmpi /bin/sh -c \
+              "export DASH_MAX_UNITS='2'; sh dash/scripts/dash-ci.sh $BUILD_TYPE | grep -v 'LOG =' | tee dash-ci.log 2> dash-ci.err;"
 
 echo "checking logs"
 


### PR DESCRIPTION
Addresses #72

valgrind command used:

~~~bash
$ mpirun -n 4 \
  valgrind --leak-check=full \
           --track-origins=yes \
           --log-file=dash-test.%p.vg \
    ./bin/dash-test-mpi
~~~

Using Debug build from gcc/g++ 4.8 with MKL disabled (requires Intel compiler which is incompatible with valgrind).

Output now only contains false positives from MPI runtime.