### PR TITLE
Sup 109 dart threadsafety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ Features:
         - `dart__base__locality__domain`
         - `dart__base__locality__unit`
 
+Fixes:
+- Added clarification that DART currently does not provide thread-safe access. 
+
 # DASH 0.2.0 (2016-03-03)
 
 ## Build System

--- a/dart-if/v3.2/include/dash/dart/if/dart.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart.h
@@ -9,7 +9,8 @@
  * Common C interface of the underlying communication back-end.
  *
  *
- * --- DASH/DART Terminology ---
+ * DASH/DART Terminology
+ * =====================
  *
  * DASH is a realization of the PGAS (partitioned global address space)
  * programming model. Below is an attempt to define some of the

--- a/dart-if/v3.2/include/dash/dart/if/dart.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart.h
@@ -41,7 +41,7 @@
  * Local/Global/Private/Shared
  * ---------------------------
  *
- * 1) Local and Global:
+ * ### 1) Local and Global: #####
  * The terms local and global are adjectives to describe the address
  * spaces in a DASH program. The local address space of a dash unit is
  * managed by the regular OS mechanisms (malloc, free), and data items
@@ -51,17 +51,17 @@
  * of the global address space. Data items in the global memory are
  * addressed by global pointers provided by the DART runtime.
  *
- * 2) Private and Shared:
+ * ### 2) Private and Shared: ###
  * The adjectives private and shared describe the accessibility of data
  * items in DASH. A shared datum is one that can be accessed by more
  * than one unit (by means of the DART runtime).  A private datum is one
  * that is not shared.
  *
- * 3) Partitions, Affinity, Ownership
+ * ### 3) Partitions, Affinity, Ownership ###
  * ... to be written...
  * idea: we might use the term affinity to express hierarchical locality
  *
- * 4) Team-Alignment and Symmetricity:
+ * ### 4) Team-Alignment and Symmetricity: ###
  * Team-aligned and symmetric are terms describing memory allocations.
  * A memory allocation is symmetric (with respect to a team), if the
  * same amount of memory (in bytes) is allocated by each member of the
@@ -78,10 +78,25 @@
  * A note on thread safety:
  * ------------------------
  *
- * At the moment, the DART API specification does not guarantee the correctness
- * of thread-parallel access. It is thus erroneous to use DART or DASH functionality
- * from within a multi-threaded context.
- * The specification of thread-safety will be added in the next release.
+ * In this release, most of DART's functionality cannot be called from within
+ * multiple threads in parallel. This is especially true for
+ * \ref DartGroupTeam "group and team management" and \ref DartGlobMem "global memory management"
+ * functionality as well as \ref DartCommunication "communication operations".
+ * All exceptions from this rule have been marked accordingly in the documentation.
+ * Improvements to thread-safety of DART are scheduled for the next release.
+ *
+ * Note that this also affects global operations in DASH as they rely on DART functionality.
+ * However, all operations on local data can be considered thread-safe, i.e., they adhere
+ * to the C++ STL thread-safety rules (see http://en.cppreference.com/w/cpp/container
+ * for details). Thus, the following code is valid:
+ *
+ * \code{.cc}
+dash::Array<int> arr(...);
+#pragma omp parallel for // OK to parallelize since we're working on .local
+for( auto i=0; i<arr.local.size(); i++ ) [
+ arr.local[i]=foo(i);
+}
+ * \endcode
  */
 #ifdef __cplusplus
 extern "C" {

--- a/dart-if/v3.2/include/dash/dart/if/dart.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart.h
@@ -86,9 +86,10 @@
  * Improvements to thread-safety of DART are scheduled for the next release.
  *
  * Note that this also affects global operations in DASH as they rely on DART functionality.
- * However, all operations on local data can be considered thread-safe, i.e., they adhere
- * to the C++ STL thread-safety rules (see http://en.cppreference.com/w/cpp/container
- * for details). Thus, the following code is valid:
+ * However, all operations on local data can be considered thread-safe, e.g., `Container.local` or
+ * `Container.lbegin`. The local access operators adhere to the C++ STL thread-safety
+ * rules (see http://en.cppreference.com/w/cpp/container for details).
+ * Thus, the following code is valid:
  *
  * \code{.cc}
 dash::Array<int> arr(...);

--- a/dart-if/v3.2/include/dash/dart/if/dart.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart.h
@@ -77,8 +77,10 @@
  * A note on thread safety:
  * ------------------------
  *
- * All functions in the DART interface shall be implemented in a thread
- * safe way.
+ * At the moment, the DART API specification does not guarantee the correctness
+ * of thread-parallel access. It is thus erroneous to use DART or DASH functionality
+ * from within a multi-threaded context.
+ * The specification of thread-safety will be added in the next release.
  */
 #ifdef __cplusplus
 extern "C" {

--- a/dart-if/v3.2/include/dash/dart/if/dart_communication.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_communication.h
@@ -7,6 +7,9 @@
 /**
  * \file dart_communication.h
  *
+ * \defgroup  DartCommunication  Communication routines in DART
+ * \ingroup   DartInterface
+ *
  * \brief A set of basic communication routines in DART.
  *
  * The semantics of the routines below are the same as with MPI. The only
@@ -14,11 +17,6 @@
  * raw buffers instead. Message sizes are thus specified in bytes.
  */
 
-/**
- * \defgroup  DartCommunication  Communication routines in DART
- * \ingroup   DartInterface
- *
- */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/dart-if/v3.2/include/dash/dart/if/dart_communication.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_communication.h
@@ -54,6 +54,7 @@ dart_ret_t dart_barrier(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_bcast(
@@ -73,6 +74,7 @@ dart_ret_t dart_bcast(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_scatter(
@@ -93,6 +95,7 @@ dart_ret_t dart_scatter(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_gather(
@@ -112,6 +115,7 @@ dart_ret_t dart_gather(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_allgather(
@@ -132,6 +136,7 @@ dart_ret_t dart_allgather(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_allgatherv(
@@ -154,6 +159,7 @@ dart_ret_t dart_allgatherv(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_allreduce(
@@ -169,6 +175,7 @@ dart_ret_t dart_allreduce(
  *
  * \todo Why is this not generic?
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_reduce_double(
@@ -189,6 +196,7 @@ dart_ret_t dart_reduce_double(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_accumulate(
@@ -211,6 +219,7 @@ dart_ret_t dart_accumulate(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_fetch_and_op(
@@ -245,6 +254,7 @@ dart_ret_t dart_fetch_and_op(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_get(
@@ -265,6 +275,7 @@ dart_ret_t dart_get(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_put(
@@ -284,6 +295,7 @@ dart_ret_t dart_put(
  * \param gptr Global pointer identifying the segment and unit to complete outstanding operations for.
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_flush(
@@ -300,6 +312,7 @@ dart_ret_t dart_flush(
  * \param gptr Global pointer identifying the segment to complete outstanding operations for.
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_flush_all(
@@ -316,6 +329,7 @@ dart_ret_t dart_flush_all(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_flush_local(
@@ -332,6 +346,7 @@ dart_ret_t dart_flush_local(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_flush_local_all(
@@ -366,6 +381,7 @@ typedef struct dart_handle_struct * dart_handle_t;
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_get_handle(
@@ -387,6 +403,7 @@ dart_ret_t dart_get_handle(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_put_handle(
@@ -415,6 +432,7 @@ dart_ret_t dart_wait(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_waitall(
@@ -428,6 +446,7 @@ dart_ret_t dart_waitall(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_wait_local(
@@ -441,6 +460,7 @@ dart_ret_t dart_wait_local(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_waitall_local(
@@ -455,6 +475,7 @@ dart_ret_t dart_waitall_local(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_test_local(
@@ -470,6 +491,7 @@ dart_ret_t dart_test_local(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_testall_local(
@@ -496,6 +518,7 @@ dart_ret_t dart_testall_local(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_get_blocking(
@@ -513,6 +536,7 @@ dart_ret_t dart_get_blocking(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartCommunication
  */
 dart_ret_t dart_put_blocking(

--- a/dart-if/v3.2/include/dash/dart/if/dart_communication.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_communication.h
@@ -10,7 +10,7 @@
  * \defgroup  DartCommunication  Communication routines in DART
  * \ingroup   DartInterface
  *
- * \brief A set of basic communication routines in DART.
+ * A set of basic communication routines in DART.
  *
  * The semantics of the routines below are the same as with MPI. The only
  * difference is that DART doesn't specify data types but operates on

--- a/dart-if/v3.2/include/dash/dart/if/dart_config.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_config.h
@@ -6,13 +6,13 @@
 /**
  * \file dart_config.h
  *
- * Interface to access the DART runtime configuration.
- */
-
-/**
  * \defgroup  DartConfig  DART runtime configuration interface
  * \ingroup   DartInterface
+ *
+ * Interface to access the DART runtime configuration.
+ *
  */
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/dart-if/v3.2/include/dash/dart/if/dart_globmem.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_globmem.h
@@ -92,10 +92,11 @@ typedef struct
 #ifdef __cplusplus
 #define DART_GPTR_NULL (dart_gptr_t { -1, 0, 0, { 0 } })
 #else
-#define DART_GPTR_NULL ((dart_gptr_t)({ .unitid = -1, \
-                                        .segid  =  0, \
-                                        .flags  =  0, \
-                                        .addr_or_offs.offset = 0 }))
+#define DART_GPTR_NULL \
+((dart_gptr_t)({ .unitid = -1, \
+                 .segid  =  0, \
+                 .flags  =  0, \
+                 .addr_or_offs.offset = 0 }))
 #endif
 
 /**
@@ -130,6 +131,7 @@ typedef struct
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_gptr_getaddr(const dart_gptr_t gptr, void **addr);
@@ -143,6 +145,7 @@ dart_ret_t dart_gptr_getaddr(const dart_gptr_t gptr, void **addr);
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_gptr_setaddr(dart_gptr_t *gptr, void *addr);
@@ -154,6 +157,8 @@ dart_ret_t dart_gptr_setaddr(dart_gptr_t *gptr, void *addr);
  * \param offs Offset by which to increment \c gptr
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_gptr_incaddr(dart_gptr_t *gptr, int32_t offs);
@@ -165,6 +170,8 @@ dart_ret_t dart_gptr_incaddr(dart_gptr_t *gptr, int32_t offs);
  * \param unit The unit to set in \c gptr
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_gptr_setunit(dart_gptr_t *gptr, dart_unit_t unit);
@@ -181,6 +188,7 @@ dart_ret_t dart_gptr_setunit(dart_gptr_t *gptr, dart_unit_t unit);
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_memalloc(size_t nbytes, dart_gptr_t *gptr);
@@ -193,6 +201,8 @@ dart_ret_t dart_memalloc(size_t nbytes, dart_gptr_t *gptr);
  * \param gptr Global pointer to the memory allocation to free
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_memfree(dart_gptr_t gptr);
@@ -218,6 +228,8 @@ dart_ret_t dart_memfree(dart_gptr_t gptr);
  * \param[out] gptr Global pointer to store information on the allocation
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_team_memalloc_aligned(
@@ -238,6 +250,8 @@ dart_ret_t dart_team_memalloc_aligned(
  * \see DART_GPTR_NULL
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_team_memfree(
@@ -257,6 +271,8 @@ dart_ret_t dart_team_memfree(
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
  * \see dart_team_memalloc_aligned
+ *
+ * \threadsafe_none
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_team_memregister_aligned(
@@ -276,6 +292,7 @@ dart_ret_t dart_team_memregister_aligned(
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_team_memregister(
@@ -296,6 +313,8 @@ dart_ret_t dart_team_memregister(
  *
  * \see dart_team_memregister
  * \see dart_team_memregister_aligned
+ *
+ * \threadsafe_none
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_team_memderegister(dart_team_t teamid, dart_gptr_t gptr);

--- a/dart-if/v3.2/include/dash/dart/if/dart_globmem.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_globmem.h
@@ -4,14 +4,13 @@
 /**
  * \file dart_globmem.h
  *
- * Routines for allocation and reclamation of global memory regions and
- * pointer semantics in partitioned global address space.
- */
-
-/**
  * \defgroup  DartGlobMem    Global memory and PGAS address semantics
  * \ingroup   DartInterface
+ *
+ * Routines for allocation and reclamation of global memory regions and pointer semantics in partitioned global address space.
+ *
  */
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/dart-if/v3.2/include/dash/dart/if/dart_initialization.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_initialization.h
@@ -31,6 +31,7 @@ extern "C" {
  *
  * \return \c DART_OK on sucess or an error code from \see dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartInitialization
 */
 dart_ret_t dart_init(int *argc, char ***argv);
@@ -40,6 +41,7 @@ dart_ret_t dart_init(int *argc, char ***argv);
  *
  * \return \c DART_OK on sucess or an error code from \c dart_ret_t otherwise.
  *
+ * \threadsafe_none
  * \ingroup DartInitialization
  */
 dart_ret_t dart_exit();
@@ -49,6 +51,7 @@ dart_ret_t dart_exit();
  *
  * \return 0 if DART has not been initialized or has been shut down already, >0 otherwise.
  *
+ * \threadsafe
  * \ingroup DartInitialization
  */
 char       dart_initialized();

--- a/dart-if/v3.2/include/dash/dart/if/dart_initialization.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_initialization.h
@@ -8,7 +8,7 @@
  * \defgroup  DartInitialization  DART Initialization and Finalization
  * \ingroup   DartInterface
  *
- * \brief Initialization and finalization of the DASH runtime backend.
+ * Initialization and finalization of the DASH runtime backend.
  *
  * No other DART function may be called before \ref dart_init or after \ref dart_exit.
  *
@@ -24,7 +24,7 @@ extern "C" {
 /** \endcond */
 
 /**
- * \brief Initialize the DART runtime
+ * Initialize the DART runtime
  *
  * \param argc Pointer to the number of command line arguments.
  * \param argv Pointer to the array of command line arguments.
@@ -36,7 +36,7 @@ extern "C" {
 dart_ret_t dart_init(int *argc, char ***argv);
 
 /**
- * \brief Finalize the DASH runtime.
+ * Finalize the DASH runtime.
  *
  * \return \c DART_OK on sucess or an error code from \c dart_ret_t otherwise.
  *
@@ -45,7 +45,7 @@ dart_ret_t dart_init(int *argc, char ***argv);
 dart_ret_t dart_exit();
 
 /**
- * \brief Whether the DASH runtime has been initialized.
+ * Whether the DASH runtime has been initialized.
  *
  * \return 0 if DART has not been initialized or has been shut down already, >0 otherwise.
  *

--- a/dart-if/v3.2/include/dash/dart/if/dart_initialization.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_initialization.h
@@ -5,16 +5,16 @@
 
 /**
  * \file dart_initialization.h
+ * \defgroup  DartInitialization  DART Initialization and Finalization
+ * \ingroup   DartInterface
  *
- * \brief Initialization and finalization of the DASH runtime backend. No other DART function may be called before \see dart_init() or after
- * \see dart_exit().
+ * \brief Initialization and finalization of the DASH runtime backend.
+ *
+ * No other DART function may be called before \ref dart_init or after \ref dart_exit.
+ *
  *
  */
 
-/**
- * \defgroup  DartInitialization  DART Initialization and Finalization
- * \ingroup   DartInterface
- */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/dart-if/v3.2/include/dash/dart/if/dart_locality.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_locality.h
@@ -1,10 +1,12 @@
 /**
- * \file dash/dart/if/dart_locality.h
+ * \file dart_locality.h
+ * \defgroup  DartLocality  Locality- and topolgy discovery
+ * \ingroup   DartInterface
  *
- * A set of routines to query and remodel the locality domain hierarchy
- * and the logical arrangement of teams.
+ * A set of routines to query and remodel the locality domain hierarchy and the logical arrangement of teams.
  *
  */
+
 #ifndef DART__LOCALITY_H_
 #define DART__LOCALITY_H_
 

--- a/dart-if/v3.2/include/dash/dart/if/dart_locality.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_locality.h
@@ -28,6 +28,7 @@ extern "C" {
 /**
  * Initialize information of the specified team.
  *
+ * \threadsafe_none
  * \ingroup DartLocality
  */
 dart_ret_t dart_team_locality_init(
@@ -36,6 +37,7 @@ dart_ret_t dart_team_locality_init(
 /**
  * Initialize information of the specified team.
  *
+ * \threadsafe_none
  * \ingroup DartLocality
  */
 dart_ret_t dart_team_locality_finalize(
@@ -44,6 +46,7 @@ dart_ret_t dart_team_locality_finalize(
 /**
  * Locality information of the team domain with the specified id tag.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_team_locality(
@@ -55,6 +58,7 @@ dart_ret_t dart_domain_team_locality(
  * Default constructor.
  * Create an empty locality domain object.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_create(
@@ -65,6 +69,7 @@ dart_ret_t dart_domain_create(
  * Create a new locality domain object as a deep copy of a specified
  * locality domain.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_clone(
@@ -75,6 +80,7 @@ dart_ret_t dart_domain_clone(
  * Destructor.
  * Delete a locality domain object.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_destruct(
@@ -84,6 +90,9 @@ dart_ret_t dart_domain_destruct(
  * Assignment operator.
  * Overwrites domain object \c domain_lhs with a deep copy of domain object
  * \c domain_rhs.
+ *
+ * \threadsafe
+ * \ingroup DartLocality
  */
 dart_ret_t dart_domain_assign(
   dart_domain_locality_t        * domain_lhs,
@@ -92,6 +101,7 @@ dart_ret_t dart_domain_assign(
 /**
  * Locality information of the subdomain with the specified id tag.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_find(
@@ -103,6 +113,7 @@ dart_ret_t dart_domain_find(
  * Remove domains in locality domain hierarchy that do not match the
  * specified domain tags and are not a parent of a matched domain.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_select(
@@ -114,6 +125,7 @@ dart_ret_t dart_domain_select(
  * Remove domains in locality domain hierarchy matching the specified domain
  * tags.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_exclude(
@@ -129,6 +141,9 @@ dart_ret_t dart_domain_exclude(
  * Units mapped to inserted subdomains are added to ancestor domains
  * recursively. Units mapped to inserted subdomains must not be mapped
  * to the target domain hierarchy already.
+ *
+ * \threadsafe
+ * \ingroup DartLocality
  */
 dart_ret_t dart_domain_add_subdomain(
   dart_domain_locality_t        * domain,
@@ -139,6 +154,7 @@ dart_ret_t dart_domain_add_subdomain(
  * Split locality domain hierarchy at given domain tag into \c num_parts
  * groups at specified scope.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_split(
@@ -150,6 +166,7 @@ dart_ret_t dart_domain_split(
 /**
  * Domain tags of all domains at the specified locality scope.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_scope_tags(
@@ -161,6 +178,7 @@ dart_ret_t dart_domain_scope_tags(
 /**
  * Locality domains at the specified locality scope.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_scope_domains(
@@ -171,6 +189,9 @@ dart_ret_t dart_domain_scope_domains(
 
 /**
  * Adds entries to locality hierarchy to group locality domains.
+ *
+ * \threadsafe
+ * \ingroup DartLocality
  */
 dart_ret_t dart_domain_group(
   dart_domain_locality_t        * domain_in,
@@ -181,6 +202,7 @@ dart_ret_t dart_domain_group(
 /**
  * Locality information of the unit with the specified global id.
  *
+ * \threadsafe
  * \ingroup DartLocality
  */
 dart_ret_t dart_unit_locality(

--- a/dart-if/v3.2/include/dash/dart/if/dart_synchronization.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_synchronization.h
@@ -3,16 +3,13 @@
 
 /**
  * \file dart_synchronization.h
+ * \defgroup  DartSync    Synchronization primitives for mutual exclusion of units.
+ * \ingroup   DartInterface
  *
  * \brief Synchronization primitives for mutual exclusion of units.
  *
  */
 
-
-/**
- * \defgroup  DartSync    Synchronization primitives for mutual exclusion of units.
- * \ingroup   DartInterface
- */
 
 #ifdef __cplusplus
 extern "C" {

--- a/dart-if/v3.2/include/dash/dart/if/dart_synchronization.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_synchronization.h
@@ -33,6 +33,8 @@ typedef struct dart_lock_struct *dart_lock_t;
  * \param lock   The lock to initialize.
  *
  * \return \c DART_OK on sucess or an error code from \see dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartSync
  */
 dart_ret_t dart_team_lock_init(dart_team_t teamid,
@@ -44,6 +46,8 @@ dart_ret_t dart_team_lock_init(dart_team_t teamid,
  * \param teamid The team this lock is used on.
  * \param lock   The \c lock to free.
  * \return \c DART_OK on sucess or an error code from \see dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartSync
  */
 dart_ret_t dart_team_lock_free(dart_team_t teamid,
@@ -54,6 +58,8 @@ dart_ret_t dart_team_lock_free(dart_team_t teamid,
  *
  * \param lock The lock to acquire
  * \return \c DART_OK on sucess or an error code from \see dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartSync
  */
 dart_ret_t dart_lock_acquire(dart_lock_t lock);
@@ -65,6 +71,8 @@ dart_ret_t dart_lock_acquire(dart_lock_t lock);
  * \param[out] result \c True if the lock was successfully acquired, false otherwise.
  *
  * \return \c DART_OK on success or an error code from \see dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartSync
  */
 dart_ret_t dart_lock_try_acquire(dart_lock_t lock, int32_t *result);
@@ -74,6 +82,8 @@ dart_ret_t dart_lock_try_acquire(dart_lock_t lock, int32_t *result);
  *
  * \param lock The lock to release.
  * \return \c DART_OK on sucess or an error code from \see dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartSync
  */
 dart_ret_t dart_lock_release(dart_lock_t lock);

--- a/dart-if/v3.2/include/dash/dart/if/dart_synchronization.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_synchronization.h
@@ -6,7 +6,7 @@
  * \defgroup  DartSync    Synchronization primitives for mutual exclusion of units.
  * \ingroup   DartInterface
  *
- * \brief Synchronization primitives for mutual exclusion of units.
+ * Synchronization primitives for mutual exclusion of units.
  *
  */
 

--- a/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
@@ -6,6 +6,8 @@
 
 /**
  * \file dart_team_group.h
+ * \defgroup  DartGroupTeam    Management of groups and teams
+ * \ingroup   DartInterface
  *
  * Routines for managing groups of units and to form teams.
  *
@@ -30,10 +32,6 @@
  *
  */
 
-/**
- * \defgroup  DartGroupTeam    Management of groups and teams
- * \ingroup   DartInterface
- */
 
 #ifdef __cplusplus
 extern "C" {

--- a/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
@@ -57,6 +57,8 @@ typedef struct dart_group_struct dart_group_t;
  * \param group Pointer to a group to be initialized.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_init(dart_group_t *group);
@@ -66,6 +68,8 @@ dart_ret_t dart_group_init(dart_group_t *group);
  *
  * \param group Pointer to a group to be finalized.
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_fini(dart_group_t *group);
@@ -78,6 +82,8 @@ dart_ret_t dart_group_fini(dart_group_t *group);
  * \param gout Pointer to the target group object.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_copy(const dart_group_t *gin,
@@ -90,7 +96,10 @@ dart_ret_t dart_group_copy(const dart_group_t *gin,
  * \param g1   Pointer to the first group to join.
  * \param g2   Pointer to the second group to join.
  * \param gout Pointer to the target group object.
+ *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_union(const dart_group_t *g1,
@@ -104,7 +113,10 @@ dart_ret_t dart_group_union(const dart_group_t *g1,
  * \param g1   Pointer to the first group to intersect.
  * \param g2   Pointer to the second group to intersect.
  * \param gout Pointer to the target group object.
+ *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_intersect(const dart_group_t *g1,
@@ -117,7 +129,10 @@ dart_ret_t dart_group_intersect(const dart_group_t *g1,
  *
  * \param unitid Unit to add to group \c g.
  * \param g      Pointer to the target group object.
+ *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_addmember(dart_group_t *g, dart_unit_t unitid);
@@ -128,7 +143,10 @@ dart_ret_t dart_group_addmember(dart_group_t *g, dart_unit_t unitid);
  *
  * \param unitid Unit to remove from group \c g.
  * \param g      Pointer to the target group object.
+ *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_delmember(dart_group_t *g, dart_unit_t unitid);
@@ -140,7 +158,10 @@ dart_ret_t dart_group_delmember(dart_group_t *g, dart_unit_t unitid);
  * \param unitid Unit to test in group \c g.
  * \param g      Pointer to the target group object.
  * \param[out] ismember  True if \c unitid is member of group \c g, false otherwise.
+ *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_ismember(const dart_group_t *g,
@@ -154,6 +175,8 @@ dart_ret_t dart_group_ismember(const dart_group_t *g,
  * \param[out] size The number of units in the group.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_size(const dart_group_t *g,
@@ -168,6 +191,8 @@ dart_ret_t dart_group_size(const dart_group_t *g,
  * \param[out] unitids An array large enough to hold the number of units as returned by \ref dart_group_size.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_getmembers(const dart_group_t *g,
@@ -183,6 +208,8 @@ dart_ret_t dart_group_getmembers(const dart_group_t *g,
  * \param[out] gout An array of at least \c n pointers to the opaque \ref dart_group_t
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_split(const dart_group_t  * g,
@@ -204,6 +231,8 @@ dart_ret_t dart_group_split(const dart_group_t  * g,
  * \param[out] gout   An array of at least \c n pointers to the opaque \ref dart_group_t
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
 */
 dart_ret_t dart_group_locality_split(const dart_group_t      * g,
@@ -218,6 +247,8 @@ dart_ret_t dart_group_locality_split(const dart_group_t      * g,
  * \param[out] size The size of the opaque \ref dart_group_t object.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_group_sizeof(size_t *size);
@@ -243,6 +274,8 @@ dart_ret_t dart_group_sizeof(size_t *size);
  * \param group  Pointer to a group object.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_team_get_group(dart_team_t teamid, dart_group_t *group);
@@ -288,6 +321,8 @@ dart_ret_t dart_team_get_group(dart_team_t teamid, dart_group_t *group);
  * \param[out] newteam Will contain the new team ID upon successful return.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_team_create(dart_team_t          teamid,
@@ -300,6 +335,8 @@ dart_ret_t dart_team_create(dart_team_t          teamid,
  * \param teamid The team to deallocate.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_team_destroy(dart_team_t teamid);
@@ -342,6 +379,8 @@ dart_ret_t dart_team_destroy(dart_team_t teamid);
  * \param[out] myid The unit ID of the calling unit in the respective team.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_team_myid(dart_team_t teamid, dart_unit_t *myid);
@@ -353,6 +392,8 @@ dart_ret_t dart_team_myid(dart_team_t teamid, dart_unit_t *myid);
  * \param[out] size The size of the team.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_team_size(dart_team_t teamid, size_t *size);
@@ -363,6 +404,8 @@ dart_ret_t dart_team_size(dart_team_t teamid, size_t *size);
  * \param[out] myid The global unit ID of the calling unit.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_myid(dart_unit_t *myid);
@@ -373,6 +416,8 @@ dart_ret_t dart_myid(dart_unit_t *myid);
  * \param[out] size The size of the team.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_size(size_t *size);
@@ -387,6 +432,8 @@ dart_ret_t dart_size(size_t *size);
  * This call is *not collective* on the specified team.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_team_unit_l2g(dart_team_t team,
@@ -402,6 +449,8 @@ dart_ret_t dart_team_unit_l2g(dart_team_t team,
  * This call is *not collective* on the specified team.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ *
+ * \threadsafe_none
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_team_unit_g2l(dart_team_t team,

--- a/dart-if/v3.2/include/dash/dart/if/dart_types.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_types.h
@@ -1,5 +1,7 @@
 /**
- * \file dash/dart/if/dart_types.h
+ * \file dart_types.h
+ * \defgroup  DartTypes  Types used in the DART interface
+ * \ingroup   DartInterface
  *
  * Definitions of types used in the DART interface.
  *
@@ -10,10 +12,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-/**
- * \defgroup  DartTypes  Types used in the DART interface
- * \ingroup   DartInterface
- */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/dart-if/v3.2/include/dash/dart/if/dart_types.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_types.h
@@ -21,7 +21,7 @@ extern "C" {
 /** \endcond */
 
 /**
- * \brief Return values of functions in the DART interface.
+ * Return values of functions in the DART interface.
  *
  * \ingroup DartTypes
  */
@@ -42,7 +42,7 @@ typedef enum
 } dart_ret_t;
 
 /**
- * \brief Operations to be used for certain RMA and collective operations.
+ * Operations to be used for certain RMA and collective operations.
  * \ingroup DartTypes
  */
 typedef enum
@@ -72,7 +72,7 @@ typedef enum
 } dart_operation_t;
 
 /**
- * \brief Raw data types supported by the DART interface.
+ * Raw data types supported by the DART interface.
  *
  * \ingroup DartTypes
  */
@@ -91,31 +91,31 @@ typedef enum
 } dart_datatype_t;
 
 /**
- * \brief Data type for storing a unit ID
+ * Data type for storing a unit ID
  * \ingroup DartTypes
  */
 typedef int32_t dart_unit_t;
 
 /**
- * \brief Data type for storing a team ID
+ * Data type for storing a team ID
  * \ingroup DartTypes
  */
 typedef int32_t dart_team_t;
 
 /**
- * \brief Undefined unit ID.
+ * Undefined unit ID.
  * \ingroup DartTypes
  */
 #define DART_UNDEFINED_UNIT_ID ((dart_unit_t)(-1))
 
 /**
- * \brief Undefined team ID.
+ * Undefined team ID.
  * \ingroup DartTypes
  */
 #define DART_UNDEFINED_TEAM_ID ((dart_team_t)(-1))
 
 /**
- * \brief Scopes of locality domains.
+ * Scopes of locality domains.
  *
  * Enum values are ordered by scope level in the locality hierarchy.
  * Consequently, the comparison \c (scope_a > scope_b) is valid

--- a/doc/config/Doxyfile.in
+++ b/doc/config/Doxyfile.in
@@ -62,6 +62,11 @@ ALIASES += commtype="\n@par Communication model\n"
 ALIASES += collective_op="\b Collective operation\n"
 ALIASES += local_op="\b Local operation\n"
 ALIASES += onesided_op="\b One-sided operation\n"
+ALIASES += thread_safety{1}="\par Thread safety\n\1"
+ALIASES += threadsafe="\thread_safety{This function is safe to be called by <i>multiple threads in parallel</i>.}"
+ALIASES += threadsafe_serial="\thread_safety{This function is safe to be called from a multi-threaded context by <i>at most one thread</i>.}"
+ALIASES += threadsafe_none="\thread_safety{This function is <i>not thread-safe</i>.}"
+
 
 # Graphs
 


### PR DESCRIPTION
Add tags describing currently supported thread-safety levels to DART headers. Extend note on thread-safety.

Addresses #109.