### PR TITLE
Fix double free in dart_segment

### DIFF
--- a/dart-impl/mpi/include/dash/dart/mpi/dart_segment.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_segment.h
@@ -44,11 +44,6 @@ dart_ret_t dart_segment_get_teamidx(dart_segid_t segid, uint16_t *team_idx);
  */
 dart_ret_t dart_segment_add_info(const dart_segment_info_t *item);
 
-/**
- * @brief Remove the segment with ID seg_id from the segment hash table.
- */
-dart_ret_t dart_segment_remove(int16_t seg_id);
-
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)
 /** @brief Query the shared memory window object associated with the specified seg_id.
  *

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_segment.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_segment.h
@@ -88,13 +88,13 @@ dart_ret_t dart_segment_get_size(
 /**
  * @brief Deallocates the segment identified by the segment ID.
  */
-dart_ret_t dart_segment_dealloc(dart_segid_t segid);
+dart_ret_t dart_segment_free(dart_segid_t segid);
 
 
 /**
  * @brief Clear the segment data hash table.
  */
-dart_ret_t dart_segment_clear();
+dart_ret_t dart_segment_fini();
 
 
 #endif /* DART_SEGMENT_H_ */

--- a/dart-impl/mpi/src/dart_globmem.c
+++ b/dart-impl/mpi/src/dart_globmem.c
@@ -390,11 +390,9 @@ dart_ret_t dart_team_memfree(
                  unitid, gptr.addr_or_offs.offset, gptr.unitid, teamid);
 	/* Remove the related correspondence relation record from the related
    * translation table. */
-  if (dart_segment_remove(seg_id) != DART_OK) {
+  if (dart_segment_dealloc(seg_id) != DART_OK) {
     return DART_ERR_INVAL;
   }
-
-  dart_segment_dealloc(seg_id);
 
   return DART_OK;
 }
@@ -568,11 +566,9 @@ dart_team_memderegister(
     return DART_ERR_INVAL;
   }
   MPI_Win_detach(win, sub_mem);
-  if (dart_segment_remove(seg_id) != DART_OK) {
+  if (dart_segment_dealloc(seg_id) != DART_OK) {
     return DART_ERR_INVAL;
   }
-
-  dart_segment_dealloc(seg_id);
 
   DART_LOG_DEBUG(
     "dart_team_memderegister: collective free, "

--- a/dart-impl/mpi/src/dart_globmem.c
+++ b/dart-impl/mpi/src/dart_globmem.c
@@ -390,7 +390,7 @@ dart_ret_t dart_team_memfree(
                  unitid, gptr.addr_or_offs.offset, gptr.unitid, teamid);
 	/* Remove the related correspondence relation record from the related
    * translation table. */
-  if (dart_segment_dealloc(seg_id) != DART_OK) {
+  if (dart_segment_free(seg_id) != DART_OK) {
     return DART_ERR_INVAL;
   }
 
@@ -566,7 +566,7 @@ dart_team_memderegister(
     return DART_ERR_INVAL;
   }
   MPI_Win_detach(win, sub_mem);
-  if (dart_segment_dealloc(seg_id) != DART_OK) {
+  if (dart_segment_free(seg_id) != DART_OK) {
     return DART_ERR_INVAL;
   }
 

--- a/dart-impl/mpi/src/dart_initialization.c
+++ b/dart-impl/mpi/src/dart_initialization.c
@@ -307,10 +307,6 @@ dart_ret_t dart_exit()
   MPI_Win_free(&team_data->window);
   MPI_Comm_free(&(team_data->sharedmem_comm));
 
-  /* <fuchsto>: Why calling dart_segment_clear twice? */
-/*
-  dart_segment_clear();
-*/
   dart_buddy_delete(dart_localpool);
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)
   free(team_data->sharedmem_tab);
@@ -319,12 +315,8 @@ dart_ret_t dart_exit()
 
 	dart_adapt_teamlist_destroy();
 
-  /* <fuchsto>: deactivated, currently segfaults when running
-   *            with 3 units:
-   */
-/*
-  dart_segment_clear();
-*/
+  dart_segment_fini();
+
   if (_init_by_dart) {
     DART_LOG_DEBUG("%2d: dart_exit: MPI_Finalize", unitid);
 		MPI_Finalize();

--- a/dart-impl/mpi/src/dart_segment.c
+++ b/dart-impl/mpi/src/dart_segment.c
@@ -337,6 +337,7 @@ dart_ret_t dart_segment_free(dart_segid_t segid)
   while (elem != NULL) {
 
     if (elem->data.segid == segid) {
+      pred->next = elem->next;
       free_segment_info(&elem->data.seg_info);
       elem->seg_id = DART_SEGMENT_INVALID;
       if (freelist_head == NULL) {
@@ -348,7 +349,6 @@ dart_ret_t dart_segment_free(dart_segid_t segid)
         elem->next = freelist_head->next;
         freelist_head->next = elem;
       }
-      pred->next = elem->next;
       return DART_OK;
     }
 

--- a/dart-impl/mpi/src/dart_segment.c
+++ b/dart-impl/mpi/src/dart_segment.c
@@ -319,7 +319,7 @@ static inline void free_segment_info(dart_segment_info_t *seg_info){
  * @return DART_OK on success.
  *         DART_ERR_INVAL if the segment was not found.
  */
-dart_ret_t dart_segment_dealloc(dart_segid_t segid)
+dart_ret_t dart_segment_free(dart_segid_t segid)
 {
   int slot = hash_segid(segid);
   dart_seghash_elem_t *pred = NULL;
@@ -376,7 +376,7 @@ static void clear_segdata_list(dart_seghash_elem_t *listhead)
 /**
  * @brief Clear the segment data hash table.
  */
-dart_ret_t dart_segment_clear()
+dart_ret_t dart_segment_fini()
 {
   int i;
   // clear the hash table


### PR DESCRIPTION
This one was tough albeit it came down to a one-line change related to the handling of the free-list in `dart_segment_free`. Thanks for your help @fuchsto and @fmoessbauer. 

Side note: I still do not know why this error did not show up when running the whole benchmark suite under valgrind locally...

Fixes #46 