### PR TITLE
Changes in DART group/team management

### DIFF
--- a/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
@@ -47,7 +47,7 @@ extern "C" {
  *
  * \ingroup DartGroupTeam
  */
-typedef struct dart_group_struct dart_group_t;
+typedef struct dart_group_struct* dart_group_t;
 
 
 /**
@@ -61,7 +61,7 @@ typedef struct dart_group_struct dart_group_t;
  * \threadsafe
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_init(dart_group_t *group);
+dart_ret_t dart_group_create(dart_group_t *group);
 
 /**
  * Reclaim resources that might be associated with the group.
@@ -72,22 +72,22 @@ dart_ret_t dart_group_init(dart_group_t *group);
  * \threadsafe
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_fini(dart_group_t *group);
+dart_ret_t dart_group_destroy(dart_group_t *group);
 
 
 /**
- * Create a copy of the group
+ * Create a copy of the group \c gin, allocating resources for \c gout.
  *
  * \param gin  Pointer to a group to be copied.
- * \param gout Pointer to the target group object.
+ * \param gout Pointer to the target group object (will be allocated).
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
  * \threadsafe
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_copy(const dart_group_t *gin,
-                           dart_group_t *gout);
+dart_ret_t dart_group_clone(const dart_group_t   gin,
+                            dart_group_t       * gout);
 
 
 /**
@@ -102,9 +102,9 @@ dart_ret_t dart_group_copy(const dart_group_t *gin,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_union(const dart_group_t *g1,
-                            const dart_group_t *g2,
-                            dart_group_t *gout);
+dart_ret_t dart_group_union(const dart_group_t   g1,
+                            const dart_group_t   g2,
+                            dart_group_t       * gout);
 
 
 /**
@@ -119,9 +119,9 @@ dart_ret_t dart_group_union(const dart_group_t *g1,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_intersect(const dart_group_t *g1,
-                                const dart_group_t *g2,
-                                dart_group_t *gout);
+dart_ret_t dart_group_intersect(const dart_group_t   g1,
+                                const dart_group_t   g2,
+                                dart_group_t       * gout);
 
 
 /**
@@ -135,7 +135,7 @@ dart_ret_t dart_group_intersect(const dart_group_t *g1,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_addmember(dart_group_t *g, dart_unit_t unitid);
+dart_ret_t dart_group_addmember(dart_group_t g, dart_unit_t unitid);
 
 
 /**
@@ -149,8 +149,8 @@ dart_ret_t dart_group_addmember(dart_group_t *g, dart_unit_t unitid);
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_delmember(dart_group_t * g,
-                                dart_unit_t    unitid);
+dart_ret_t dart_group_delmember(dart_group_t g,
+                                dart_unit_t  unitid);
 
 
 /**
@@ -165,7 +165,7 @@ dart_ret_t dart_group_delmember(dart_group_t * g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_ismember(const dart_group_t * g,
+dart_ret_t dart_group_ismember(const dart_group_t   g,
                                dart_unit_t          unitid,
                                int32_t            * ismember);
 
@@ -181,7 +181,7 @@ dart_ret_t dart_group_ismember(const dart_group_t * g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_size(const dart_group_t * g,
+dart_ret_t dart_group_size(const dart_group_t   g,
                            size_t             * size);
 
 
@@ -198,7 +198,7 @@ dart_ret_t dart_group_size(const dart_group_t * g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_getmembers(const dart_group_t * g,
+dart_ret_t dart_group_getmembers(const dart_group_t   g,
                                  dart_unit_t        * unitids);
 
 
@@ -218,10 +218,10 @@ dart_ret_t dart_group_getmembers(const dart_group_t * g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_split(const dart_group_t  * g,
+dart_ret_t dart_group_split(const dart_group_t    g,
                             size_t                n,
                             size_t              * nout,
-                            dart_group_t       ** gout);
+                            dart_group_t        * gout);
 
 /**
  * Split the group \c g into \c n groups by the specified locality scope.
@@ -245,24 +245,12 @@ dart_ret_t dart_group_split(const dart_group_t  * g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
 */
-dart_ret_t dart_group_locality_split(const dart_group_t      * g,
+dart_ret_t dart_group_locality_split(const dart_group_t        g,
                                      dart_domain_locality_t  * domain,
                                      dart_locality_scope_t     scope,
                                      size_t                    n,
                                      size_t                  * nout,
-                                     dart_group_t           ** gout);
-
-/**
- * Get the size of an opaque \ref dart_group_t object.
- *
- * \param[out] size The size of the opaque \ref dart_group_t object.
- *
- * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
- *
- * \threadsafe_none
- * \ingroup DartGroupTeam
- */
-dart_ret_t dart_group_sizeof(size_t * size);
+                                     dart_group_t            * gout);
 
 
 /**
@@ -337,7 +325,7 @@ dart_ret_t dart_team_get_group(dart_team_t teamid, dart_group_t *group);
  * \ingroup DartGroupTeam
  */
 dart_ret_t dart_team_create(dart_team_t          teamid,
-                            const dart_group_t * group,
+                            const dart_group_t   group,
                             dart_team_t        * newteam);
 
 /**

--- a/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
@@ -41,6 +41,16 @@ extern "C" {
 #define DART_INTERFACE_ON
 /** \endcond */
 
+/**
+ * \name Group management operations
+ * Non-collectove operations to create, destroy, and manipulate teams.
+ *
+ * Note that \c dart_group_t is an opaque datastructure that is allocated by all
+ * functions creating a group (marked as \c [out]).
+ * This memory has to be released by calling \ref dart_group_destroy after use.
+ */
+
+/** \{ */
 
 /**
  * DART groups are represented by an opaque struct \c dart_group_struct
@@ -51,10 +61,10 @@ typedef struct dart_group_struct* dart_group_t;
 
 
 /**
- * Initialize a DART group object.
+ * Allocate and initialize a DART group object.
  * Must be called before any other function on the group object.
  *
- * \param group Pointer to a group to be initialized.
+ * \param[out] group Pointer to a group to be created.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
@@ -67,6 +77,7 @@ dart_ret_t dart_group_create(dart_group_t *group);
  * Reclaim resources that might be associated with the group.
  *
  * \param group Pointer to a group to be finalized.
+ *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
  * \threadsafe
@@ -78,8 +89,8 @@ dart_ret_t dart_group_destroy(dart_group_t *group);
 /**
  * Create a copy of the group \c gin, allocating resources for \c gout.
  *
- * \param gin  Pointer to a group to be copied.
- * \param gout Pointer to the target group object (will be allocated).
+ * \param      gin  Pointer to a group to be copied.
+ * \param[out] gout Pointer to the target group object (will be allocated).
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
@@ -91,11 +102,11 @@ dart_ret_t dart_group_clone(const dart_group_t   gin,
 
 
 /**
- * Creation a union of the two groups
+ * Create a union of two groups
  *
- * \param g1   Pointer to the first group to join.
- * \param g2   Pointer to the second group to join.
- * \param gout Pointer to the target group object.
+ * \param      g1   Pointer to the first group to join.
+ * \param      g2   Pointer to the second group to join.
+ * \param[out] gout Pointer to the target group object (will be allocated).
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
@@ -110,9 +121,9 @@ dart_ret_t dart_group_union(const dart_group_t   g1,
 /**
  * Create an intersection of the two groups
  *
- * \param g1   Pointer to the first group to intersect.
- * \param g2   Pointer to the second group to intersect.
- * \param gout Pointer to the target group object.
+ * \param      g1   Pointer to the first group to intersect.
+ * \param      g2   Pointer to the second group to intersect.
+ * \param[out] gout Pointer to the target group object (will be allocated).
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
@@ -127,8 +138,8 @@ dart_ret_t dart_group_intersect(const dart_group_t   g1,
 /**
  * Add a member to the group.
  *
- * \param unitid Unit to add to group \c g.
  * \param g      Pointer to the target group object.
+ * \param unitid Unit to add to group \c g.
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
@@ -211,7 +222,7 @@ dart_ret_t dart_group_getmembers(const dart_group_t   g,
  * \param[out]  nout   The actual number of groups that \c g has been split
  *                     into.
  * \param[out]  gout   An array of at least \c n pointers to the opaque
- *                     \ref dart_group_t
+ *                     \ref dart_group_t (the first \c nout objects will be allocated).
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
@@ -238,7 +249,7 @@ dart_ret_t dart_group_split(const dart_group_t    g,
  * \param[out] nout   The actual number of groups that \c g has been split
  *                    into.
  * \param[out] gout   An array of at least \c n pointers to the opaque
- *                    \ref dart_group_t
+ *                    \ref dart_group_t (the first \c nout will be allocated).
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
@@ -252,6 +263,21 @@ dart_ret_t dart_group_locality_split(const dart_group_t        g,
                                      size_t                  * nout,
                                      dart_group_t            * gout);
 
+/** \} */
+
+/**
+ * \name Team management operations
+ * Operations to create, destroy, and query team information.
+ *
+ * Teams are created based on DART groups.
+ *
+ * Note that team creation and destruction are collective operations.
+ *
+ * Functions returning DART groups allocate these opaque objects, which
+ * then have to be destroyed by the user using \ref dart_group_destroy.
+ */
+
+/** \{ */
 
 /**
  * The default team consisting of all units
@@ -269,8 +295,8 @@ dart_ret_t dart_group_locality_split(const dart_group_t        g,
 /**
  * Query the group associated with the specified team
  *
- * \param teamid The team to use.
- * \param group  Pointer to a group object.
+ * \param      teamid The team to use.
+ * \param[out] group  Pointer to a group object (will be allocated).
  *
  * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
  *
@@ -469,6 +495,7 @@ dart_ret_t dart_team_unit_g2l(dart_team_t team,
                               dart_unit_t globalid,
                               dart_unit_t *localid);
 
+/** \} */
 
 
 /** \cond DART_HIDDEN_SYMBOLS */

--- a/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
+++ b/dart-if/v3.2/include/dash/dart/if/dart_team_group.h
@@ -338,7 +338,20 @@ dart_ret_t dart_team_create(dart_team_t          teamid,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_destroy(dart_team_t teamid);
+dart_ret_t dart_team_destroy(dart_team_t * teamid);
+
+
+/**
+ * Clone a DART team object by duplicating the underlying team information.
+ *
+ * \param      team     The source team to duplicate
+ * \param[out] newteam  The target team to duplicate to.
+ *
+ * \return \c DART_OK on success, any other of \ref dart_ret_t otherwise.
+ * \threadsafe_none
+ * \ingroup DartGroupTeam
+ */
+dart_ret_t dart_team_clone(dart_team_t team, dart_team_t *newteam);
 
 /**
  * Return the unit id of the caller in the specified team.

--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -371,7 +371,7 @@ dart_ret_t dart__base__host_topology__update_module_locations(
     if (num_leaders > 1) {
       DART_LOG_TRACE("dart__base__host_topology__init: finalize leader team");
       DART_ASSERT_RETURNS(
-        dart_team_destroy(leader_team),
+        dart_team_destroy(&leader_team),
         DART_OK);
     }
   }
@@ -414,7 +414,7 @@ dart_ret_t dart__base__host_topology__update_module_locations(
     if (num_hosts > 1) {
       DART_LOG_TRACE("dart__base__host_topology__init: finalize local team");
       DART_ASSERT_RETURNS(
-        dart_team_destroy(local_team),
+        dart_team_destroy(&local_team),
         DART_OK);
     }
 

--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -154,14 +154,12 @@ dart_ret_t dart__base__host_topology__update_module_locations(
    *
    * Select one leader unit per node for communication:
    */
-  size_t group_t_size;
-  dart_group_sizeof(&group_t_size);
 
   dart_unit_locality_t * my_uloc;
   dart_unit_t            local_leader_unit_id = DART_UNDEFINED_UNIT_ID;
   dart_unit_t            my_id                = DART_UNDEFINED_UNIT_ID;
-  dart_group_t         * leader_group         = malloc(group_t_size);
-  dart_group_t         * local_group          = malloc(group_t_size);
+  dart_group_t           leader_group;
+  dart_group_t           local_group;
   dart_team_t            leader_team; /* team of all node leaders   */
 
   DART_ASSERT_RETURNS(
@@ -172,10 +170,10 @@ dart_ret_t dart__base__host_topology__update_module_locations(
       unit_mapping, my_id, &my_uloc),
     DART_OK);
   DART_ASSERT_RETURNS(
-    dart_group_init(leader_group),
+    dart_group_create(&leader_group),
     DART_OK);
   DART_ASSERT_RETURNS(
-    dart_group_init(local_group),
+    dart_group_create(&local_group),
     DART_OK);
 
   dart_unit_locality_t * unit_locality;
@@ -241,9 +239,8 @@ dart_ret_t dart__base__host_topology__update_module_locations(
   }
 
   DART_ASSERT_RETURNS(
-    dart_group_fini(leader_group),
+    dart_group_destroy(&leader_group),
     DART_OK);
-  free(leader_group);
 
   if (my_id == local_leader_unit_id) {
     dart_module_location_t * module_locations = NULL;
@@ -439,9 +436,8 @@ dart_ret_t dart__base__host_topology__update_module_locations(
 
 
   DART_ASSERT_RETURNS(
-    dart_group_fini(local_group),
+    dart_group_destroy(&local_group),
     DART_OK);
-  free(local_group);
 
 #if 1
   /* Classify hostnames into categories 'node' and 'module'.

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -25,31 +25,47 @@
  * Private Functions                                                        *
  * ======================================================================= */
 
-dart_ret_t dart_group_init(
+static struct dart_group_struct* allocate_group()
+{
+  struct dart_group_struct* group = malloc(sizeof(struct dart_group_struct));
+  return group;
+}
+
+dart_ret_t dart_group_create(
   dart_group_t *group)
 {
+  struct dart_group_struct* res = allocate_group();
   // Initialize the group as empty but not directly assign MPI_GROUP_EMPTY as it might lead to invalid free later
   MPI_Group g;
   MPI_Comm_group(MPI_COMM_WORLD, &g);
-  MPI_Group_incl(g, 0, NULL, &group->mpi_group);
+  MPI_Group_incl(g, 0, NULL, &res->mpi_group);
+  *group = res;
   return DART_OK;
 }
 
-dart_ret_t dart_group_fini(
+dart_ret_t dart_group_destroy(
   dart_group_t *group)
 {
-  if (group->mpi_group != MPI_GROUP_NULL) {
-    MPI_Group_free(&group->mpi_group);
-    group->mpi_group = MPI_GROUP_NULL;
+  struct dart_group_struct** g = group;
+  if ((*g)->mpi_group != MPI_GROUP_NULL) {
+    MPI_Group_free(&(*g)->mpi_group);
+    (*g)->mpi_group = MPI_GROUP_NULL;
   }
+
+  free(*g);
+  *g = NULL;
+
   return DART_OK;
 }
 
-dart_ret_t dart_group_copy(
-  const dart_group_t *gin,
-  dart_group_t *gout)
+dart_ret_t dart_group_clone(
+  const dart_group_t   gin,
+  dart_group_t       * gout)
 {
-  gout->mpi_group = gin -> mpi_group;
+  //gout->mpi_group = gin->mpi_group;
+  struct dart_group_struct* res = allocate_group();
+  MPI_Group_excl(gin->mpi_group, 0, NULL, &res->mpi_group);
+  *gout = res;
   return DART_OK;
 }
 
@@ -67,29 +83,31 @@ dart_ret_t dart_adapt_group_union(
 #endif
 
 dart_ret_t dart_group_union(
-  const dart_group_t *g1,
-  const dart_group_t *g2,
-  dart_group_t *gout)
+  const dart_group_t   g1,
+  const dart_group_t   g2,
+  dart_group_t       * gout)
 {
+  *gout = NULL;
   /* g1 and g2 are both ordered groups. */
+  struct dart_group_struct* res = allocate_group();
   if (MPI_Group_union(
               g1->mpi_group,
               g2->mpi_group,
-              &(gout -> mpi_group)) == MPI_SUCCESS)
+              &res->mpi_group) == MPI_SUCCESS)
   {
     int i, j, k, size_in, size_out;
     dart_unit_t *pre_unitidsout, *post_unitidsout;;
 
     MPI_Group group_all;
     MPI_Comm_group(MPI_COMM_WORLD, &group_all);
-    MPI_Group_size(gout->mpi_group, &size_out);
+    MPI_Group_size(res->mpi_group, &size_out);
     if (size_out > 1) {
       MPI_Group_size(g1->mpi_group, &size_in);
       pre_unitidsout  = (dart_unit_t *)malloc(
                           size_out * sizeof (dart_unit_t));
       post_unitidsout = (dart_unit_t *)malloc(
                           size_out * sizeof (dart_unit_t));
-      dart_group_getmembers (gout, pre_unitidsout);
+      dart_group_getmembers (res, pre_unitidsout);
 
       /* Sort gout by the method of 'merge sort'. */
       i = k = 0;
@@ -107,31 +125,35 @@ dart_ret_t dart_group_union(
       while (j <= size_out -1) {
         post_unitidsout[k++] = pre_unitidsout[j++];
       }
-      MPI_Group_free(&gout->mpi_group);
+      MPI_Group_free(&res->mpi_group);
       MPI_Group_incl(
         group_all,
         size_out,
         post_unitidsout,
-        &(gout->mpi_group));
+        &(res->mpi_group));
       free (pre_unitidsout);
       free (post_unitidsout);
     }
+    *gout = res;
     return DART_OK;
   }
   return DART_ERR_INVAL;
 }
 
 dart_ret_t dart_group_intersect(
-  const dart_group_t *g1,
-  const dart_group_t *g2,
-  dart_group_t *gout)
+  const dart_group_t   g1,
+  const dart_group_t   g2,
+  dart_group_t       * gout)
 {
+  struct dart_group_struct* res = allocate_group();
+  *gout = NULL;
   if (MPI_Group_intersection(
            g1 -> mpi_group,
            g2 -> mpi_group,
-           &(gout -> mpi_group)) != MPI_SUCCESS) {
+           &(res->mpi_group)) != MPI_SUCCESS) {
     return DART_ERR_INVAL;
   }
+  *gout = res;
   return DART_OK;
 }
 
@@ -140,30 +162,36 @@ dart_ret_t dart_group_intersect(
  *            to a team)?
  */
 dart_ret_t dart_group_addmember(
-  dart_group_t *g,
-  dart_unit_t unitid)
+  dart_group_t g,
+  dart_unit_t  unitid)
 {
   int array[1];
-  dart_group_t group_copy, group;
+  struct dart_group_struct group;
+  dart_group_t  res;
   MPI_Group     group_all;
   /* Group_all comprises all the running units. */
   MPI_Comm_group(MPI_COMM_WORLD, &group_all);
-  dart_group_copy(g, &group_copy);
   array[0]   = unitid;
   MPI_Group_incl(group_all, 1, array, &group.mpi_group);
   /* Make the new group being an ordered group. */
-  dart_group_union(&group_copy, &group, g);
-  dart_group_fini(&group);
-  dart_group_fini(&group_copy);
+  if (dart_group_union(g, &group, &res) != DART_OK) {
+    return DART_ERR_INVAL;
+  }
+  MPI_Group_free(&group.mpi_group);
+  // swap the group from res to g and properly deallocate
+  MPI_Group tmp  = g->mpi_group;
+  g->mpi_group   = res->mpi_group;
+  res->mpi_group = tmp;
+  dart_group_destroy(&res);
   return DART_OK;
 }
 
 dart_ret_t dart_group_delmember(
-  dart_group_t *g,
-  dart_unit_t unitid)
+  dart_group_t g,
+  dart_unit_t  unitid)
 {
   int array[1];
-  MPI_Group newgroup, group_all;
+  MPI_Group newgroup, group_all, resgroup;
   MPI_Comm_group(MPI_COMM_WORLD, &group_all);
   array[0] = unitid;
   MPI_Group_incl(
@@ -172,34 +200,36 @@ dart_ret_t dart_group_delmember(
     array,
     &newgroup);
   MPI_Group_difference(
-    g -> mpi_group,
+    g->mpi_group,
     newgroup,
-    &(g -> mpi_group));
+    &resgroup);
   MPI_Group_free(&newgroup);
+  MPI_Group_free(&g->mpi_group);
+  g->mpi_group = resgroup;
   return DART_OK;
 }
 
 dart_ret_t dart_group_size(
-  const dart_group_t *g,
-  size_t *size)
+  const dart_group_t   g,
+  size_t             * size)
 {
   int s;
   MPI_Group_size(g->mpi_group, &s);
-  (*size) = s;
+  *size = s;
   return DART_OK;
 }
 
 dart_ret_t dart_group_getmembers(
-  const dart_group_t *g,
-  dart_unit_t *unitids)
+  const dart_group_t   g,
+  dart_unit_t        * unitids)
 {
-  int size, i;
+  int size;
   int *array;
   MPI_Group group_all;
   MPI_Group_size(g->mpi_group, &size);
   MPI_Comm_group(MPI_COMM_WORLD, &group_all);
   array = (int*) malloc(sizeof (int) * size);
-  for (i = 0; i < size; i++) {
+  for (int i = 0; i < size; i++) {
     array[i] = i;
   }
   MPI_Group_translate_ranks(
@@ -213,12 +243,12 @@ dart_ret_t dart_group_getmembers(
 }
 
 dart_ret_t dart_group_split(
-  const dart_group_t  * g,
+  const dart_group_t    g,
   size_t                n,
   size_t              * nout,
-  dart_group_t       ** gout)
+  dart_group_t        * gout)
 {
-  int size, length, i, ranges[1][3];
+  int size, length, ranges[1][3];
 
   MPI_Group_size(g->mpi_group, &size);
 
@@ -236,7 +266,8 @@ dart_ret_t dart_group_split(
   length = (size + (int)(n-1)) / ((int)(n));
 
   /* Note: split the group into chunks of subgroups. */
-  for (i = 0; i < (int)n; i++) {
+  for (int i = 0; i < (int)n; i++) {
+    gout[i] = allocate_group();
     if (i * length < size) {
       ranges[0][0] = i * length;
 
@@ -260,15 +291,13 @@ dart_ret_t dart_group_split(
 }
 
 dart_ret_t dart_group_locality_split(
-  const dart_group_t      * group,
+  const dart_group_t        group,
   dart_domain_locality_t  * domain,
   dart_locality_scope_t     scope,
   size_t                    num_groups,
   size_t                  * nout,
-  dart_group_t           ** gout)
+  dart_group_t            * gout)
 {
-  MPI_Group grouptem;
-
   DART_LOG_TRACE("dart_group_locality_split: split at scope %d", scope);
 
   dart_team_t team = domain->team;
@@ -330,12 +359,12 @@ dart_ret_t dart_group_locality_split(
                        g, u, group_global_unit_ids[u]);
       }
 
+      gout[g] = allocate_group();
       MPI_Group_incl(
         group->mpi_group,
         group_num_units,
         group_global_unit_ids,
-        &grouptem);
-      gout[g]->mpi_group = grouptem;
+        &(gout[g]->mpi_group));
 
       free(group_global_unit_ids);
     }
@@ -420,12 +449,12 @@ dart_ret_t dart_group_locality_split(
                        g, u, group_global_unit_ids[u]);
       }
 
+      gout[g] = allocate_group();
       MPI_Group_incl(
         group->mpi_group,
         group_num_units,
         group_global_unit_ids,
-        &grouptem);
-      (*(gout + g))->mpi_group = grouptem;
+        &(gout[g]->mpi_group));
 
       free(group_team_unit_ids);
       free(group_global_unit_ids);
@@ -440,14 +469,9 @@ dart_ret_t dart_group_locality_split(
   return DART_OK;
 }
 
-dart_ret_t dart_group_sizeof(size_t *size)
-{
-  *size = sizeof(dart_group_t);
-  return DART_OK;
-}
 
 dart_ret_t dart_group_ismember(
-  const dart_group_t * g,
+  const dart_group_t   g,
   dart_unit_t          unitid,
   int32_t            * ismember)
 {
@@ -477,13 +501,17 @@ dart_ret_t dart_team_get_group(
 {
   MPI_Comm comm;
   uint16_t index;
+  *group = NULL;
 
+  struct dart_group_struct* res = allocate_group();
   int result = dart_adapt_teamlist_convert(teamid, &index);
   if (result == -1) {
     return DART_ERR_INVAL;
   }
   comm = dart_team_data[index].comm;
-  MPI_Comm_group(comm, &(group->mpi_group));
+  MPI_Comm_group(comm, &(res->mpi_group));
+
+  *group = res;
   return DART_OK;
 }
 
@@ -494,7 +522,7 @@ dart_ret_t dart_team_get_group(
  */
 dart_ret_t dart_team_create(
   dart_team_t          teamid,
-  const dart_group_t * group,
+  const dart_group_t   group,
   dart_team_t        * newteam)
 {
   MPI_Comm    comm;
@@ -520,7 +548,7 @@ dart_ret_t dart_team_create(
   comm = dart_team_data[unique_id].comm;
   subcomm = MPI_COMM_NULL;
 
-  MPI_Comm_create(comm, group -> mpi_group, &subcomm);
+  MPI_Comm_create(comm, group->mpi_group, &subcomm);
 
   *newteam = DART_TEAM_NULL;
 
@@ -783,13 +811,15 @@ dart_ret_t dart_team_unit_l2g(
 //  printf ("globalid is %d\n", *globalid);
   return DART_OK;
 #endif
+
   int size;
   dart_group_t group;
 
   dart_team_get_group (teamid, &group);
-  MPI_Group_size (group.mpi_group, &size);
+  MPI_Group_size (group->mpi_group, &size);
 
   if (localid >= size) {
+    dart_group_destroy(&group);
     DART_LOG_ERROR ("Invalid localid input: %d", localid);
     return DART_ERR_INVAL;
   }
@@ -800,12 +830,13 @@ dart_ret_t dart_team_unit_l2g(
     MPI_Group group_all;
     MPI_Comm_group(MPI_COMM_WORLD, &group_all);
     MPI_Group_translate_ranks(
-      group.mpi_group,
+      group->mpi_group,
       1,
       &localid,
       group_all,
       globalid);
   }
+  dart_group_destroy(&group);
 
   return DART_OK;
 }
@@ -850,8 +881,9 @@ dart_ret_t dart_team_unit_g2l(
       group_all,
       1,
       &globalid,
-      group.mpi_group,
+      group->mpi_group,
       localid);
+    dart_group_destroy(&group);
   }
   return DART_OK;
 }

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -693,14 +693,18 @@ dart_ret_t dart_team_create(
 }
 
 dart_ret_t dart_team_destroy(
-  dart_team_t teamid)
+  dart_team_t * teamid)
 {
   MPI_Comm    comm;
   MPI_Win     win;
   uint16_t    index;
   dart_unit_t id;
 
-  int result = dart_adapt_teamlist_convert(teamid, &index);
+  if (*teamid == DART_TEAM_NULL) {
+    return DART_OK;
+  }
+
+  int result = dart_adapt_teamlist_convert(*teamid, &index);
   if (result == -1) {
     return DART_ERR_INVAL;
   }
@@ -725,8 +729,21 @@ dart_ret_t dart_team_destroy(
   /* -- Release the communicator associated with teamid -- */
   MPI_Comm_free (&comm);
 
-  DART_LOG_DEBUG("%2d: TEAMDESTROY  - destroy team %d", id, teamid);
+  DART_LOG_DEBUG("%2d: TEAMDESTROY  - destroy team %d", id, *teamid);
+
+  *teamid = DART_TEAM_NULL;
+
   return DART_OK;
+}
+
+
+dart_ret_t dart_team_clone(dart_team_t team, dart_team_t *newteam)
+{
+  dart_group_t group;
+  dart_team_get_group(team, &group);
+  int ret = dart_team_create(team, group, newteam);
+  dart_group_destroy(&group);
+  return ret;
 }
 
 dart_ret_t dart_myid(dart_unit_t *unitid)

--- a/dart-impl/shmem/src/dart_groups_impl.c
+++ b/dart-impl/shmem/src/dart_groups_impl.c
@@ -10,7 +10,7 @@ dart_ret_t dart_group_sizeof(size_t *size)
   return DART_OK;
 }
 
-dart_ret_t dart_group_init(dart_group_t *group)
+dart_ret_t dart_group_create(dart_group_t *group)
 {
   int i;
   
@@ -23,13 +23,13 @@ dart_ret_t dart_group_init(dart_group_t *group)
   return DART_OK; 
 }
 
-dart_ret_t dart_group_fini(dart_group_t *group)
+dart_ret_t dart_group_destroy(dart_group_t *group)
 {
   group->nmem = 0;
   return DART_OK;
 }
 
-dart_ret_t dart_group_copy(const dart_group_t *g, dart_group_t *gout)
+dart_ret_t dart_group_clone(const dart_group_t *g, dart_group_t *gout)
 {
   int i;
   
@@ -166,7 +166,7 @@ dart_ret_t dart_group_split(const dart_group_t *g, size_t nsplits,
   for (i = 0; i < nsplits; i++)
     {
       bsize = (i < brem) ? (bdiv + 1) : bdiv;
-      dart_group_init(gsplit[i]);
+      dart_group_create(gsplit[i]);
 
       for (k = 0; (k < bsize) && (j < nmem); k++, j++)
 	{

--- a/dart-impl/shmem/src/dart_teams_impl.c
+++ b/dart-impl/shmem/src/dart_teams_impl.c
@@ -310,13 +310,13 @@ dart_ret_t dart_shmem_team_init(
   teams[slot].teamid=team;
   
   // build the group for this team
-  dart_group_init(&(teams[slot].group));
+  dart_group_create(&(teams[slot].group));
   if( slot==0 && !group ) {
     for( i=0; i<tsize; i++ ) {
       dart_group_addmember(&(teams[slot].group), i);
     }
   } else  {
-    dart_group_copy(group,
+    dart_group_clone(group,
 		    &(teams[slot].group));
   }
     
@@ -397,7 +397,7 @@ dart_ret_t dart_team_get_group(dart_team_t teamid, dart_group_t *group)
   }
       
   if( SLOT_IS_VALID(slot) ) {
-    ret = dart_group_copy( &(teams[slot].group),
+    ret = dart_group_clone( &(teams[slot].group),
 			   group);
   } else {
     ret = DART_ERR_INVAL;

--- a/dart-impl/shmem/test/test.03.groups/main.c
+++ b/dart-impl/shmem/test/test.03.groups/main.c
@@ -61,9 +61,9 @@ int test_union( dart_group_t *g1,
   int mem4[10] = {0,1,2,5,6,7,11,22,33};
   int nmemb;
 
-  CHECK(dart_group_init(g1));
-  CHECK(dart_group_init(g2));
-  CHECK(dart_group_init(g3));
+  CHECK(dart_group_create(g1));
+  CHECK(dart_group_create(g2));
+  CHECK(dart_group_create(g3));
 
   for(i=0; i<5; i++) {
     CHECK(dart_group_addmember(g1, mem1[i]));
@@ -83,9 +83,9 @@ int test_union( dart_group_t *g1,
     if( mem3[i]!=mem4[i] ) pass=0;
   } 
 
-  CHECK(dart_group_fini(g1));
-  CHECK(dart_group_fini(g2));
-  CHECK(dart_group_fini(g3));
+  CHECK(dart_group_destroy(g1));
+  CHECK(dart_group_destroy(g2));
+  CHECK(dart_group_destroy(g3));
   
   return pass;
 }
@@ -102,9 +102,9 @@ int test_intersect( dart_group_t *g1,
   int mem4[10] = {5};
   int nmemb;
 
-  CHECK(dart_group_init(g1));
-  CHECK(dart_group_init(g2));
-  CHECK(dart_group_init(g3));
+  CHECK(dart_group_create(g1));
+  CHECK(dart_group_create(g2));
+  CHECK(dart_group_create(g3));
 
   for(i=0; i<5; i++) {
     CHECK(dart_group_addmember(g1, mem1[i]));
@@ -124,9 +124,9 @@ int test_intersect( dart_group_t *g1,
     if( mem3[i]!=mem4[i] ) pass=0;
   } 
 
-  CHECK(dart_group_fini(g1));
-  CHECK(dart_group_fini(g2));
-  CHECK(dart_group_fini(g3));
+  CHECK(dart_group_destroy(g1));
+  CHECK(dart_group_destroy(g2));
+  CHECK(dart_group_destroy(g3));
 
   return pass;
 }

--- a/dart-impl/shmem/test/test.06.teams-leak/main.c
+++ b/dart-impl/shmem/test/test.06.teams-leak/main.c
@@ -24,7 +24,7 @@ int main(int argc, char* argv[])
   size_t gsize;
   dart_group_sizeof(&gsize);
   group = malloc(gsize);
-  dart_group_init(group);
+  dart_group_create(group);
 
   int i;
   for( i=0; i<size; i+=1 ) {

--- a/dart-impl/shmem/test/test.06.teams/main.c
+++ b/dart-impl/shmem/test/test.06.teams/main.c
@@ -26,8 +26,8 @@ int main(int argc, char* argv[])
   dart_group_sizeof(&gsize);
   geven = malloc(gsize);
   godd = malloc(gsize);
-  dart_group_init(geven);
-  dart_group_init(godd);
+  dart_group_create(geven);
+  dart_group_create(godd);
 
   int i;
   for( i=0; i<size; i+=2 ) {

--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -109,11 +109,7 @@ private:
   {
     if (dash::is_initialized() && !_has_group) {
       DASH_LOG_DEBUG("Team.get_group()");
-      size_t sz;
-      dart_group_sizeof(&sz);
-      _group = (dart_group_t*)malloc(sz);
-      dart_group_init(_group);
-      dart_team_get_group(_dartid, _group);
+      dart_team_get_group(_dartid, &_group);
       _has_group = true;
     }
     return _has_group;
@@ -173,6 +169,9 @@ public:
     DASH_LOG_DEBUG_VAR("Team.~Team()", this);
 
     Team::unregister_team(this);
+
+    if (_has_group)
+      dart_group_destroy(&_group);
 
     if (_child) {
       delete(_child);
@@ -545,7 +544,7 @@ private:
   mutable size_t          _size         = 0;
   mutable dart_unit_t     _myid         = -1;
   mutable bool            _has_group    = false;
-  mutable dart_group_t  * _group        = nullptr;
+  mutable dart_group_t    _group        = nullptr;
 
   /// Deallocation list for freeing memory acquired via
   /// team-aligned allocation


### PR DESCRIPTION
Changed the type of `dart_group_t` to be a pointer typedef. 

The interface handles group allocation now similar to MPI: a group OUT parameter of a function is allocated by the function, the user does not have to provide allocated group objects for them. However, the user is responsible for freeing the group objects after use. The only use case for `dart_group_create` now is to create an empty group. 

I also implemented  `clone` functions for group and team objects. However, I currently see no use case for explicit  `assign` functions as the basic types `dart_group_t` and `dart_team_t` can be assigned and invalidated using meaningful defaults by the user.  

Please review carefully and suggest any changes you would like to see. 

Addresses #167 