### PR TITLE
Fix errors and warnings reported by Clang

### DIFF
--- a/dart-impl/mpi/include/dash/dart/mpi/dart_synchronization_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_synchronization_priv.h
@@ -4,7 +4,7 @@
  * Definition of dart_lock_struct.
  */
 #ifndef DART_ADAPT_SYNCHRONIZATION_PRIV_H_INCLUDED
-#define DART_ADAPT_SYNCHRONZIATION_PRIV_H_INCLUDED
+#define DART_ADAPT_SYNCHRONIZATION_PRIV_H_INCLUDED
 
 #include <dash/dart/if/dart_types.h>
 #include <dash/dart/if/dart_globmem.h>

--- a/dash/examples/app.01.mindeg/main.cpp
+++ b/dash/examples/app.01.mindeg/main.cpp
@@ -215,13 +215,14 @@ int read_mtx(const std::string & fname,
   std::ifstream infile;
   dash::Shared<int> nnodes;
   dash::Shared<int> ret;
-  int M, N, L;
+  int L = 0;
 
   if ( dash::myid() == 0 ) {
     infile.open(fname.c_str());
     if (!infile) {
       ret.set(-2);
     } else {
+      int M = 0, N = 0;
       while (infile.peek() == '%') {
         infile.ignore(2048, '\n');
       }

--- a/dash/examples/bench.10.summa/main.cpp
+++ b/dash/examples/bench.10.summa/main.cpp
@@ -8,7 +8,9 @@
 #define DASH__ALGORITHM__COPY__USE_WAIT
 #endif
 
+#ifdef DASH_ENABLE_OPENMP
 #include <omp.h>
+#endif
 
 #ifndef MPI_IMPL_ID
 #define MPI_IMPL_ID unknown

--- a/dash/examples/ex.06.pattern-block-visualizer/main.cpp
+++ b/dash/examples/ex.06.pattern-block-visualizer/main.cpp
@@ -292,7 +292,7 @@ std::string pattern_to_string(
 
   std::ostringstream ss;
   ss << "dash::"
-     << pattern.PatternName
+     << PatternType::PatternName
      << "<"
      << ndim << ","
      << storage_order << ","
@@ -326,7 +326,7 @@ std::string pattern_to_filename(
   auto bspc = pattern.blockspec();
 
   std::ostringstream ss;
-  ss << pattern.PatternName
+  ss << PatternType::PatternName
      << "--"
      << ndim << "-"
      << storage_order << "-"

--- a/dash/examples/ex.06.pattern-block-visualizer/main.cpp
+++ b/dash/examples/ex.06.pattern-block-visualizer/main.cpp
@@ -62,7 +62,7 @@ void print_example(
   dash::tools::PatternBlockVisualizer<PatternT> pv(pattern);
   pv.set_title(pattern_desc);
 
-  std::array<index_t, pattern.ndim()> coords = {{0}};
+  std::array<index_t, PatternT::ndim()> coords = {{0}};
 
   cerr << "Generating visualization of "
        << endl

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -130,7 +130,7 @@ public:
 
   inline bool operator!=(const T & value) const
   {
-    return !(*this != value);
+    return !(*this == value);
   }
 
   friend void swap(GlobRef<T> a, GlobRef<T> b) {

--- a/dash/include/dash/io/hdf5/StorageDriver.h
+++ b/dash/include/dash/io/hdf5/StorageDriver.h
@@ -310,7 +310,7 @@ public:
     hdf5_options                                      foptions
                                                         = _get_fdefaults())
   {
-    static_assert(array.ndim() == pattern_t::ndim(),
+    static_assert(ndim == pattern_t::ndim(),
                   "Pattern dimension has to match matrix dimension");
 
     static_assert(std::is_same<index_t,

--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -627,8 +627,8 @@ dash::default_index_t distance(
   /// Global pointer to the final position in the global sequence
   dart_gptr_t last)
 {
-  GlobPtr<ElementType> & gptr_first(dart_gptr_t(first));
-  GlobPtr<ElementType> & gptr_last(dart_gptr_t(last));
+  GlobPtr<ElementType> & gptr_first(first);
+  GlobPtr<ElementType> & gptr_last(last);
   return gptr_last - gptr_first;
 }
 

--- a/dash/include/dash/matrix/internal/Matrix-inl.h
+++ b/dash/include/dash/matrix/internal/Matrix-inl.h
@@ -372,7 +372,7 @@ Matrix<T, NumDim, IndexT, PatternT>
   size_type offset,
   size_type extent)
 {
-  return _ref.sub<SubDimension>(offset, extent);
+  return this->_ref.template sub<SubDimension>(offset, extent);
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT>
@@ -382,7 +382,7 @@ Matrix<T, NumDim, IndexT, PatternT>
 ::sub(
   size_type n)
 {
-  return _ref.sub<SubDimension>(n);
+  return this->_ref.template sub<SubDimension>(n);
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT>
@@ -391,7 +391,7 @@ Matrix<T, NumDim, IndexT, PatternT>
 ::col(
   size_type n)
 {
-  return _ref.sub<1>(n);
+  return this->_ref.template sub<1>(n);
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT>
@@ -400,7 +400,7 @@ Matrix<T, NumDim, IndexT, PatternT>
 ::row(
   size_type n)
 {
-  return _ref.sub<0>(n);
+  return this->_ref.template sub<0>(n);
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT>
@@ -410,7 +410,7 @@ Matrix<T, NumDim, IndexT, PatternT>
   size_type offset,
   size_type extent)
 {
-  return _ref.sub<0>(offset, extent);
+  return this->_ref.template sub<0>(offset, extent);
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT>
@@ -420,7 +420,7 @@ Matrix<T, NumDim, IndexT, PatternT>
   size_type offset,
   size_type extent)
 {
-  return _ref.sub<1>(offset, extent);
+  return this->_ref.template sub<1>(offset, extent);
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT>

--- a/dash/include/dash/pattern/MakePattern.h
+++ b/dash/include/dash/pattern/MakePattern.h
@@ -187,9 +187,6 @@ make_team_spec(
   typename SizeSpecType::size_type   n_numa_dom   = 0,
   typename SizeSpecType::size_type   n_cores      = 0)
 {
-  // Deduce number of dimensions from size spec:
-  const dim_t ndim  = SizeSpecType::ndim();
-
   DASH_LOG_TRACE_VAR("dash::make_team_spec()", sizespec.extents());
   DASH_LOG_TRACE_VAR("dash::make_team_spec", team.size());
 

--- a/dash/include/dash/pattern/SeqTilePattern.h
+++ b/dash/include/dash/pattern/SeqTilePattern.h
@@ -1663,7 +1663,7 @@ std::ostream & operator<<(
 
   std::ostringstream ss;
   ss << "dash::"
-     << pattern.PatternName
+     << SeqTilePattern<ND,Ar,Index>::PatternName
      << "<"
      << ndim << ","
      << storage_order << ","

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -1759,7 +1759,7 @@ std::ostream & operator<<(
 
   std::ostringstream ss;
   ss << "dash::"
-     << pattern.PatternName
+     << TilePattern<ND,Ar,Index>::PatternName
      << "<"
      << ndim << ","
      << storage_order << ","

--- a/dash/include/dash/util/LocalityDomain.h
+++ b/dash/include/dash/util/LocalityDomain.h
@@ -436,8 +436,6 @@ private:
   }
 
 private:
-  /// Parent locality domain.
-  mutable self_t                                  * _parent    = nullptr;
   /// Underlying \c dart_domain_locality_t object.
   dart_domain_locality_t                          * _domain    = nullptr;
   /// Copy of _domain->domain_tag to avoid string copying.

--- a/dash/src/util/LocalityDomain.cc
+++ b/dash/src/util/LocalityDomain.cc
@@ -475,8 +475,7 @@ dash::util::LocalityDomain::find(
 dash::util::LocalityDomain::LocalityDomain(
   const dash::util::LocalityDomain & parent,
   dart_domain_locality_t           * domain
-) : _parent(const_cast<dash::util::LocalityDomain *>(&parent)),
-    _domain(domain),
+) : _domain(domain),
     _is_owner(false)
 {
   DASH_LOG_TRACE("LocalityDomain(parent,sd)()",

--- a/dash/test/MatrixTest.cc
+++ b/dash/test/MatrixTest.cc
@@ -414,7 +414,8 @@ TEST_F(MatrixTest, Sub2DimDefault)
   element_t * lit  = matrix.lbegin();
   element_t * lend = matrix.lend();
   LOG_MESSAGE("Local range: lend(%p) - lbegin(%p) = %d",
-              (void*)lend, (void*)lit, lend - lit);
+              static_cast<void*>(lend), static_cast<void*>(lit),
+              lend - lit);
   ASSERT_EQ_U(matrix.lend() - matrix.lbegin(),
               matrix.local_size());
   // Assign unit-specific values in local matrix range:

--- a/dash/test/MatrixTest.cc
+++ b/dash/test/MatrixTest.cc
@@ -414,7 +414,7 @@ TEST_F(MatrixTest, Sub2DimDefault)
   element_t * lit  = matrix.lbegin();
   element_t * lend = matrix.lend();
   LOG_MESSAGE("Local range: lend(%p) - lbegin(%p) = %d",
-              lend, lit, lend - lit);
+              (void*)lend, (void*)lit, lend - lit);
   ASSERT_EQ_U(matrix.lend() - matrix.lbegin(),
               matrix.local_size());
   // Assign unit-specific values in local matrix range:


### PR DESCRIPTION
Small fixes to make the Clang compiler happy (includes at least one logic error spotted by Clang). Clean build with Clang 3.8.

Fixes #206 