### PR TITLE
Use a copy of MPI_COMM_WORLD to avoid conflicts on global collective operations

### DIFF
--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -33,13 +33,13 @@
 
 #define DART__BASE__LOCALITY__MAX_TEAM_DOMAINS 32
 
-dart_host_topology_t *
+static dart_host_topology_t *
 dart__base__locality__host_topology_[DART__BASE__LOCALITY__MAX_TEAM_DOMAINS];
 
-dart_unit_mapping_t *
+static dart_unit_mapping_t *
 dart__base__locality__unit_mapping_[DART__BASE__LOCALITY__MAX_TEAM_DOMAINS];
 
-dart_domain_locality_t *
+static dart_domain_locality_t *
 dart__base__locality__global_domain_[DART__BASE__LOCALITY__MAX_TEAM_DOMAINS];
 
 /* ====================================================================== *

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_team_private.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_team_private.h
@@ -144,6 +144,9 @@
 
 extern dart_team_t dart_next_availteamid;
 
+extern MPI_Comm dart_comm_world;
+#define DART_COMM_WORLD dart_comm_world
+
 
 typedef struct dart_team_data {
   /**

--- a/dart-impl/mpi/src/dart_communication.c
+++ b/dart-impl/mpi/src/dart_communication.c
@@ -43,7 +43,7 @@ static int unit_g2l(
     MPI_Group group, group_all;
     comm = dart_team_data[index].comm;
     MPI_Comm_group(comm, &group);
-    MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+    MPI_Comm_group(DART_COMM_WORLD, &group_all);
     MPI_Group_translate_ranks (group_all, 1, &abs_id, group, rel_id);
   }
   return 0;

--- a/dart-impl/mpi/src/dart_globmem.c
+++ b/dart-impl/mpi/src/dart_globmem.c
@@ -183,7 +183,7 @@ dart_team_memalloc_aligned(
 		MPI_Group group;
 		MPI_Group group_all;
 		MPI_Comm_group(comm, &group);
-		MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+		MPI_Comm_group(DART_COMM_WORLD, &group_all);
 		MPI_Group_translate_ranks(group, 1, &localid, group_all, &gptr_unitid);
 	}
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)
@@ -446,7 +446,7 @@ dart_team_memregister_aligned(
     MPI_Group group;
     MPI_Group group_all;
     MPI_Comm_group(comm, &group);
-    MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+    MPI_Comm_group(DART_COMM_WORLD, &group_all);
     MPI_Group_translate_ranks(group, 1, &localid, group_all, &gptr_unitid);
   }
   win = dart_team_data[index].window;
@@ -522,7 +522,7 @@ dart_team_memregister(
     MPI_Group group;
     MPI_Group group_all;
     MPI_Comm_group(comm, &group);
-    MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+    MPI_Comm_group(DART_COMM_WORLD, &group_all);
     MPI_Group_translate_ranks(group, 1, &localid, group_all, &gptr_unitid);
   }
   win = dart_team_data[index].window;

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -37,7 +37,7 @@ dart_ret_t dart_group_create(
   struct dart_group_struct* res = allocate_group();
   // Initialize the group as empty but not directly assign MPI_GROUP_EMPTY as it might lead to invalid free later
   MPI_Group g;
-  MPI_Comm_group(MPI_COMM_WORLD, &g);
+  MPI_Comm_group(DART_COMM_WORLD, &g);
   MPI_Group_incl(g, 0, NULL, &res->mpi_group);
   *group = res;
   return DART_OK;
@@ -99,7 +99,7 @@ dart_ret_t dart_group_union(
     dart_unit_t *pre_unitidsout, *post_unitidsout;;
 
     MPI_Group group_all;
-    MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+    MPI_Comm_group(DART_COMM_WORLD, &group_all);
     MPI_Group_size(res->mpi_group, &size_out);
     if (size_out > 1) {
       MPI_Group_size(g1->mpi_group, &size_in);
@@ -171,7 +171,7 @@ dart_ret_t dart_group_addmember(
   dart_group_t  res;
   MPI_Group     group_all;
   /* Group_all comprises all the running units. */
-  MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+  MPI_Comm_group(DART_COMM_WORLD, &group_all);
   array[0]   = unitid;
   MPI_Group_incl(group_all, 1, array, &group.mpi_group);
   /* Make the new group being an ordered group. */
@@ -193,7 +193,7 @@ dart_ret_t dart_group_delmember(
 {
   int array[1];
   MPI_Group newgroup, group_all, resgroup;
-  MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+  MPI_Comm_group(DART_COMM_WORLD, &group_all);
   array[0] = unitid;
   MPI_Group_incl(
     group_all,
@@ -228,7 +228,7 @@ dart_ret_t dart_group_getmembers(
   int *array;
   MPI_Group group_all;
   MPI_Group_size(g->mpi_group, &size);
-  MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+  MPI_Comm_group(DART_COMM_WORLD, &group_all);
   array = (int*) malloc(sizeof (int) * size);
   for (int i = 0; i < size; i++) {
     array[i] = i;
@@ -655,7 +655,7 @@ dart_ret_t dart_team_create(
     // dart_sharedmem_size[index] * sizeof (int));
 
       MPI_Comm_group(sharedmem_comm, &sharedmem_group);
-      MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+      MPI_Comm_group(DART_COMM_WORLD, &group_all);
 
       int * dart_unit_mapping = malloc(
           team_data->sharedmem_nodesize * sizeof(int));
@@ -751,7 +751,7 @@ dart_ret_t dart_team_clone(dart_team_t team, dart_team_t *newteam)
 dart_ret_t dart_myid(dart_unit_t *unitid)
 {
   if (dart_initialized()) {
-    MPI_Comm_rank(MPI_COMM_WORLD, unitid);
+    MPI_Comm_rank(DART_COMM_WORLD, unitid);
   } else {
     *unitid = -1;
   }
@@ -761,7 +761,7 @@ dart_ret_t dart_myid(dart_unit_t *unitid)
 dart_ret_t dart_size(size_t *size)
 {
   int s;
-  MPI_Comm_size (MPI_COMM_WORLD, &s);
+  MPI_Comm_size (DART_COMM_WORLD, &s);
   (*size) = s;
   return DART_OK;
 }
@@ -847,7 +847,7 @@ dart_ret_t dart_team_unit_l2g(
   }
   else {
     MPI_Group group_all;
-    MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+    MPI_Comm_group(DART_COMM_WORLD, &group_all);
     MPI_Group_translate_ranks(
       group->mpi_group,
       1,
@@ -895,7 +895,7 @@ dart_ret_t dart_team_unit_g2l(
     dart_group_t group;
     MPI_Group group_all;
     dart_team_get_group(teamid, &group);
-    MPI_Comm_group(MPI_COMM_WORLD, &group_all);
+    MPI_Comm_group(DART_COMM_WORLD, &group_all);
     MPI_Group_translate_ranks(
       group_all,
       1,

--- a/dart-impl/mpi/src/dart_team_private.c
+++ b/dart-impl/mpi/src/dart_team_private.c
@@ -10,6 +10,8 @@
 
 dart_team_t dart_next_availteamid;
 
+MPI_Comm dart_comm_world;
+
 #if 0
 MPI_Comm dart_teams[DART_MAX_TEAM_NUMBER];
 

--- a/dash/include/dash/GlobDynamicMem.h
+++ b/dash/include/dash/GlobDynamicMem.h
@@ -1355,7 +1355,7 @@ private:
 
 private:
   allocator_type             _allocator;
-  dash::Team               * _team   = nullptr;
+  dash::Team               * _team;
   dart_team_t                _teamid;
   size_type                  _nunits = 0;
   local_iterator             _lbegin = nullptr;

--- a/dash/include/dash/allocator/CollectiveAllocator.h
+++ b/dash/include/dash/allocator/CollectiveAllocator.h
@@ -66,8 +66,7 @@ public:
    */
   explicit CollectiveAllocator(
     Team & team = dash::Team::All()) noexcept
-  : _team_id(team.dart_id()),
-    _nunits(team.size())
+  : _team_id(team.dart_id())
   { }
 
   /**
@@ -76,11 +75,8 @@ public:
    */
   CollectiveAllocator(self_t && other) noexcept
   : _team_id(other._team_id),
-    _nunits(other._nunits),
-    _allocated(other._allocated)
-  {
-    other._allocated.clear();
-  }
+    _allocated(std::move(other._allocated))
+  { }
 
   /**
    * Copy constructor.
@@ -88,8 +84,7 @@ public:
    * \see DashAllocatorConcept
    */
   CollectiveAllocator(const self_t & other) noexcept
-  : _team_id(other._team_id),
-    _nunits(other._nunits)
+  : _team_id(other._team_id)
   { }
 
   /**
@@ -98,8 +93,7 @@ public:
    */
   template<class U>
   CollectiveAllocator(const CollectiveAllocator<U> & other) noexcept
-  : _team_id(other._team_id),
-    _nunits(other._nunits)
+  : _team_id(other._team_id)
   { }
 
   /**
@@ -128,9 +122,10 @@ public:
   self_t & operator=(const self_t && other) noexcept
   {
     // Take ownership of other instance's allocation vector:
-    clear();
-    _allocated = other._allocated;
-    other._allocated.clear();
+    if (this != &other) {
+      std::swap(_allocated, other._allocated);
+      _team_id = other._team_id;
+    }
     return *this;
   }
 
@@ -241,8 +236,7 @@ private:
   }
 
 private:
-  dart_team_t          _team_id   = DART_TEAM_NULL;
-  size_t               _nunits    = 0;
+  dart_team_t          _team_id;
   std::vector<pointer> _allocated;
 
 }; // class CollectiveAllocator
@@ -253,8 +247,7 @@ bool operator==(
   const CollectiveAllocator<U> & rhs)
 {
   return (sizeof(T)    == sizeof(U) &&
-          lhs._team_id == rhs._team_id &&
-          lhs._nunits  == rhs._nunits );
+          lhs._team_id == rhs._team_id );
 }
 
 template <class T, class U>

--- a/dash/include/dash/allocator/LocalAllocator.h
+++ b/dash/include/dash/allocator/LocalAllocator.h
@@ -71,10 +71,8 @@ public:
    * Takes ownership of the moved instance's allocation.
    */
   LocalAllocator(self_t && other) noexcept
-  : _allocated(other._allocated)
-  {
-    other._allocated.clear();
-  }
+  : _team_id(other._team_id), _allocated(std::move(other._allocated))
+  { }
 
   /**
    * Default constructor, deleted.
@@ -229,7 +227,7 @@ private:
   }
 
 private:
-  dart_team_t          _team_id   = DART_TEAM_NULL;
+  dart_team_t          _team_id;
   std::vector<pointer> _allocated;
 
 }; // class LocalAllocator

--- a/dash/include/dash/util/TeamLocality.h
+++ b/dash/include/dash/util/TeamLocality.h
@@ -232,7 +232,7 @@ public:
   }
 
 private:
-  dash::Team                        * _team          = nullptr;
+  dash::Team                        * _team;
   /// Parent scope of the team locality domain hierarchy.
   Scope_t                             _scope         = Scope_t::Undefined;
   /// Locality domain of the team.

--- a/dash/include/dash/util/TeamLocality.h
+++ b/dash/include/dash/util/TeamLocality.h
@@ -232,7 +232,7 @@ public:
   }
 
 private:
-  dash::Team                        * _team;
+  dash::Team                        * _team          = nullptr;
   /// Parent scope of the team locality domain hierarchy.
   Scope_t                             _scope         = Scope_t::Undefined;
   /// Locality domain of the team.

--- a/dash/src/Team.cc
+++ b/dash/src/Team.cc
@@ -44,7 +44,6 @@ bool operator==(
   return lhs.object == rhs.object;
 }
 
-
 Team::Team(
   dart_team_t id,
   Team      * parent,


### PR DESCRIPTION
The copy is named DART_COMM_WORLD and is meant for internal use only. 