### PR TITLE
Replace SIZE_MAX with C++-equivalent 

### DIFF
--- a/dash/src/util/Config.cc
+++ b/dash/src/util/Config.cc
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <cstring>
 #include <unistd.h>
+#include <limits>
+
 
 // Environment variables as array of strings, terminated by null pointer.
 extern char ** environ;
@@ -134,7 +136,7 @@ void Config::set(
         case 0:   sh = 0;  break;
         default:  sh = -1; break;
       }
-      if (sh > 0 && value_bytes < SIZE_MAX >> sh) {
+      if (sh > 0 && value_bytes < (std::numeric_limits<size_t>::max()) >> sh) {
         value_bytes <<= sh;
       }
     }


### PR DESCRIPTION
std::numeric_limits<size_t>::max() for better compiler support (didn't on gcc4.7, now it works)
Thanks for the great project,
   Martin