### PR TITLE
renamed `dash::Pattern` to `dash::BlockPattern` and re-enabled doxygen.

### DIFF
--- a/dash/include/dash/Pattern.h
+++ b/dash/include/dash/Pattern.h
@@ -630,6 +630,26 @@ public:
 #include <dash/pattern/CSRPattern.h>
 #include <dash/pattern/LoadBalancePattern.h>
 
+#include <dash/Types.h>
+#include <dash/Distribution.h>
+
+namespace dash {
+
+/**
+ * Template alias for dash::Pattern with the same default template
+ * arguments
+ *
+ * \see BlockPattern
+ */
+template<
+  dim_t      NumDimensions,
+  MemArrange Arrangement   = ROW_MAJOR,
+  typename   IndexType     = dash::default_index_t
+>
+using Pattern = dash::BlockPattern<NumDimensions, Arrangement, IndexType>;
+
+} // namespace dash
+
 #include <dash/pattern/PatternIterator.h>
 #include <dash/pattern/PatternProperties.h>
 #include <dash/pattern/MakePattern.h>

--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -1600,23 +1600,6 @@ private:
   }
 };
 
-#ifndef DOXYGEN
-
-/**
- * Template alias for dash::Pattern with the same default template
- * arguments
- *
- * \see BlockPattern
- */
-template<
-  dim_t      NumDimensions,
-  MemArrange Arrangement   = ROW_MAJOR,
-  typename   IndexType     = dash::default_index_t
->
-using Pattern = dash::BlockPattern<NumDimensions, Arrangement, IndexType>;
-
-#endif // DOXYGEN
-
 } // namespace dash
 
 #include <dash/pattern/BlockPattern1D.h>

--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -20,8 +20,6 @@
 
 namespace dash {
 
-#ifndef DOXYGEN
-
 /**
  * Defines how a list of global indices is mapped to single units
  * within a Team.
@@ -40,7 +38,7 @@ template<
   MemArrange Arrangement   = ROW_MAJOR,
   typename   IndexType     = dash::default_index_t
 >
-class Pattern
+class BlockPattern
 {
 public:
   static constexpr char const * PatternName = "BlockPattern";
@@ -77,7 +75,7 @@ private:
   typedef typename std::make_unsigned<IndexType>::type
     SizeType;
   /// Fully specified type definition of self
-  typedef Pattern<NumDimensions, Arrangement, IndexType>
+  typedef BlockPattern<NumDimensions, Arrangement, IndexType>
     self_t;
   typedef CartesianIndexSpace<NumDimensions, Arrangement, IndexType>
     MemoryLayout_t;
@@ -182,7 +180,7 @@ public:
    * \endcode
    */
   template<typename ... Args>
-  Pattern(
+  BlockPattern(
     /// Argument list consisting of the pattern size (extent, number of
     /// elements) in every dimension followed by optional distribution
     /// types.
@@ -249,7 +247,7 @@ public:
    *              TeamSpec<2>(dash::Team::All(), 1));
    * \endcode
    */
-  Pattern(
+  BlockPattern(
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t         & sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
@@ -326,7 +324,7 @@ public:
    *              TeamSpec<2>(dash::Team::All(), 1));
    * \endcode
    */
-  Pattern(
+  BlockPattern(
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t         & sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
@@ -367,7 +365,7 @@ public:
   /**
    * Copy constructor.
    */
-  Pattern(const self_t & other)
+  BlockPattern(const self_t & other)
   : _distspec(other._distspec),
     _team(other._team),
     _teamspec(other._teamspec),
@@ -392,8 +390,8 @@ public:
    * Introduced so variadic constructor is not a better match for
    * copy-construction.
    */
-  Pattern(self_t & other)
-  : Pattern(static_cast<const self_t &>(other))
+  BlockPattern(self_t & other)
+  : BlockPattern(static_cast<const self_t &>(other))
   { }
 
   /**
@@ -431,7 +429,7 @@ public:
   /**
    * Assignment operator.
    */
-  Pattern & operator=(const Pattern & other)
+  BlockPattern & operator=(const BlockPattern & other)
   {
     DASH_LOG_TRACE("BlockPattern.=(other)");
     if (this != &other) {
@@ -1602,10 +1600,25 @@ private:
   }
 };
 
+#ifndef DOXYGEN
+
+/**
+ * Template alias for dash::Pattern with the same default template
+ * arguments
+ *
+ * \see BlockPattern
+ */
+template<
+  dim_t      NumDimensions,
+  MemArrange Arrangement   = ROW_MAJOR,
+  typename   IndexType     = dash::default_index_t
+>
+using Pattern = dash::BlockPattern<NumDimensions, Arrangement, IndexType>;
+
+#endif // DOXYGEN
+
 } // namespace dash
 
 #include <dash/pattern/BlockPattern1D.h>
-
-#endif // DOXYGEN
 
 #endif // DASH__BLOCK_PATTERN_H_

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -1,8 +1,6 @@
 #ifndef DASH__BLOCK_PATTERN_1D_H_
 #define DASH__BLOCK_PATTERN_1D_H_
 
-#ifndef DOXYGEN
-
 #include <functional>
 #include <array>
 #include <type_traits>
@@ -33,7 +31,7 @@ template<
   MemArrange Arrangement,
   typename   IndexType
 >
-class Pattern<1, Arrangement, IndexType>
+class BlockPattern<1, Arrangement, IndexType>
 {
 private:
   static const dim_t NumDimensions = 1;
@@ -73,7 +71,7 @@ private:
   typedef typename std::make_unsigned<IndexType>::type
     SizeType;
   /// Fully specified type definition of self
-  typedef Pattern<NumDimensions, Arrangement, IndexType>
+  typedef BlockPattern<NumDimensions, Arrangement, IndexType>
     self_t;
   typedef CartesianIndexSpace<NumDimensions, Arrangement, IndexType>
     MemoryLayout_t;
@@ -158,7 +156,7 @@ public:
    * \endcode
    */
   template<typename ... Args>
-  Pattern(
+  BlockPattern(
     /// Argument list consisting of the pattern size (extent, number of
     /// elements) in every dimension followed by optional distribution
     /// types.
@@ -222,7 +220,7 @@ public:
    *              TeamSpec<1>(dash::Team::All()));
    * \endcode
    */
-  Pattern(
+  BlockPattern(
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t         sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE).
@@ -289,7 +287,7 @@ public:
    *              TeamSpec<1>(dash::Team::All()));
    * \endcode
    */
-  Pattern(
+  BlockPattern(
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t         sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
@@ -330,7 +328,7 @@ public:
   /**
    * Copy constructor.
    */
-  Pattern(const self_t & other)
+  BlockPattern(const self_t & other)
   : _size(other._size),
     _memory_layout(other._memory_layout),
     _distspec(other._distspec),
@@ -356,8 +354,8 @@ public:
    * Introduced so variadic constructor is not a better match for
    * copy-construction.
    */
-  Pattern(self_t & other)
-  : Pattern(static_cast<const self_t &>(other)) {
+  BlockPattern(self_t & other)
+  : BlockPattern(static_cast<const self_t &>(other)) {
   }
 
   /**
@@ -1281,7 +1279,5 @@ private:
 };
 
 } // namespace dash
-
-#endif // DOXYGEN
 
 #endif // DASH__BLOCK_PATTERN_1D_H_


### PR DESCRIPTION
`dash::Pattern` is now an alias to be backwards compatible. Alias is
disabled in doxygen target to avoid name clashes with pattern concept