### PR TITLE
allocate equal amount of local elements even if pattern is underfilled

### DIFF
--- a/dash/include/dash/allocator/CollectiveAllocator.h
+++ b/dash/include/dash/allocator/CollectiveAllocator.h
@@ -23,6 +23,8 @@ namespace allocator {
  * Encapsulates a memory allocation and deallocation strategy of global
  * memory regions distributed across local memory of units in a specified
  * team.
+ * 
+ * \note This allocator allocates a symmetric amount of memory on each node.
  *
  * Satisfied STL concepts:
  *
@@ -167,6 +169,9 @@ public:
   /**
    * Allocates \c num_local_elem local elements at every unit in global
    * memory space.
+   * 
+   * \note As allocation is symmetric, each unit has to allocate
+   *       an equal number of local elements.
    *
    * \return  Global pointer to allocated memory range, or \c DART_GPTR_NULL
    *          if \c num_local_elem is 0 or less.

--- a/dash/include/dash/matrix/internal/Matrix-inl.h
+++ b/dash/include/dash/matrix/internal/Matrix-inl.h
@@ -152,10 +152,11 @@ bool Matrix<T, NumDim, IndexT, PatternT>
   DASH_LOG_TRACE_VAR("Matrix.allocate", _lsize);
   DASH_LOG_TRACE_VAR("Matrix.allocate", _lcapacity);
   // Allocate and initialize memory
-  _glob_mem        = new GlobMem_t(_lsize, _pattern.team());
+  // use _lcapacity as tje collective allocator requires symmetric allocations
+  _glob_mem        = new GlobMem_t(_lcapacity, _pattern.team());
   _begin           = GlobIter_t(_glob_mem, _pattern);
   _lbegin          = _glob_mem->lbegin();
-  _lend            = _glob_mem->lend();
+  _lend            = _lbegin + _lsize;
   // Register team deallocator:
   _team->register_deallocator(
     this, std::bind(&Matrix::deallocate, this));


### PR DESCRIPTION
to satisfy invariants of CollectiveAllocator. Added documentation in CollectiveAllocator. Refers to #239 