### PR TITLE
Feat clang ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,11 +17,13 @@ test:
   override:
     - bash ./dash/scripts/circleci/pull-docker.sh:
         parallel: true
-    - bash ./dash/scripts/circleci/run-docker.sh Release:
+    - bash ./dash/scripts/circleci/run-docker.sh Release gnu:
         parallel: true
-    - bash ./dash/scripts/circleci/run-docker.sh Minimal:
+    - bash ./dash/scripts/circleci/run-docker.sh Minimal gnu:
         parallel: true
-    - bash ./dash/scripts/circleci/run-docker.sh Nasty:
+    - bash ./dash/scripts/circleci/run-docker.sh Nasty gnu:
+        parallel: true
+    - bash ./dash/scripts/circleci/run-docker.sh Release clang:
         parallel: true
     - grep "FAIL" ./dash-ci.log && (echo "Full log:" ; cat ./dash-ci.log ; exit 1) || exit 0:
         parallel: true

--- a/dash/scripts/circleci/run-docker.sh
+++ b/dash/scripts/circleci/run-docker.sh
@@ -29,12 +29,10 @@ for MPIENV in ${MPIENVS[@]}; do
 
     # upload xml test-results
     mkdir -p $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG
-    cp ./build-ci/*/$BUILD_CONFIG/dash-tests-*.xml $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/
+    cp ./build-ci/*/$COMPILER/$BUILD_CONFIG/dash-tests-*.xml $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/
     # upload build and test logs 
     mkdir -p $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/logs
-    cp ./build-ci/*/$BUILD_CONFIG/*.log $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/logs
-    # clear logs
-    rm -rf ./build-ci/*
+    cp ./build-ci/*/$COMPILER/$BUILD_CONFIG/*.log $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/logs
 
     echo "checking logs"
 

--- a/dash/scripts/circleci/run-docker.sh
+++ b/dash/scripts/circleci/run-docker.sh
@@ -33,6 +33,8 @@ for MPIENV in ${MPIENVS[@]}; do
     # upload build and test logs 
     mkdir -p $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/logs
     cp ./build-ci/*/$BUILD_CONFIG/*.log $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/logs
+    # clear logs
+    rm -rf ./build-ci/*
 
     echo "checking logs"
 

--- a/dash/scripts/circleci/run-docker.sh
+++ b/dash/scripts/circleci/run-docker.sh
@@ -2,7 +2,20 @@
 
 MPIENVS=(mpich openmpi)
 BUILD_CONFIG=$1
+COMPILER=$2
+
 DASH_ENV_EXPORTS="export DASH_MAKE_PROCS='4'; export DASH_MAX_UNITS='3'; export DASH_BUILDEX='OFF';"
+
+if [[ "$COMPILER" == "clang" ]]; then
+  C_COMPILER="clang-3.8"
+  CXX_COMPILER="clang++-3.8"
+else
+  COMPILER="gnu"
+  C_COMPILER="gcc"
+  CXX_COMPILER="g++"
+fi
+
+DASH_ENV_EXPORTS="${DASH_ENV_EXPORTS} export CC='${C_COMPILER}'; export CXX='${CXX_COMPILER}';"
 
 # run tests
 i=0
@@ -15,11 +28,11 @@ for MPIENV in ${MPIENVS[@]}; do
                   /bin/sh -c "$DASH_ENV_EXPORTS sh dash/scripts/dash-ci.sh $BUILD_CONFIG | tee dash-ci.log 2> dash-ci.err;"
 
     # upload xml test-results
-    mkdir -p $CIRCLE_TEST_REPORTS/$MPIENV/$BUILD_CONFIG
-    cp ./build-ci/*/$BUILD_CONFIG/dash-tests-*.xml $CIRCLE_TEST_REPORTS/$MPIENV/$BUILD_CONFIG/
+    mkdir -p $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG
+    cp ./build-ci/*/$BUILD_CONFIG/dash-tests-*.xml $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/
     # upload build and test logs 
-    mkdir -p $CIRCLE_TEST_REPORTS/$MPIENV/$BUILD_CONFIG/logs
-    cp ./build-ci/*/$BUILD_CONFIG/*.log $CIRCLE_TEST_REPORTS/$MPIENV/$BUILD_CONFIG/logs
+    mkdir -p $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/logs
+    cp ./build-ci/*/$BUILD_CONFIG/*.log $CIRCLE_TEST_REPORTS/$MPIENV/$COMPILER/$BUILD_CONFIG/logs
 
     echo "checking logs"
 

--- a/dash/scripts/dash-ci.sh
+++ b/dash/scripts/dash-ci.sh
@@ -11,7 +11,13 @@ run_ci()
   BUILD_TYPE=${1}
   BUILD_UUID=`uuidgen | awk -F '-' '{print $1}'`
 
-  DEPLOY_PATH=$BASEPATH/build-ci/${TIMESTAMP}--uuid-${BUILD_UUID}/${BUILD_TYPE}
+  case "$CC" in
+    *gcc*)   COMPILER="gnu" ;;
+    *clang*) COMPILER="clang" ;;
+    *)       COMPILER="unknown" ;;
+  esac
+
+  DEPLOY_PATH=$BASEPATH/build-ci/${TIMESTAMP}--uuid-${BUILD_UUID}/$COMPILER/${BUILD_TYPE}
 
   mkdir -p $DEPLOY_PATH && \
     cd $DEPLOY_PATH

--- a/dash/scripts/docker-testing/mpich/dockerfile
+++ b/dash/scripts/docker-testing/mpich/dockerfile
@@ -3,16 +3,15 @@ FROM          ubuntu:latest
 
 MAINTAINER    The DASH Team <team@dash-project.org>
 
-RUN           apt-get update -y
-RUN           apt-get install -y \
-                  git \
-                  build-essential \
-                  cmake \
-                  uuid-runtime \
+RUN           apt-get update -y    \
+           && apt-get install -y   \
+                  git              \
+                  build-essential  \
+                  libz-dev         \
+                  cmake            \
+                  uuid-runtime     \
                   libhwloc-plugins \
-                  libhwloc-dev \
-                  libmpich-dev \
-                  libhdf5-mpich-dev
+                  libhwloc-dev
 
 # Install PAPI from source
 WORKDIR       /tmp
@@ -26,8 +25,32 @@ RUN           cd papi*/src/                     \
               && make                           \
               && make install
 ENV           PAPI_BASE=/opt/papi
-ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib
+
+# MPICH 3.2
+ADD           http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz mpich.tgz
+RUN           tar -xf mpich.tgz
+RUN           cd mpich*                           \
+           && ./configure --prefix=/opt/mpich     \
+                          --enable-threads        \
+                          --disable-fortran       \
+           && make                                \
+           && make install
+ENV           PATH=${PATH}:/opt/mpich/bin
+
+# PHDF5 1.10
+ADD           https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz phdf5.tgz
+RUN           tar -xf phdf5.tgz
+RUN           cd hdf5*                        \
+           && CC=/opt/mpich/bin/mpicc         \
+              ./configure --enable-parallel   \
+                          --prefix=/opt/phdf5 \
+           && make                            \
+           && make install
+ENV           HDF5_BASE=/opt/phdf5
+
+ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib:/opt/mpich/lib:${HDF5_BASE}/lib
 ENV           VERBOSE_CI='true'
+
 # DEBUG: enable core dumps 
 RUN           ulimit -c unlimited
 

--- a/dash/scripts/docker-testing/mpich/dockerfile
+++ b/dash/scripts/docker-testing/mpich/dockerfile
@@ -11,11 +11,14 @@ RUN           apt-get update -y    \
                   cmake            \
                   uuid-runtime     \
                   libhwloc-plugins \
-                  libhwloc-dev
+                  libhwloc-dev     \
+                  clang-3.8
+
+WORKDIR       /tmp
+ENV           CC=gcc
+ENV           CXX=g++
 
 # Install PAPI from source
-WORKDIR       /tmp
-
 # Compiler error when compiling with -pedantic for papi > 5.4.1
 # ADD         http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz papi.tgz
 ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.1.tar.gz papi.tgz

--- a/dash/scripts/docker-testing/openmpi/dockerfile
+++ b/dash/scripts/docker-testing/openmpi/dockerfile
@@ -3,18 +3,15 @@ FROM          ubuntu:latest
 
 MAINTAINER    The DASH Team <team@dash-project.org>
 
-RUN           apt-get update -y
-RUN           apt-get install -y \
-                  git \
-                  build-essential \
-                  cmake \
-                  uuid-runtime \
+RUN           apt-get update -y    \
+           && apt-get install -y   \
+                  git              \
+                  build-essential  \
+                  libz-dev         \
+                  cmake            \
+                  uuid-runtime     \
                   libhwloc-plugins \
-                  libhwloc-dev \
-                  libopenmpi-dev \
-                  openmpi-bin \
-                  openmpi-common \
-                  libhdf5-openmpi-dev
+                  libhwloc-dev
 
 # Install PAPI from source
 WORKDIR       /tmp
@@ -23,12 +20,35 @@ WORKDIR       /tmp
 # ADD         http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz papi.tgz
 ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.1.tar.gz papi.tgz
 RUN           tar -xf papi.tgz
-RUN           cd papi*/src/                     \
-              && ./configure --prefix=/opt/papi \
-              && make                           \
-              && make install
+RUN           cd papi*/src/                  \
+           && ./configure --prefix=/opt/papi \
+           && make                           \
+           && make install
 ENV           PAPI_BASE=/opt/papi
-ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib
+
+# Openmpi 1.10.5
+ADD           https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.5.tar.gz ompi.tgz
+RUN           tar -xf ompi.tgz
+RUN           cd openmpi*                         \
+           && ./configure --prefix=/opt/openmpi  \
+                           --enable-mpi-thread-multiple \
+           && make                               \
+           && make install
+ENV           PATH=${PATH}:/opt/openmpi/bin
+ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/openmpi/lib
+
+# PHDF5 1.10
+ADD           https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz phdf5.tgz
+RUN           tar -xf phdf5.tgz
+RUN           cd hdf5*                        \
+           && CC=/opt/openmpi/bin/mpicc       \
+              ./configure --enable-parallel   \
+                          --prefix=/opt/phdf5 \
+           && make                            \
+           && make install
+ENV           HDF5_BASE=/opt/phdf5
+
+ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib:${HDF5_BASE}/lib
 ENV           MPI_EXEC_FLAGS='--allow-run-as-root'
 ENV           VERBOSE_CI='true'
 

--- a/dash/scripts/docker-testing/openmpi/dockerfile
+++ b/dash/scripts/docker-testing/openmpi/dockerfile
@@ -11,11 +11,14 @@ RUN           apt-get update -y    \
                   cmake            \
                   uuid-runtime     \
                   libhwloc-plugins \
-                  libhwloc-dev
+                  libhwloc-dev     \
+                  clang-3.8
+
+WORKDIR       /tmp
+ENV           CC=gcc
+ENV           CXX=g++
 
 # Install PAPI from source
-WORKDIR       /tmp
-
 # Compiler error when compiling with -pedantic for papi > 5.4.1
 # ADD         http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz papi.tgz
 ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.1.tar.gz papi.tgz

--- a/dash/scripts/docker-testing/openmpi2/dockerfile
+++ b/dash/scripts/docker-testing/openmpi2/dockerfile
@@ -3,12 +3,13 @@ FROM          ubuntu:latest
 
 MAINTAINER    The DASH Team <team@dash-project.org>
 
-RUN           apt-get update -y
-RUN           apt-get install -y \
-                  git \
-                  build-essential \
-                  cmake \
-                  uuid-runtime \
+RUN           apt-get update -y    \
+           && apt-get install -y   \
+                  git              \
+                  build-essential  \
+                  libz-dev         \
+                  cmake            \
+                  uuid-runtime     \
                   libhwloc-plugins \
                   libhwloc-dev
 
@@ -23,17 +24,32 @@ RUN           cd papi*/src/                     \
               && ./configure --prefix=/opt/papi \
               && make                           \
               && make install
+
 # Openmpi 2.0
 ADD           https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.1.tar.gz ompi.tgz
 RUN           tar -xf ompi.tgz
-RUN           cd openmpi*                           \
-              && ./configure --prefix=/opt/openmpi  \
-              && make                               \
-              && make install
+RUN           cd openmpi*                         \
+           && ./configure --prefix=/opt/openmpi   \
+                          --enable-mpi-thread-multiple \
+           && make                                \
+           && make install
+ENV           PATH=${PATH}:/opt/openmpi/bin
+ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/openmpi/lib
+
+# PHDF5 1.10
+ADD           https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz phdf5.tgz
+RUN           tar -xf phdf5.tgz
+RUN           cd hdf5*                        \
+           && CC=/opt/openmpi/bin/mpicc       \
+              ./configure --enable-parallel   \
+                          --prefix=/opt/phdf5 \
+           && make                            \
+           && make install
+ENV           HDF5_BASE=/opt/phdf5
+
 # Prepare env
 ENV           PAPI_BASE=/opt/papi
-ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib:/opt/openmpi/lib
-ENV           PATH=${PATH}:/opt/openmpi/bin
+ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib:${HDF5_BASE}/lib
 ENV           MPI_EXEC_FLAGS='--allow-run-as-root'
 ENV           VERBOSE_CI='true'
 # Workaround for issue #63


### PR DESCRIPTION
Refers to  #225. Add support for clang-3.8 in our docker containers. The ci-scripts are changed accordingly. Currently only the CircleCI scripts are set up to support this. There, the release target is also build using clang. If other targets are desired, they can simply be added:
```yml
    - bash ./dash/scripts/circleci/run-docker.sh Release gnu:
        parallel: true
    - bash ./dash/scripts/circleci/run-docker.sh Minimal gnu:
        parallel: true
    - bash ./dash/scripts/circleci/run-docker.sh Nasty gnu:
        parallel: true
    - bash ./dash/scripts/circleci/run-docker.sh Release clang:
        parallel: true
```

This should be sufficient for now.