### PR TITLE
many fixes for index calculations in BlockPattern with underfilled blocks

### DIFF
--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -1118,9 +1118,14 @@ public:
     auto block_coords = _blockspec.coords(global_block_index);
     std::array<index_type, NumDimensions> offsets;
     std::array<size_type, NumDimensions>  extents;
+    
     for (auto d = 0; d < NumDimensions; ++d) {
-      extents[d] = _blocksize_spec.extent(d);
-      offsets[d] = block_coords[d] * extents[d];
+      auto num_blocks_d = _blockspec.extent(d);
+      extents[d]        = _blocksize_spec.extent(d);
+      if(block_coords[d] == (num_blocks_d - 1)){
+        extents[d] -= underfilled_blocksize(d);
+      }
+      offsets[d] = block_coords[d] * _blocksize_spec.extent(d);
     }
     return ViewSpec_t(offsets, extents);
   }
@@ -1145,11 +1150,13 @@ public:
     for (auto d = 0; d < NumDimensions; ++d) {
       auto num_blocks_d =_local_blockspec.extent(d);
       if(l_block_coords[d] == (num_blocks_d - 1)){
-        // workaround, propably not efficient
-        block_vs_extents[d]= local_extent(d) - local_block_local(local_block_index).offset(d);
+          size_type remaining = local_extent(d) % block_vs_extents[d];
+          block_vs_extents[d] = (remaining == 0) ? block_vs_extents[d] : remaining;
+        // to calculate offset, extent of fully filled blocks are needed
+        l_elem_coords[d] *= _blocksize_spec.extent(d);
+      } else {
+        l_elem_coords[d] *= block_vs_extents[d];
       }
-      auto blocksize_d  = block_vs_extents[d];
-      l_elem_coords[d] *= blocksize_d;
     }
     // Global coordinates of first element in block:
     auto g_elem_coords = global(l_elem_coords);
@@ -1189,13 +1196,13 @@ public:
     // last block in at least one dimension
     for(dim_t d=0; d<NumDimensions; ++d){
       if(l_block_coords[d] == (_local_blockspec.extent(d)-1)){
-          extents[d]-=underfilled_blocksize(d);
+          size_type remaining = local_extent(d) % extents[d];
+          extents[d] = (remaining == 0) ? extents[d] : remaining;
+          // to calculate offset, extent of fully filled blocks are needed
+          offsets[d] = l_block_coords[d] * _blocksize_spec.extent(d);
+      } else {
+        offsets[d] = l_block_coords[d] * extents[d];
       }
-    }
-    // Local block coords to local element offset:
-    for (auto d = 0; d < NumDimensions; ++d) {
-      auto blocksize_d = extents[d];
-      offsets[d]       = l_block_coords[d] * blocksize_d;
     }
     return ViewSpec_t(offsets, extents);
   }

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -863,6 +863,9 @@ public:
     index_type offset = g_block_index * _size;
     std::array<index_type, NumDimensions> offsets = {{ offset }};
     std::array<size_type, NumDimensions>  extents = {{ _blocksize }};
+    if(g_block_index == (_nblocks - 1)){
+      extents[0] -= underfilled_blocksize(0);
+    }
     ViewSpec_t block_vs(offsets, extents);
     DASH_LOG_DEBUG_VAR("BlockPattern<1>.block >", block_vs);
     return block_vs;
@@ -881,6 +884,14 @@ public:
     auto g_elem_index = global(l_elem_index);
     std::array<index_type, NumDimensions> offsets = {{ g_elem_index }};
     std::array<size_type, NumDimensions>  extents = {{ _blocksize }};
+    DASH_LOG_DEBUG("_nlblocks", _nlblocks);
+    DASH_LOG_DEBUG("_nblocks", _nblocks);
+    DASH_LOG_DEBUG("l_block_index", l_block_index);
+    DASH_LOG_DEBUG("g_block_index", global(l_block_index));
+    if(l_block_index == (_nlblocks - 1)) {
+      size_type remaining = _local_size % extents[0];
+      extents[0] = (remaining == 0) ? extents[0] : remaining;
+    }
     ViewSpec_t block_vs(offsets, extents);
     DASH_LOG_DEBUG_VAR("BlockPattern<1>.local_block >", block_vs);
     return block_vs;
@@ -897,6 +908,11 @@ public:
     index_type offset = l_block_index * _blocksize;
     std::array<index_type, NumDimensions> offsets = {{ offset }};
     std::array<size_type, NumDimensions>  extents = {{ _blocksize }};
+    if(l_block_index == (_nlblocks - 1))
+    {
+      size_type remaining = _local_size % extents[0];
+      extents[0] = (remaining == 0) ? extents[0] : remaining;
+    }
     ViewSpec_t block_vs(offsets, extents);
     DASH_LOG_DEBUG_VAR("BlockPattern<1>.local_block_local >", block_vs);
     return block_vs;


### PR DESCRIPTION
This commit fixes the offsets and sizes of blocks in the `dash::BlockPattern` and it's specialization `dash::BlockPattern<1,...>` for underfilled blocks. It took me some time to haunt down the bugs because there were no (really, NO) unit tests on this functionality for underfilled cases.
The wrong pattern information were the cause of sporadic crashes in the HDF5 adapter for some pattern configurations.

So please @dash-project/developers : Write **unit tests** for every new function / feature / procedure / whatever. This will make life so much easier.