### PR TITLE
Improvements to TestBase

### DIFF
--- a/dash/test/MatrixTest.cc
+++ b/dash/test/MatrixTest.cc
@@ -893,7 +893,7 @@ TEST_F(MatrixTest, DelayedAlloc)
                          "phase:",       phase_coords, "=", phase,
                          "expected:",    expected,
                          "actual:",      actual);
-          EXPECT_DOUBLE_EQ_U(expected, actual);
+          EXPECT_EQ_U(expected, actual);
         }
       }
     }

--- a/dash/test/TestBase.h
+++ b/dash/test/TestBase.h
@@ -1,6 +1,8 @@
 #ifndef DASH__TEST__TEST_BASE_H_
 #define DASH__TEST__TEST_BASE_H_
 
+#include <type_traits>
+
 #include <gtest/gtest.h>
 
 #include <dash/Init.h>
@@ -19,7 +21,6 @@ namespace internal {
 
 #define ASSERT_TRUE_U(b)  EXPECT_TRUE(b)  << "Unit " << dash::myid().id
 #define ASSERT_FALSE_U(b) EXPECT_FALSE(b) << "Unit " << dash::myid().id
-#define ASSERT_EQ_U(e,a)  EXPECT_EQ(e,a)  << "Unit " << dash::myid().id
 #define ASSERT_NE_U(e,a)  EXPECT_NE(e,a)  << "Unit " << dash::myid().id
 #define ASSERT_LT_U(e,a)  EXPECT_LT(e,a)  << "Unit " << dash::myid().id
 #define ASSERT_GT_U(e,a)  EXPECT_GT(e,a)  << "Unit " << dash::myid().id
@@ -32,16 +33,91 @@ namespace internal {
 
 #define EXPECT_TRUE_U(b)  EXPECT_TRUE(b)  << "Unit " << dash::myid().id
 #define EXPECT_FALSE_U(b) EXPECT_FALSE(b) << "Unit " << dash::myid().id
-#define EXPECT_EQ_U(e,a)  EXPECT_EQ(e,a)  << "Unit " << dash::myid().id
 #define EXPECT_NE_U(e,a)  EXPECT_NE(e,a)  << "Unit " << dash::myid().id
 #define EXPECT_LT_U(e,a)  EXPECT_LT(e,a)  << "Unit " << dash::myid().id
 #define EXPECT_GT_U(e,a)  EXPECT_GT(e,a)  << "Unit " << dash::myid().id
 #define EXPECT_LE_U(e,a)  EXPECT_LE(e,a)  << "Unit " << dash::myid().id
 #define EXPECT_GE_U(e,a)  EXPECT_GE(e,a)  << "Unit " << dash::myid().id
-#define EXPECT_DOUBLE_EQ_U(e,a) \
-  EXPECT_DOUBLE_EQ(e,a) << "Unit " << dash::myid().id
-#define EXPECT_FLOAT_EQ_U(e,a)  \
-  EXPECT_FLOAT_EQ(e,a)  << "Unit " << dash::myid().id
+
+/**
+ * This is used in the general case. It evaluates to a failing test,
+ * which is OK because assert_float_eq is only called for floating point
+ * types. It's a wrapper around CmpHelperFloatingPointEQ, which cannot
+ * be called on arbitrary types.
+ *
+ * TODO: A warning is issued if the expected value is literal NULL.
+ *       GTest seems to have a workaround for that case, which we might
+ *       adopt.
+ */
+template<typename T, typename S>
+typename std::enable_if<!std::is_floating_point<T>::value, ::testing::AssertionResult>::type
+assert_float_eq(
+  const char *exp_e,
+  const char *exp_a,
+  const T& val_e,
+  const S& val_a)
+{
+  // return success for types other than floats
+  return ::testing::AssertionFailure() << "Wrong type for assert_float_eq()";
+}
+
+/**
+ * Internally calls CmpHelperFloatingPointEQ provided by GTest.
+ */
+template<typename T>
+typename std::enable_if<std::is_floating_point<T>::value,
+              ::testing::AssertionResult>::type
+assert_float_eq(
+  const char *exp_e,
+  const char *exp_a,
+  T val_e,
+  T val_a)
+{
+  return ::testing::internal::CmpHelperFloatingPointEQ<T>(
+                                  exp_e, exp_a, val_e, val_a);
+}
+
+/**
+ * float_type_helper is used to pick double over float.
+ */
+template<typename T, typename S>
+struct float_type_helper {
+  using type = T;
+};
+
+template<typename S>
+struct float_type_helper<double, S> {
+  using type = double;
+};
+
+template<typename S>
+struct float_type_helper<S, double> {
+  using type = double;
+};
+
+template<>
+struct float_type_helper<double, double> {
+  using type = double;
+};
+
+#define ASSERT_EQ_U(e,a)                                         \
+  do {                                                           \
+    if (std::is_floating_point<decltype(e)>::value               \
+     || std::is_floating_point<decltype(a)>::value) {            \
+      using value_type =                                         \
+              typename ::testing::internal::float_type_helper<   \
+                                decltype(e), decltype(a)>::type; \
+      EXPECT_PRED_FORMAT2(                                       \
+        ::testing::internal::assert_float_eq<value_type>, e, a)  \
+            << "Unit " << dash::myid().id;                       \
+    }                                                            \
+    else {                                                       \
+      EXPECT_EQ(e,a)        << "Unit " << dash::myid().id;       \
+    }                                                            \
+  } while(0)
+
+#define EXPECT_EQ_U(e,a) ASSERT_EQ_U(e,a)
+
 
 enum GTestColor {
     COLOR_DEFAULT,
@@ -112,18 +188,19 @@ class TestBase : public ::testing::Test {
  protected:
 
   virtual void SetUp() {
-    LOG_MESSAGE("===> Running test case with %lu units ...", dash::size());
+    LOG_MESSAGE("===> Running test case");
     dash::init(&TESTENV.argc, &TESTENV.argv);
-    LOG_MESSAGE("-==- DASH initialized");
+    LOG_MESSAGE("-==- DASH initialized with %lu", dash::size());
     dash::barrier();
   }
 
   virtual void TearDown() {
+    size_t size = dash::size();
     LOG_MESSAGE("-==- Test case finished at unit %d",        dash::myid().id);
     dash::Team::All().barrier();
     LOG_MESSAGE("-==- Finalize DASH at unit %d",             dash::myid().id);
     dash::finalize();
-    LOG_MESSAGE("<=== Finished test case with %lu units",    dash::size());
+    LOG_MESSAGE("<=== Finished test case with %lu units",    size);
   }
 
   std::string _hostname() const {

--- a/dash/test/TestBase.h
+++ b/dash/test/TestBase.h
@@ -190,7 +190,7 @@ class TestBase : public ::testing::Test {
   virtual void SetUp() {
     LOG_MESSAGE("===> Running test case");
     dash::init(&TESTENV.argc, &TESTENV.argv);
-    LOG_MESSAGE("-==- DASH initialized with %lu", dash::size());
+    LOG_MESSAGE("-==- DASH initialized with %lu units", dash::size());
     dash::barrier();
   }
 


### PR DESCRIPTION
1. Fix output of DASH size during test initialization/tear-down
2. Introduce generic EXPECT_EQ_U macro correctly comparing floating point values. This allows for correct checks even in places where EXPECT_EQ_U is called on templated types, e.g., in the HDF5 tests.

The latter causes GCC to issue a warning if `NULL` is passed as `expected`. I played around with the templates but couldn't find a simple way for fixing it. The warning is issued once during test-suite compilation:

```
In file included from /home/joseph/src/dash/dash/build/gtest/src/GTestExternal/googletest/include/gtest/gtest.h:1874:0,
                 from /home/joseph/src/dash/dash/dash/test/TestBase.h:6,
                 from /home/joseph/src/dash/dash/dash/test/DARTLocalityTest.h:4,
                 from /home/joseph/src/dash/dash/dash/test/DARTLocalityTest.cc:2:
/home/joseph/src/dash/dash/dash/test/DARTLocalityTest.cc: In member function ‘virtual void DARTLocalityTest_ExcludeLocalityDomain_Test::TestBody()’:
/home/joseph/src/dash/dash/build/gtest/src/GTestExternal/googletest/include/gtest/gtest_pred_impl.h:147:45: warning: passing NULL to non-pointer argument 3 of ‘typename std::enable_if<(! std::is_floating_point<_Tp>::value), testing::AssertionResult>::type testing::internal::assert_float_eq(const char*, const char*, const T&, const S&) [with T = long int; S = dart_domain_locality_s*; typename std::enable_if<(! std::is_floating_point<_Tp>::value), testing::AssertionResult>::type = testing::AssertionResult]’ [-Wconversion-null]
   GTEST_ASSERT_(pred_format(#v1, #v2, v1, v2), \
```

Note that the code that causes the warning is never executed.