### PR TITLE
updated openmpi2 docker containers to version 2.0.2

### DIFF
--- a/dash/scripts/docker-testing/openmpi2/dockerfile
+++ b/dash/scripts/docker-testing/openmpi2/dockerfile
@@ -26,7 +26,7 @@ RUN           cd papi*/src/                     \
               && make install
 
 # Openmpi 2.0
-ADD           https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.1.tar.gz ompi.tgz
+ADD           https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz ompi.tgz
 RUN           tar -xf ompi.tgz
 RUN           cd openmpi*                         \
            && ./configure --prefix=/opt/openmpi   \
@@ -53,7 +53,7 @@ ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib:${HDF5_BASE}/l
 ENV           MPI_EXEC_FLAGS='--allow-run-as-root'
 ENV           VERBOSE_CI='true'
 # Workaround for issue #63
-ENV           GTEST_FILTER="-SharedTest.AtomicAdd:TransformTest.Array*"
+#ENV           GTEST_FILTER="-SharedTest.AtomicAdd:TransformTest.Array*"
 
 # Set workdir to dash home
 WORKDIR       /opt/dash

--- a/dash/scripts/docker-testing/openmpi2_vg/dockerfile
+++ b/dash/scripts/docker-testing/openmpi2_vg/dockerfile
@@ -7,7 +7,7 @@ FROM          ubuntu:latest
 
 MAINTAINER    The DASH Team <team@dash-project.org>
 
-RUN           apt-get update -y
+RUN           apt-get update -y --fix-missing
 RUN           apt-get install -y \
                 git \
                 build-essential \
@@ -30,7 +30,7 @@ ENV           VALGRIND_BASE=/opt/valgrind
 ENV           PATH=${PATH}:${VALGRIND_BASE}/bin
 
 # Openmpi 2.0
-ADD           https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.1.tar.gz ompi.tgz
+ADD           https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz ompi.tgz
 RUN           tar -xf ompi.tgz
 RUN           cd openmpi*                                     \
               && ./configure --prefix=/opt/openmpi            \


### PR DESCRIPTION
At a first glance, all unit tests now pass using OpenMPI 2.0.2. Be aware, that currently `MPI_THREAD_MULTIPLE` is only available for backends which support native RDMA (no CI).