### PR TITLE
Disable Shared Windows when using OpenMPI

### DIFF
--- a/CMakeExt/MPI.cmake
+++ b/CMakeExt/MPI.cmake
@@ -20,6 +20,7 @@ if (MPI_INCLUDE_PATH AND MPI_LIBRARY)
     set(MPI_IMPL_ID "openmpi" CACHE STRING "MPI implementation identifier")
     # temporarily disable shared memory windows due to alignment problems
     set(ENABLE_SHARED_WINDOWS OFF)
+    message(NOTE "MPI shared windows are disabled due to defective allocation in OpenMPI")
   endif()
 else (MPI_INCLUDE_PATH AND MPI_LIBRARY)
   set(MPI_FOUND FALSE CACHE BOOL "Did not find the MPI library")

--- a/CMakeExt/MPI.cmake
+++ b/CMakeExt/MPI.cmake
@@ -18,6 +18,8 @@ if (MPI_INCLUDE_PATH AND MPI_LIBRARY)
   elseif ("${MPI_INCLUDE_PATH}" MATCHES "openmpi")
     set(MPI_IMPL_IS_OPENMPI TRUE CACHE BOOL "OpenMPI detected")
     set(MPI_IMPL_ID "openmpi" CACHE STRING "MPI implementation identifier")
+    # temporarily disable shared memory windows due to alignment problems
+    set(ENABLE_SHARED_WINDOWS OFF)
   endif()
 else (MPI_INCLUDE_PATH AND MPI_LIBRARY)
   set(MPI_FOUND FALSE CACHE BOOL "Did not find the MPI library")

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_mem.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_mem.h
@@ -12,11 +12,7 @@
 #include <string.h>
 #include <inttypes.h>
 
-#define DART_MAX_TEAM_NUMBER (256)
-#define DART_MAX_LENGTH (1024*1024*16)
-
 struct dart_buddy;
-
 
 extern char* dart_mempool_localalloc;
 extern struct dart_buddy* dart_localpool;
@@ -30,10 +26,10 @@ extern struct dart_buddy* dart_localpool;
  * 2**(level). The internal memory requirements are
  * O(2**(2*level)).
  *
- * \param level The number of levels of the internal binary tree.
+ * \param size The size of the memory pool managed by the buddy allocator.
  */
 struct dart_buddy *
-dart_buddy_new(int level);
+dart_buddy_new(size_t size);
 
 /**
  * Delete the given buddy allocator instance.

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_team_private.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_team_private.h
@@ -147,6 +147,7 @@ extern dart_team_t dart_next_availteamid;
 extern MPI_Comm dart_comm_world;
 #define DART_COMM_WORLD dart_comm_world
 
+#define DART_MAX_TEAM_NUMBER (256)
 
 typedef struct dart_team_data {
   /**

--- a/dart-impl/mpi/src/dart_globmem.c
+++ b/dart-impl/mpi/src/dart_globmem.c
@@ -159,6 +159,9 @@ dart_team_memalloc_aligned(
     return DART_ERR_INVAL;
   }
 
+  DART_LOG_TRACE("dart_team_memalloc_aligned : dts:%i nelem:%zu nbytes:%zu",
+    dtype_size, nelem, nbytes);
+
   int16_t segid = DART_FETCH_AND_INC16(&dart_memid);
 
   uint16_t index;
@@ -212,6 +215,14 @@ dart_team_memalloc_aligned(
    * !!!   (because the shared array has not been allocated correctly)."
    * !!!
    * !!! Reproduced on SuperMUC and mpich3.1 on projekt03.
+   *
+   * !!! BUG IN OPENMPI 1.10.5 and 2.0.2
+   * !!!
+   * !!! The alignment of the memory returned by MPI_Win_allocate_shared is not
+   * !!! guaranteed to be natural, i.e., on 64b systems it can be only 4 byte
+   * !!! if running with an odd number of processes.
+   * !!! The issue has been reported.
+   * !!!
    *
    * Related support ticket of MPICH:
    * http://trac.mpich.org/projects/mpich/ticket/2178
@@ -345,8 +356,8 @@ dart_team_memalloc_aligned(
 
   DART_LOG_DEBUG(
     "dart_team_memalloc_aligned: bytes:%lu offset:%d gptr_unitid:%d "
-    "across team %d",
-		nbytes, 0, gptr_unitid, teamid);
+    "baseptr:%p across team %d",
+    nbytes, 0, gptr_unitid, sub_mem, teamid);
 
 	return DART_OK;
 }

--- a/dart-impl/mpi/src/dart_initialization.c
+++ b/dart-impl/mpi/src/dart_initialization.c
@@ -17,7 +17,7 @@
 #include <dash/dart/mpi/dart_locality_priv.h>
 #include <dash/dart/mpi/dart_segment.h>
 
-#define DART_BUDDY_ORDER 24
+#define DART_LOCAL_ALLOC_SIZE (1024*1024*16)
 
 /* Point to the base address of memory region for local allocation. */
 static int _init_by_dart = 0;
@@ -54,7 +54,7 @@ dart_ret_t do_init()
 
   team_data->comm = DART_COMM_WORLD;
 
-  dart_localpool = dart_buddy_new(DART_BUDDY_ORDER);
+  dart_localpool = dart_buddy_new(DART_LOCAL_ALLOC_SIZE);
 
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)
 
@@ -64,14 +64,14 @@ dart_ret_t do_init()
 
   if (sharedmem_comm != MPI_COMM_NULL) {
     DART_LOG_DEBUG("dart_init: MPI_Win_allocate_shared(nbytes:%d)",
-                   DART_MAX_LENGTH);
+                   DART_LOCAL_ALLOC_SIZE);
     MPI_Info win_info;
     MPI_Info_create(&win_info);
     MPI_Info_set(win_info, "alloc_shared_noncontig", "true");
     /* Reserve a free shared memory block for non-collective
      * global memory allocation. */
     int ret = MPI_Win_allocate_shared(
-                DART_MAX_LENGTH,
+                DART_LOCAL_ALLOC_SIZE,
                 sizeof(char),
                 win_info,
                 sharedmem_comm,
@@ -119,7 +119,7 @@ dart_ret_t do_init()
   }
 #else
   MPI_Alloc_mem(
-    DART_MAX_LENGTH,
+    DART_LOCAL_ALLOC_SIZE,
     MPI_INFO_NULL,
     &dart_mempool_localalloc);
 #endif
@@ -129,7 +129,7 @@ dart_ret_t do_init()
    * Return in dart_win_local_alloc. */
   MPI_Win_create(
     dart_mempool_localalloc,
-    DART_MAX_LENGTH,
+    DART_LOCAL_ALLOC_SIZE,
     sizeof(char),
     MPI_INFO_NULL,
     DART_COMM_WORLD,

--- a/dart-impl/mpi/src/dart_mem.c
+++ b/dart-impl/mpi/src/dart_mem.c
@@ -17,10 +17,16 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define NODE_UNUSED 0
-#define NODE_USED 1
-#define NODE_SPLIT 2
-#define NODE_FULL 3
+// 8-byte minimum allocations to reduce storage overhead
+#define DART_MEM_ALIGN_BITS 3
+#define DART_MEM_ALIGN_BYTES (1<<DART_MEM_ALIGN_BITS)
+
+enum {
+ NODE_UNUSED = 0,
+ NODE_USED   = 1,
+ NODE_SPLIT  = 2,
+ NODE_FULL   = 3
+};
 
 struct dart_buddy {
   dart_mutex_t mutex;
@@ -32,14 +38,25 @@ struct dart_buddy {
 char* dart_mempool_localalloc;
 struct dart_buddy  *  dart_localpool;
 
-struct dart_buddy *
-	dart_buddy_new(int level)
+static inline int
+num_level(size_t size)
 {
-	int size = 1 << level;
+  int level = 1;
+  while ((1 << level) < size) {
+    level++;
+  }
+  return level;
+}
+
+struct dart_buddy *
+	dart_buddy_new(size_t size)
+{
+  int level = num_level(size) - DART_MEM_ALIGN_BITS;
+	int lsize = 1 << level;
 	struct dart_buddy * self =
-    malloc(sizeof(struct dart_buddy) + sizeof(uint8_t) * (size * 2 - 2));
+    malloc(sizeof(struct dart_buddy) + sizeof(uint8_t) * (lsize * 2 - 2));
 	self->level = level;
-	memset(self->tree, NODE_UNUSED, size * 2 - 1);
+	memset(self->tree, NODE_UNUSED, lsize * 2 - 1);
 	dart_mutex_init(&self->mutex);
 	return self;
 }
@@ -71,9 +88,10 @@ next_pow_of_2(size_t x) {
 	return x + 1;
 }
 
-static inline uint64_t
+static inline size_t
 _index_offset(int index, int level, int max_level) {
-	return ((index + 1) - (1 << level)) << (max_level - level);
+	return (((index + 1) - (1 << level))
+	              << (max_level - level)) * DART_MEM_ALIGN_BYTES;
 }
 
 static void
@@ -91,9 +109,11 @@ _mark_parent(struct dart_buddy * self, int index) {
 	}
 }
 
-uint64_t
+size_t
 dart_buddy_alloc(struct dart_buddy * self, size_t s) {
-	int size;
+  int size;
+  // honor the alignment
+  s >>= DART_MEM_ALIGN_BITS;
 	if (s == 0) {
 		size = 1;
 	}
@@ -181,6 +201,8 @@ int dart_buddy_free(struct dart_buddy * self, uint64_t offset)
 	int      length = 1 << self->level;
 	uint64_t left   = 0;
 	int      index  = 0;
+
+	offset >>= DART_MEM_ALIGN_BITS;
 
 	if (offset >= (uint64_t)length) {
 		assert(offset < (uint64_t)length);

--- a/dash/test/DARTCollectiveTest.h
+++ b/dash/test/DARTCollectiveTest.h
@@ -1,5 +1,5 @@
-#ifndef DASH__TEST__DART_ONESIDED_TEST_H_
-#define DASH__TEST__DART_ONESIDED_TEST_H_
+#ifndef DASH__TEST__DART_COLLECTIVE_TEST_H_
+#define DASH__TEST__DART_COLLECTIVE_TEST_H_
 
 #include "TestBase.h"
 
@@ -28,4 +28,4 @@ protected:
   }
 };
 
-#endif // DASH__TEST__DART_ONESIDED_TEST_H_
+#endif // DASH__TEST__DART_COLLECTIVE_TEST_H_

--- a/dash/test/DARTMemAllocTest.cc
+++ b/dash/test/DARTMemAllocTest.cc
@@ -1,0 +1,53 @@
+
+#include "DARTMemAllocTest.h"
+#include <dash/dart/if/dart_communication.h>
+#include <dash/dart/if/dart_globmem.h>
+#include <dash/Array.h>
+
+
+TEST_F(DARTMemAllocTest, LocalAlloc)
+{
+  typedef int value_t;
+  const size_t block_size = 10;
+
+  dart_gptr_t gptr;
+  ASSERT_EQ_U(
+    DART_OK,
+    dart_memalloc(block_size * sizeof(value_t), DART_TYPE_LONG, &gptr));
+  ASSERT_NE_U(
+    DART_GPTR_NULL,
+    gptr);
+  value_t *baseptr;
+  ASSERT_EQ_U(
+    DART_OK,
+    dart_gptr_getaddr(gptr, (void**)&baseptr));
+
+  for (size_t i = 0; i < block_size; ++i) {
+    baseptr[i] = _dash_id;
+  }
+
+  dash::Array<dart_gptr_t> arr(_dash_size);
+  arr.local[0] = gptr;
+  arr.barrier();
+
+  value_t neighbor_val;
+  size_t  neighbor_id = (_dash_id + 1) % _dash_size;
+  dart_storage_t ds = dash::dart_storage<value_t>(1);
+  ASSERT_EQ_U(
+    DART_OK,
+    dart_get_blocking(
+        &neighbor_val,
+        arr[neighbor_id],
+        ds.nelem,
+        ds.dtype));
+
+  ASSERT_EQ_U(
+    neighbor_id,
+    neighbor_val);
+
+  arr.barrier();
+
+  ASSERT_EQ_U(
+    DART_OK,
+    dart_memfree(gptr));
+}

--- a/dash/test/DARTMemAllocTest.h
+++ b/dash/test/DARTMemAllocTest.h
@@ -1,0 +1,32 @@
+#ifndef DASH__TEST__DART_ONESIDED_TEST_H_
+#define DASH__TEST__DART_ONESIDED_TEST_H_
+
+#include "TestBase.h"
+
+
+/**
+ * Test fixture for onesided operations provided by DART.
+ */
+class DARTMemAllocTest : public dash::test::TestBase {
+protected:
+  size_t _dash_id;
+  size_t _dash_size;
+
+  DARTMemAllocTest()
+  : _dash_id(0),
+    _dash_size(0) {
+    LOG_MESSAGE(">>> Test suite: DARTOnesidedTest");
+  }
+
+  virtual ~DARTMemAllocTest() {
+    LOG_MESSAGE("<<< Closing test suite: DARTOnesidedTest");
+  }
+
+  virtual void SetUp() {
+    dash::test::TestBase::SetUp();
+    _dash_id   = dash::myid();
+    _dash_size = dash::size();
+  }
+};
+
+#endif // DASH__TEST__DART_ONESIDED_TEST_H_


### PR DESCRIPTION
1. Temporarily disable shared windows if OpenMPI is detected because `MPI_Win_allocate_shared` returns memory with broken alignment. 
2. Fix the buddy allocator to handle minimum 8 byte allocations. Note that this has no effect on memory alignment (the memory is still allocated through  `MPI_Win_allocate_shared`) but reduces meta data overhead from 2x to 1/4x. 

Hotfix for #280 