### PR TITLE
fixed const access at LocalMatrixRef by making sub, row, col, rows, cols const

### DIFF
--- a/dash/include/dash/matrix/LocalMatrixRef.h
+++ b/dash/include/dash/matrix/LocalMatrixRef.h
@@ -246,17 +246,17 @@ public:
     operator[](index_type n) const;
 
   template<dim_t NumSubDimensions>
-  LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
-    sub(size_type n);
-  inline LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
-    col(size_type n);
-  inline LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
-    row(size_type n);
+  const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+    sub(size_type n) const;
+  inline const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+    col(size_type n) const;
+  inline const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+    row(size_type n) const;
 
   template<dim_t SubDimension>
-  LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> sub(
+  const LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> sub(
     size_type n,
-    size_type range);
+    size_type range) const;
 
   /**
    * Create a view representing the matrix slice within a row
@@ -267,11 +267,11 @@ public:
    *
    * \see  sub
    */
-  inline LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> rows(
+  inline const LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> rows(
     /// Offset of first row in range
     size_type offset,
     /// Number of rows in the range
-    size_type range);
+    size_type range) const;
 
   /**
    * Create a view representing the matrix slice within a column
@@ -282,11 +282,11 @@ public:
    *
    * \see  sub
    */
-  inline LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> cols(
+  inline const LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> cols(
     /// Offset of first column in range
     size_type offset,
     /// Number of columns in the range
-    size_type extent);
+    size_type extent) const;
 
 private:
   MatrixRefView_t _refview;

--- a/dash/include/dash/matrix/LocalMatrixRef.h
+++ b/dash/include/dash/matrix/LocalMatrixRef.h
@@ -192,7 +192,7 @@ public:
    *       not have a pattern. The pattern of the referenced matrix
    *       refers to the global data domain.
    */
-  constexpr    PatternT    & pattern()             const;
+  constexpr const PatternT & pattern()             const;
 
   inline       iterator      begin()                     noexcept;
   inline const_iterator      begin()               const noexcept;
@@ -242,16 +242,31 @@ public:
    * Subscript operator, access element at given offset in
    * global element range.
    */
-  constexpr LocalMatrixRef<T, NumDimensions, CUR-1, PatternT>
+  constexpr const LocalMatrixRef<T, NumDimensions, CUR-1, PatternT>
     operator[](index_type n) const;
+
+  LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+    col(size_type n);
+  constexpr const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+    col(size_type n) const;
+
+  LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+    row(size_type n);
+  constexpr const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+    row(size_type n) const;
+
+  template<dim_t NumSubDimensions>
+  LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+    sub(size_type n);
 
   template<dim_t NumSubDimensions>
   const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
     sub(size_type n) const;
-  constexpr LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
-    col(size_type n) const;
-  constexpr LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
-    row(size_type n) const;
+  
+  template<dim_t SubDimension>
+  LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> sub(
+    size_type n,
+    size_type range);
 
   template<dim_t SubDimension>
   const LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> sub(
@@ -267,7 +282,13 @@ public:
    *
    * \see  sub
    */
-  constexpr LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> rows(
+  LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> rows(
+    /// Offset of first row in range
+    size_type offset,
+    /// Number of rows in the range
+    size_type range);
+  
+  constexpr const LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> rows(
     /// Offset of first row in range
     size_type offset,
     /// Number of rows in the range
@@ -282,7 +303,13 @@ public:
    *
    * \see  sub
    */
-  constexpr LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> cols(
+  LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> cols(
+    /// Offset of first column in range
+    size_type offset,
+    /// Number of columns in the range
+    size_type extent);
+  
+  constexpr const LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> cols(
     /// Offset of first column in range
     size_type offset,
     /// Number of columns in the range

--- a/dash/include/dash/matrix/LocalMatrixRef.h
+++ b/dash/include/dash/matrix/LocalMatrixRef.h
@@ -192,7 +192,7 @@ public:
    *       not have a pattern. The pattern of the referenced matrix
    *       refers to the global data domain.
    */
-  inline const PatternT    & pattern()             const;
+  constexpr    PatternT    & pattern()             const;
 
   inline       iterator      begin()                     noexcept;
   inline const_iterator      begin()               const noexcept;
@@ -242,15 +242,15 @@ public:
    * Subscript operator, access element at given offset in
    * global element range.
    */
-  const LocalMatrixRef<T, NumDimensions, CUR-1, PatternT>
+  constexpr LocalMatrixRef<T, NumDimensions, CUR-1, PatternT>
     operator[](index_type n) const;
 
   template<dim_t NumSubDimensions>
   const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
     sub(size_type n) const;
-  inline const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+  constexpr LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
     col(size_type n) const;
-  inline const LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
+  constexpr LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
     row(size_type n) const;
 
   template<dim_t SubDimension>
@@ -267,7 +267,7 @@ public:
    *
    * \see  sub
    */
-  inline const LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> rows(
+  constexpr LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> rows(
     /// Offset of first row in range
     size_type offset,
     /// Number of rows in the range
@@ -282,7 +282,7 @@ public:
    *
    * \see  sub
    */
-  inline const LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> cols(
+  constexpr LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT> cols(
     /// Offset of first column in range
     size_type offset,
     /// Number of columns in the range

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -410,9 +410,9 @@ const LocalMatrixRef<T, NumDim, CUR, PatternT>
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 template<dim_t SubDimension>
 LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
-LocalMatrixRef<T, NumDim, CUR, PatternT>
+const LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::sub(
-  size_type n)
+  size_type n) const
 {
   static_assert(
       NumDim-1 > 0,
@@ -445,17 +445,17 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 inline LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
-LocalMatrixRef<T, NumDim, CUR, PatternT>
+const LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::col(
-  size_type n)
+  size_type n) const
 {
   return sub<1>(n);
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 inline LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
-LocalMatrixRef<T, NumDim, CUR, PatternT>::row(
-  size_type n)
+const LocalMatrixRef<T, NumDim, CUR, PatternT>::row(
+  size_type n) const
 {
   return sub<0>(n);
 }
@@ -463,10 +463,10 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>::row(
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 template<dim_t SubDimension>
 LocalMatrixRef<T, NumDim, NumDim, PatternT>
-LocalMatrixRef<T, NumDim, CUR, PatternT>
+const LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::sub(
   size_type offset,
-  size_type extent)
+  size_type extent) const
 {
   DASH_LOG_TRACE_VAR("LocalMatrixRef.sub()", SubDimension);
   DASH_LOG_TRACE_VAR("LocalMatrixRef.sub()", offset);
@@ -489,19 +489,19 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 LocalMatrixRef<T, NumDim, NumDim, PatternT>
-LocalMatrixRef<T, NumDim, CUR, PatternT>
+const LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::rows(
   size_type offset,
-  size_type extent)
+  size_type extent) const
 {
   return sub<0>(offset, extent);
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 LocalMatrixRef<T, NumDim, NumDim, PatternT>
-LocalMatrixRef<T, NumDim, CUR, PatternT>::cols(
+const LocalMatrixRef<T, NumDim, CUR, PatternT>::cols(
   size_type offset,
-  size_type extent)
+  size_type extent) const
 {
   return sub<1>(offset, extent);
 }

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -363,54 +363,28 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
                  "curdim:",   CUR,
                  "index:",    pos,
                  "viewspec:", _refview._viewspec);
-  LocalMatrixRef<T, NumDim, CUR-1, PatternT> ref(*this, pos);
-  return ref;
-#if 0
-  DASH_LOG_TRACE("LocalMatrixRef.[]=",
-                 "current refview:",
-                 "refview.coord:",         _refview._coord,
-                 "refview.dim:",           _refview._dim,
-                 "refview.viewspec.rank:", _refview._viewspec.rank());
-  LocalMatrixRef<T, NumDim, CUR-1, PatternT> ref;
-  // Transfer ownership of _refview:
-  ref._refview = _refview;
-  ref._refview._coord[_refview._dim] = n;
-  ref._refview._dim++;
-  ref._refview._viewspec.set_rank(ref._refview._dim);
-  DASH_LOG_TRACE("LocalMatrixRef.[]= >",
-                 "refview coords:", ref._refview._coord);
-  return ref;
-#endif
+  return LocalMatrixRef<T, NumDim, CUR-1, PatternT>(*this, pos);
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-LocalMatrixRef<T, NumDim, CUR-1, PatternT>
-const LocalMatrixRef<T, NumDim, CUR, PatternT>
+constexpr LocalMatrixRef<T, NumDim, CUR-1, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::operator[](
   index_type pos) const
 {
+#if 0
   DASH_LOG_TRACE("LocalMatrixRef.[]()",
                  "curdim:",   CUR,
                  "index:",    pos,
                  "viewspec:", _refview._viewspec);
-  LocalMatrixRef<T, NumDim, CUR-1, PatternT> ref(*this, pos);
-  return ref;
-#if 0
-  LocalMatrixRef<T, NumDim, CUR-1, PatternT> ref;
-  ref._refview = new MatrixRefView<T, NumDim, PatternT>(*_refview);
-  ref._refview._coord[_refview._dim] = n;
-  ref._refview._dim++;
-  ref._refview._viewspec.set_rank(ref._refview._dim);
-  DASH_LOG_TRACE("LocalMatrixRef.[] >",
-                 "refview coords:", ref._refview._coord);
-  return ref;
 #endif
+  return LocalMatrixRef<T, NumDim, CUR-1, PatternT>(*this, pos);
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 template<dim_t SubDimension>
-LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
-const LocalMatrixRef<T, NumDim, CUR, PatternT>
+const LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::sub(
   size_type n) const
 {
@@ -444,8 +418,8 @@ const LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-inline LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
-const LocalMatrixRef<T, NumDim, CUR, PatternT>
+constexpr LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::col(
   size_type n) const
 {
@@ -453,8 +427,8 @@ const LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-inline LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
-const LocalMatrixRef<T, NumDim, CUR, PatternT>::row(
+constexpr LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>::row(
   size_type n) const
 {
   return sub<0>(n);
@@ -462,8 +436,8 @@ const LocalMatrixRef<T, NumDim, CUR, PatternT>::row(
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 template<dim_t SubDimension>
-LocalMatrixRef<T, NumDim, NumDim, PatternT>
-const LocalMatrixRef<T, NumDim, CUR, PatternT>
+const LocalMatrixRef<T, NumDim, NumDim, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::sub(
   size_type offset,
   size_type extent) const
@@ -488,8 +462,8 @@ const LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-LocalMatrixRef<T, NumDim, NumDim, PatternT>
-const LocalMatrixRef<T, NumDim, CUR, PatternT>
+constexpr LocalMatrixRef<T, NumDim, NumDim, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::rows(
   size_type offset,
   size_type extent) const
@@ -498,8 +472,8 @@ const LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-LocalMatrixRef<T, NumDim, NumDim, PatternT>
-const LocalMatrixRef<T, NumDim, CUR, PatternT>::cols(
+constexpr LocalMatrixRef<T, NumDim, NumDim, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>::cols(
   size_type offset,
   size_type extent) const
 {
@@ -618,7 +592,7 @@ LocalMatrixRef<T, NumDim, 0, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-inline const PatternT&
+constexpr PatternT&
 LocalMatrixRef<T, NumDim, CUR, PatternT>::pattern() const
 {
 	return _refview._mat->_pattern;

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -367,7 +367,7 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-constexpr LocalMatrixRef<T, NumDim, CUR-1, PatternT>
+constexpr const LocalMatrixRef<T, NumDim, CUR-1, PatternT>
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::operator[](
   index_type pos) const
@@ -379,6 +379,18 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
                  "viewspec:", _refview._viewspec);
 #endif
   return LocalMatrixRef<T, NumDim, CUR-1, PatternT>(*this, pos);
+}
+
+template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
+template<dim_t SubDimension>
+LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
+::sub(
+  size_type n)
+{
+  // following Meyers, Eff. C++ p. 23, Item 3
+  using RefType = LocalMatrixRef<T, NumDim, CUR, PatternT>;
+  return static_cast<const RefType &>(*this).sub<SubDimension>(n);
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
@@ -418,7 +430,16 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-constexpr LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
+LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
+::col(
+  size_type n)
+{
+  return sub<1>(n);
+}
+
+template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
+constexpr const LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::col(
   size_type n) const
@@ -427,11 +448,32 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-constexpr LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
+LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>::row(
+  size_type n)
+{
+  return sub<0>(n);
+}
+
+template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
+constexpr const LocalMatrixRef<T, NumDim, NumDim-1, PatternT>
 LocalMatrixRef<T, NumDim, CUR, PatternT>::row(
   size_type n) const
 {
   return sub<0>(n);
+}
+
+template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
+template<dim_t SubDimension>
+LocalMatrixRef<T, NumDim, NumDim, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
+::sub(
+  size_type offset,
+  size_type extent)
+{
+  // following Meyers, Eff. C++ p. 23, Item 3
+  using RefType = LocalMatrixRef<T, NumDim, CUR, PatternT>;
+  return static_cast<const RefType &>(*this).sub<SubDimension>(offset, extent);
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
@@ -462,7 +504,17 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-constexpr LocalMatrixRef<T, NumDim, NumDim, PatternT>
+LocalMatrixRef<T, NumDim, NumDim, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
+::rows(
+  size_type offset,
+  size_type extent)
+{
+  return sub<0>(offset, extent);
+}
+
+template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
+constexpr const LocalMatrixRef<T, NumDim, NumDim, PatternT>
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::rows(
   size_type offset,
@@ -472,7 +524,16 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-constexpr LocalMatrixRef<T, NumDim, NumDim, PatternT>
+LocalMatrixRef<T, NumDim, NumDim, PatternT>
+LocalMatrixRef<T, NumDim, CUR, PatternT>::cols(
+  size_type offset,
+  size_type extent)
+{
+  return sub<1>(offset, extent);
+}
+
+template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
+constexpr const LocalMatrixRef<T, NumDim, NumDim, PatternT>
 LocalMatrixRef<T, NumDim, CUR, PatternT>::cols(
   size_type offset,
   size_type extent) const
@@ -592,7 +653,7 @@ LocalMatrixRef<T, NumDim, 0, PatternT>
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
-constexpr PatternT&
+constexpr const PatternT&
 LocalMatrixRef<T, NumDim, CUR, PatternT>::pattern() const
 {
 	return _refview._mat->_pattern;

--- a/dash/test/MatrixTest.cc
+++ b/dash/test/MatrixTest.cc
@@ -1222,3 +1222,35 @@ TEST_F(MatrixTest, CopyRow)
   }
 }
 
+TEST_F(MatrixTest, InterfaceTest)
+{
+  typedef dash::Pattern<2>                 pattern_t;
+  typedef typename pattern_t::index_type   index_t;
+
+  dash::Matrix<int, 2, index_t, pattern_t> matrix(dash::SizeSpec<2>(8, 15));
+  
+  auto const & matrix_by_ref = matrix;
+  auto & matrix_local  = matrix.local;
+  
+  dash::fill(matrix.begin(), matrix.end(), 0);
+  dash::barrier();
+  
+  int el = matrix(0,0);
+  el = matrix[0][0];
+  el = matrix.local[0][0];
+  el = *(matrix.local.lbegin());
+  dash::barrier();
+  el = ++(*(matrix.local.lbegin()));
+  el = ++(*(matrix.local.row(0).lbegin()));
+  
+  // test access using const & matrix
+  el = matrix_by_ref[0][0];
+  el = matrix_by_ref.local[0][0];
+  // should not compile
+  // el = ++(*(matrix_by_ref.local.lbegin()));
+  // el = ++(*(matrix_by_ref.local.row(0).lbegin()));
+  // matrix_by_ref.local.row(0)[0] = 5;
+  
+  // test access using non-const & matrix.local
+  *(matrix_local.lbegin()) = 5;
+}


### PR DESCRIPTION
Fixes use cases like the following (issue #283):

```c++
void foo(const dash::NArray<uint, 2> & matIn){
  // ...
  auto mPtr = matIn.local.row(0).lbegin();
  // ...
}
```