### PR TITLE
pull and run same (mpich) docker container on travis

### DIFF
--- a/dash/scripts/travisci/run-docker.sh
+++ b/dash/scripts/travisci/run-docker.sh
@@ -4,7 +4,7 @@ BUILD_TYPE=$1
 
 echo "Starting docker container for build target $BUILD_TYPE ..."
 
-docker run -v $PWD:/opt/dash dashproject/ci:openmpi /bin/sh -c \
+docker run -v $PWD:/opt/dash dashproject/ci:mpich /bin/sh -c \
               "export DASH_MAX_UNITS='2'; sh dash/scripts/dash-ci.sh ${BUILD_TYPE} | tee dash-ci.log 2> dash-ci.err;"
 
 echo "checking logs"


### PR DESCRIPTION
Before this PR, the mpich container was pulled, but the openmpi container was executed.