### PR TITLE
Enforce element types of DASH containers to be trivially copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Features:
 - Better textual output of unit tests
 - Added support for HDF5 groups
 - Support patterns with underfilled blocks in dash::io::hdf5
+- Allow trivially copyable data types in containers
 
 Bugfixes:
 
@@ -39,6 +40,10 @@ Bugfixes:
 - Support for HDF5.
 - Generate cmake package for DASH and DART
 - Added code coverage tests
+- Enforce minimum C++ compiler versions:
+    - GCC: 5.1.0
+    - Clang: 3.8.0
+    - Intel: 15.0.0
 
 - New compiler flags:
 

--- a/CMakeExt/CompilerFlags.cmake
+++ b/CMakeExt/CompilerFlags.cmake
@@ -146,6 +146,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
   set (CXX_STD_FLAG "--std=c++11"
        CACHE STRING "C++ compiler std flag")
   set (CXX_OMP_FLAG ${OpenMP_CXX_FLAGS})
+  
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.8.0")
+    message(FATAL_ERROR "Insufficient Clang version detected (3.8.0) or above required")
+  endif()
+
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   # using GCC
   set (CXX_STD_FLAG "--std=c++11"
@@ -156,6 +161,11 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   if(ENABLE_LT_OPTIMIZATION)
     set (CXX_LTO_FLAG "-flto -fwhole-program -fno-use-linker-plugin")
   endif()
+
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1.0")
+    message(FATAL_ERROR "Insufficient GCC version detected (5.1.0 or above required)")
+  endif()
+
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
   # using Intel C++
   set (CXX_STD_FLAG "-std=c++11"
@@ -167,6 +177,12 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
   if(ENABLE_CC_REPORTS)
     set (CC_REPORT_FLAG "-qopt-report=4 -qopt-report-phase ipo")
   endif()
+
+
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "15.0.0")
+    message(FATAL_ERROR "Insufficient Intel compiler version detected (15.0.0 or above required)")
+  endif()
+
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Cray")
   # Cray compiler not supported for C++
   message(FATAL_ERROR,

--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -589,6 +589,17 @@ template<
 >
 class Array
 {
+  /**
+   * The Cray compiler (as of CCE8.5.6) does not support
+   * std::is_trivially_copyable.
+   *
+   * TODO: Remove the guard once this has been fixed by Cray.
+   */
+#ifndef __CRAYC
+  static_assert(std::is_trivially_copyable<ElementType>::value,
+    "Element type must be trivially copyable");
+#endif
+
 private:
   typedef Array<ElementType, IndexType, PatternType> self_t;
 
@@ -651,19 +662,6 @@ public:
   /// Proxy object, provides non-blocking operations on array.
   async_type           async;
 
-public:
-/*
-   Check requirements on element type
-   is_trivially_copyable is not implemented presently, and is_trivial
-   is too strict (e.g. fails on std::pair).
-
-   static_assert(std::is_trivially_copyable<ElementType>::value,
-     "Element type must be trivially copyable");
-   static_assert(std::is_trivial<ElementType>::value,
-     "Element type must be trivially copyable");
-*/
-
-public:
   /**
    * Default constructor, for delayed allocation.
    *

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -86,48 +86,29 @@ public:
   /**
    * Default constructor, underlying global address is unspecified.
    */
-  explicit GlobPtr() = default;
+  constexpr explicit GlobPtr() = default;
 
   /**
    * Constructor, specifies underlying global address.
    */
-  explicit GlobPtr(dart_gptr_t gptr)
-  {
-    DASH_LOG_TRACE_VAR("GlobPtr(dart_gptr_t)", gptr);
-    _dart_gptr = gptr;
-  }
+  constexpr explicit GlobPtr(dart_gptr_t gptr) : _dart_gptr(gptr)
+  { }
 
   /**
    * Constructor for conversion of std::nullptr_t.
    */
-  GlobPtr(std::nullptr_t p)
-  {
-    DASH_LOG_TRACE("GlobPtr()", "nullptr");
-    _dart_gptr = DART_GPTR_NULL;
-  }
+  constexpr GlobPtr(std::nullptr_t p) : _dart_gptr(DART_GPTR_NULL)
+  { }
 
   /**
    * Copy constructor.
    */
-  GlobPtr(const self_t & other)
-  : _dart_gptr(other._dart_gptr)
-  {
-    DASH_LOG_TRACE("GlobPtr()", "GlobPtr<T> other");
-  }
+  constexpr GlobPtr(const self_t & other) = default;
 
   /**
    * Assignment operator.
    */
-  self_t & operator=(const self_t & rhs)
-  {
-    DASH_LOG_TRACE("GlobPtr.=()", "GlobPtr<T> rhs");
-    DASH_LOG_TRACE_VAR("GlobPtr.=", rhs);
-    if (this != &rhs) {
-      _dart_gptr = rhs._dart_gptr;
-    }
-    DASH_LOG_TRACE("GlobPtr.= >");
-    return *this;
-  }
+  self_t & operator=(const self_t & rhs) = default;
 
   /**
    * Converts pointer to its underlying global address.

--- a/dash/include/dash/List.h
+++ b/dash/include/dash/List.h
@@ -168,6 +168,17 @@ template<
   class    AllocatorType = dash::allocator::DynamicAllocator<ElementType> >
 class List
 {
+   /**
+    * The Cray compiler (as of CCE8.5.6) does not support
+    * std::is_trivially_copyable.
+    *
+    * TODO: Remove the guard once this has been fixed by Cray.
+    */
+ #ifndef __CRAYC
+   static_assert(std::is_trivially_copyable<ElementType>::value,
+     "Element type must be trivially copyable");
+ #endif
+
   template<typename T_, class A_>
   friend class LocalListRef;
 

--- a/dash/include/dash/Matrix.h
+++ b/dash/include/dash/Matrix.h
@@ -135,8 +135,16 @@ template<
   class    PatternT       = TilePattern<NumDimensions, ROW_MAJOR, IndexT> >
 class Matrix
 {
-  static_assert(std::is_trivial<ElementT>::value,
-    "Element type must be trivial copyable");
+  /**
+   * The Cray compiler (as of CCE8.5.6) does not support
+   * std::is_trivially_copyable.
+   *
+   * TODO: Remove the guard once this has been fixed by Cray.
+   */
+#ifndef __CRAYC
+  static_assert(std::is_trivially_copyable<ElementT>::value,
+    "Element type must be trivially copyable");
+#endif
   static_assert(std::is_same<IndexT, typename PatternT::index_type>::value,
     "Index type IndexT must be the same for Matrix and specified pattern");
 

--- a/dash/include/dash/Pair.h
+++ b/dash/include/dash/Pair.h
@@ -25,13 +25,16 @@ namespace dash {
     /**
      * The default constructor.
      */
-    constexpr Pair() = default;
+    constexpr Pair()
+      : first(), second()
+    { }
 
     /**
      * Two objects may be passed to a Pair constructor to be copied.
      */
     constexpr Pair(const T1& __a, const T2& __b)
-    : first(__a), second(__b) { }
+      : first(__a), second(__b)
+    { }
 
     /**
      * A Pair might be constructed from another pair iff first and second
@@ -42,7 +45,8 @@ namespace dash {
                 std::is_convertible<const U1&, T1>::value &&
                 std::is_convertible<const U2&, T2>::value>::value>
     constexpr Pair(const Pair<U1, U2>& p)
-      : first(p.first), second(p.second) { }
+      : first(p.first), second(p.second)
+    { }
 
     constexpr Pair(const Pair&) = default;
     constexpr Pair(Pair&&) = default;
@@ -50,25 +54,29 @@ namespace dash {
     template<class U1, class = typename
         std::enable_if<std::is_convertible<U1, T1>::value>::type>
     constexpr Pair(U1&& x, const T2& y)
-      : first(std::forward<U1>(x)), second(y) { }
+      : first(std::forward<U1>(x)), second(y)
+    { }
 
     template<class U2, class = typename
         std::enable_if<std::is_convertible<U2, T2>::value>::type>
     constexpr Pair(const T1& x, U2&& y)
-      : first(x), second(std::forward<U2>(y)) { }
+      : first(x), second(std::forward<U2>(y))
+    { }
 
     template<class U1, class U2, class = typename
         std::enable_if<std::is_convertible<U1, T1>::value &&
                        std::is_convertible<U2, T2>::value>::type>
     constexpr Pair(U1&& x, U2&& y)
-      : first(std::forward<U1>(x)), second(std::forward<U2>(y)) { }
+      : first(std::forward<U1>(x)), second(std::forward<U2>(y))
+    { }
 
     template<class U1, class U2, class = typename
         std::enable_if<std::is_convertible<U1, T1>::value &&
                        std::is_convertible<U2, T2>::value>::type>
     constexpr Pair(Pair<U1, U2>&& p)
       : first(std::forward<U1>(p.first)),
-        second(std::forward<U2>(p.second)) { }
+        second(std::forward<U2>(p.second))
+    { }
 
     Pair&
     operator=(const Pair& p) = default;

--- a/dash/include/dash/Pair.h
+++ b/dash/include/dash/Pair.h
@@ -1,0 +1,202 @@
+#ifndef DASH_DASH_INCLUDE_DASH_PAIR_H_
+#define DASH_DASH_INCLUDE_DASH_PAIR_H_
+
+#include <type_traits>
+
+namespace dash {
+
+  /**
+   * A trivially-copyable implementation of std::pair to be used
+   * as element type of DASH containers.
+   *
+   * The implementation was mainly taken and adapted from std_pair.h.
+   *
+   * \todo Implementation of tuples are missing at the moment.
+   */
+  template<class T1, class T2>
+  struct Pair
+  {
+    typedef T1 first_type;    /// @c first_type is the first bound type
+    typedef T2 second_type;   /// @c second_type is the second bound type
+
+    T1 first;                 /// @c first is a copy of the first object
+    T2 second;                /// @c second is a copy of the second object
+
+    /**
+     * The default constructor.
+     */
+    constexpr Pair() = default;
+
+    /**
+     * Two objects may be passed to a Pair constructor to be copied.
+     */
+    constexpr Pair(const T1& __a, const T2& __b)
+    : first(__a), second(__b) { }
+
+    /**
+     * A Pair might be constructed from another pair iff first and second
+     * are convertible.
+     */
+    template<class U1, class U2, class = typename
+              std::enable_if<
+                std::is_convertible<const U1&, T1>::value &&
+                std::is_convertible<const U2&, T2>::value>::value>
+    constexpr Pair(const Pair<U1, U2>& p)
+      : first(p.first), second(p.second) { }
+
+    constexpr Pair(const Pair&) = default;
+    constexpr Pair(Pair&&) = default;
+
+    template<class U1, class = typename
+        std::enable_if<std::is_convertible<U1, T1>::value>::type>
+    constexpr Pair(U1&& x, const T2& y)
+      : first(std::forward<U1>(x)), second(y) { }
+
+    template<class U2, class = typename
+        std::enable_if<std::is_convertible<U2, T2>::value>::type>
+    constexpr Pair(const T1& x, U2&& y)
+      : first(x), second(std::forward<U2>(y)) { }
+
+    template<class U1, class U2, class = typename
+        std::enable_if<std::is_convertible<U1, T1>::value &&
+                       std::is_convertible<U2, T2>::value>::type>
+    constexpr Pair(U1&& x, U2&& y)
+      : first(std::forward<U1>(x)), second(std::forward<U2>(y)) { }
+
+    template<class U1, class U2, class = typename
+        std::enable_if<std::is_convertible<U1, T1>::value &&
+                       std::is_convertible<U2, T2>::value>::type>
+    constexpr Pair(Pair<U1, U2>&& p)
+      : first(std::forward<U1>(p.first)),
+        second(std::forward<U2>(p.second)) { }
+
+    Pair&
+    operator=(const Pair& p) = default;
+
+    Pair&
+    operator=(Pair&& p)
+    noexcept(
+        std::is_nothrow_move_assignable<T1>::value &&
+        std::is_nothrow_move_assignable<T2>::value) = default;
+
+    template<class U1, class U2>
+    Pair&
+    operator=(const Pair<U1, U2>& p)
+    {
+      first  = p.first;
+      second = p.second;
+      return *this;
+    }
+
+    template<class U1, class U2>
+    Pair&
+    operator=(Pair<U1, U2>&& p)
+    {
+      first  = std::forward<U1>(p.first);
+      second = std::forward<U2>(p.second);
+      return *this;
+    }
+
+    void
+    swap(Pair& p)
+    noexcept(noexcept(swap(first, p.first))
+        && noexcept(swap(second, p.second)))
+    {
+      std::swap(first, p.first);
+      std::swap(second, p.second);
+    }
+  };
+
+  /**
+   * Two pairs of the same type are equal iff their members are equal.
+   */
+  template<class T1, class T2>
+  inline constexpr bool
+  operator==(const Pair<T1, T2>& x, const Pair<T1, T2>& y)
+  {
+    return x.first == y.first && x.second == y.second;
+  }
+
+  /**
+   * A pair is smaller than another pair if the first member is smaller
+   * or the first is equal and the second is smaller.
+   * See <http://gcc.gnu.org/onlinedocs/libstdc++/manual/utilities.html>
+   */
+  template<class T1, class T2>
+  inline constexpr bool
+  operator<(const Pair<T1, T2>& x, const Pair<T1, T2>& y)
+  {
+    return  x.first < y.first
+      || (!(y.first < x.first) && !(x.second >= y.second));
+  }
+
+  /**
+   * Inequality comparison operator implemented in terms of
+   * equality operator.
+   */
+  template<class T1, class T2>
+  inline constexpr bool
+  operator!=(const Pair<T1, T2>& x, const Pair<T1, T2>& y)
+  {
+    return !(x == y);
+  }
+
+  /**
+   * Greater-than operator implemented in terms of less-than operator.
+   */
+  template<class T1, class T2>
+  inline constexpr bool
+  operator>(const Pair<T1, T2>& x, const Pair<T1, T2>& y)
+  {
+    return y < x;
+  }
+
+  /**
+   * Less-than-or-equal operator implemented in terms of less-than operator.
+   */
+  template<class T1, class T2>
+  inline constexpr bool
+  operator<=(const Pair<T1, T2>& x, const Pair<T1, T2>& y)
+  {
+    return !(y < x);
+  }
+
+  /**
+   * Greater-than-or-equal operator implemented in terms of less-than operator.
+   */
+  template<class T1, class T2>
+  inline constexpr bool
+  operator>=(const Pair<T1, T2>& x, const Pair<T1, T2>& y)
+  {
+    return !(x < y);
+  }
+
+  /**
+   * Wrapper for Pair::swap.
+   */
+  template<class T1, class T2>
+  inline void
+  swap(Pair<T1, T2>& x, Pair<T1, T2>& y)
+  noexcept(noexcept(x.swap(y)))
+  {
+    x.swap(y);
+  }
+
+  /**
+   * Convennience wrapper to create a Pair object.
+   */
+  template<class T1, class T2>
+  constexpr Pair<typename std::__decay_and_strip<T1>::__type,
+                 typename std::__decay_and_strip<T2>::__type>
+  make_pair(T1&& x, T2&& y)
+  {
+    typedef typename std::__decay_and_strip<T1>::__type ds_type1;
+    typedef typename std::__decay_and_strip<T2>::__type ds_type2;
+    typedef Pair<ds_type1, ds_type2>                    pair_type;
+    return pair_type(std::forward<T1>(x), std::forward<T2>(y));
+  }
+
+} // namespace dash
+
+
+#endif /* DASH_DASH_INCLUDE_DASH_PAIR_H_ */

--- a/dash/include/dash/map/UnorderedMap.h
+++ b/dash/include/dash/map/UnorderedMap.h
@@ -77,6 +77,19 @@ template<
                        std::pair<const Key, Mapped> > >
 class UnorderedMap
 {
+  /**
+   * The Cray compiler (as of CCE8.5.6) does not support
+   * std::is_trivially_copyable.
+   *
+   * TODO: Remove the guard once this has been fixed by Cray.
+   */
+#ifndef __CRAYC
+  static_assert(std::is_trivially_copyable<Key>::value,
+    "Element type must be trivially copyable");
+  static_assert(std::is_trivially_copyable<Mapped>::value,
+    "Element type must be trivially copyable");
+#endif
+
   template<typename K_, typename M_, typename H_, typename P_, typename A_>
   friend class UnorderedMapLocalRef;
 

--- a/dash/test/STLAlgorithmTest.cc
+++ b/dash/test/STLAlgorithmTest.cc
@@ -2,6 +2,7 @@
 #include "STLAlgorithmTest.h"
 
 #include <dash/Array.h>
+#include <dash/Pair.h>
 
 #include <algorithm>
 #include <vector>
@@ -11,13 +12,13 @@
 template <class T1, class T2>
 std::ostream & operator<<(
   std::ostream            & os,
-  const std::pair<T1, T2> & p) {
+  const dash::Pair<T1, T2> & p) {
   os << "(" << p.first << "," << p.second << ")";
   return os;
 }
 
 TEST_F(STLAlgorithmTest, StdCopyGlobalToLocal) {
-  typedef std::pair<dart_unit_t, int> element_t;
+  typedef dash::Pair<dart_unit_t, int> element_t;
   typedef dash::Array<element_t>      array_t;
   typedef array_t::const_iterator     const_it_t;
   typedef array_t::index_type         index_t;
@@ -26,7 +27,7 @@ TEST_F(STLAlgorithmTest, StdCopyGlobalToLocal) {
   // Initialize local elements
   index_t l_off = 0;
   for (auto l_it = array.lbegin(); l_it != array.lend(); ++l_it, ++l_off) {
-    *l_it = std::make_pair(dash::myid().id, l_off);
+    *l_it = dash::make_pair(dash::myid().id, l_off);
   }
   // Wait for all units to initialize their assigned range
   array.barrier();
@@ -70,7 +71,7 @@ TEST_F(STLAlgorithmTest, StdCopyGlobalToLocal) {
 }
 
 TEST_F(STLAlgorithmTest, StdCopyGlobalToGlobal) {
-  typedef std::pair<dart_unit_t, int> element_t;
+  typedef dash::Pair<dart_unit_t, int> element_t;
   typedef dash::Array<element_t>      array_t;
   typedef array_t::const_iterator     const_it_t;
   typedef array_t::index_type         index_t;
@@ -83,7 +84,7 @@ TEST_F(STLAlgorithmTest, StdCopyGlobalToGlobal) {
   index_t lidx = 0;
   for (auto l_it = array_a.lbegin(); l_it != array_a.lend();
        ++l_it, ++lidx) {
-    *l_it = std::make_pair(dash::myid().id, lidx);
+    *l_it = dash::make_pair(dash::myid().id, lidx);
   }
   // Wait for all units to initialize their assigned range:
   array_a.barrier();


### PR DESCRIPTION
Consistently enforce `std::is_trivially_copyable` on element types of containers (except when using the Cray compiler).
Introduce minimum required compiler version.
Makes `GlobPtr` trivially copyable after #221 has been resolved.
Introduce `dash::Pair` which closely resembles `std::pair` except for being trivially copyable. 
Fixes #241 