### PR TITLE
Many stability fixes coming up from static code analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build.mic*
 build.min*
 build.nasty*
 build.cov*
+build.analyze*
 build-ci*
 compile_commands.json
 dash/include/dash/util/StaticConfig.h

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -31,7 +31,7 @@ if [ "$SCANBUILD_OPTS" = "" ]; then
   SCANBUILD_OPTS="-analyze-headers -plist-html"
 fi
 SCANBUILD_OPTS="-o $REPORT_DIR ${SCANBUILD_OPTS}"
-SCANBUILD_OPTS="--force-analyze-debug-code ${SCANBUILD_OPTS}"
+SCANBUILD_OPTS="--force-analyze-debug-code -v ${SCANBUILD_OPTS}"
 
 which $BUILD_WRAPPER ||
   (echo "This build requires $BUILD_WRAPPER. Set env. var SCANBUILD_BIN" \
@@ -123,8 +123,8 @@ mkdir -p $BUILD_DIR/$REPORT_DIR
                         -DENABLE_HDF5=ON \
                         \
                         -DBUILD_EXAMPLES=OFF \
-                        -DBUILD_TESTS=ON \
-                        -DBUILD_DOCS=ON \
+                        -DBUILD_TESTS=OFF \
+                        -DBUILD_DOCS=OFF \
                         \
                         -DIPM_PREFIX=${IPM_HOME} \
                         -DPAPI_PREFIX=${PAPI_HOME} \

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -9,12 +9,14 @@
 BUILD_DIR=./build.analyze
 REPORT_DIR=report            # relative to BUILD_DIR
 BUILD_WRAPPER="${SCANBUILD_BIN}";
-ANALYZE_OPTS="-o $REPORT_DIR -analyze-headers -plist-html"
 
 
 # try to find build wrapper
 if [ "$BUILD_WRAPPER" = "" ]; then
   BUILD_WRAPPER="scan-build"
+fi
+if [ "$SCANBUILD_OPTS" = "" ]; then
+  SCANBUILD_OPTS="-o $REPORT_DIR --analyze-headers --plist-html"
 fi
 
 which $BUILD_WRAPPER ||
@@ -73,7 +75,7 @@ fi
 # Configure with default release build settings:
 rm -Rf $BUILD_DIR/*
 mkdir -p $BUILD_DIR/$REPORT_DIR
-(cd $BUILD_DIR && $BUILD_WRAPPER $ANALYZE_OPTS \
+(cd $BUILD_DIR && $BUILD_WRAPPER $SCANBUILD_OPTS \
                   cmake3 -DCMAKE_BUILD_TYPE=Release \
                         -DENVIRONMENT_TYPE=default \
                         -DENABLE_COMPTIME_RED=OFF \
@@ -116,7 +118,7 @@ mkdir -p $BUILD_DIR/$REPORT_DIR
                         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                         ../ && \
  await_confirm && \
- $BUILD_WRAPPER $ANALYZE_OPTS make -j 4) && \
+ $BUILD_WRAPPER $SCANBUILD_OPTS make -j 4) && \
  (cp $BUILD_DIR/compile_commands.json .) && \
 exit_message
 

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -71,10 +71,10 @@ fi
 # installed.
 
 # Configure with default release build settings:
-mkdir -p $BUILD_DIR/$REPORT_DIR
 rm -Rf $BUILD_DIR/*
+mkdir -p $BUILD_DIR/$REPORT_DIR
 (cd $BUILD_DIR && $BUILD_WRAPPER $ANALYZE_OPTS \
-                  cmake -DCMAKE_BUILD_TYPE=Release \
+                  cmake3 -DCMAKE_BUILD_TYPE=Release \
                         -DENVIRONMENT_TYPE=default \
                         -DENABLE_COMPTIME_RED=OFF \
                         \
@@ -106,7 +106,7 @@ rm -Rf $BUILD_DIR/*
                         -DENABLE_PLASMA=ON \
                         -DENABLE_HDF5=ON \
                         \
-                        -DBUILD_EXAMPLES=ON \
+                        -DBUILD_EXAMPLES=OFF \
                         -DBUILD_TESTS=ON \
                         -DBUILD_DOCS=ON \
                         \

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -16,8 +16,10 @@ if [ "$BUILD_WRAPPER" = "" ]; then
   BUILD_WRAPPER="scan-build"
 fi
 if [ "$SCANBUILD_OPTS" = "" ]; then
-  SCANBUILD_OPTS="-o $REPORT_DIR --analyze-headers --plist-html"
+  SCANBUILD_OPTS="-analyze-headers -plist-html"
 fi
+SCANBUILD_OPTS="-o $REPORT_DIR ${SCANBUILD_OPTS}"
+
 
 which $BUILD_WRAPPER ||
   (echo "This build requires $BUILD_WRAPPER. Set env. var SCANBUILD_BIN" \

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -74,9 +74,14 @@ fi
 mkdir -p $BUILD_DIR
 mkdir -p $REPORT_DIR
 rm -Rf $BUILD_DIR/*
+rm -Rf $REPORT_DIR/*
 (cd $BUILD_DIR && $BUILD_WRAPPER $ANALYZE_OPTS \
                   cmake -DCMAKE_BUILD_TYPE=Release \
                         -DENVIRONMENT_TYPE=default \
+                        \
+                        -DCMAKE_C_COMPILER=clang \
+                        -DCMAKE_CXX_COMPILER=clang++ \
+                        \
                         -DDART_IF_VERSION=3.2 \
                         -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0/ \
                         -DDART_IMPLEMENTATIONS=mpi \
@@ -98,7 +103,7 @@ rm -Rf $BUILD_DIR/*
                         -DENABLE_LIKWID=OFF \
                         -DENABLE_HWLOC=ON \
                         -DENABLE_PAPI=ON \
-                        -DENABLE_MKL=ON \
+                        -DENABLE_MKL=OFF \
                         -DENABLE_BLAS=ON \
                         -DENABLE_LAPACK=ON \
                         -DENABLE_SCALAPACK=ON \
@@ -115,7 +120,7 @@ rm -Rf $BUILD_DIR/*
                         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                         ../ && \
  await_confirm && \
- $BUILD_WRAPPER $ANALYZE_OPTS make -j 4) &&
+ $BUILD_WRAPPER $ANALYZE_OPTS make -j 4) && \
  (cp $BUILD_DIR/compile_commands.json .) && \
 exit_message
 

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -29,7 +29,7 @@ fi
 await_confirm() {
   if ! $FORCE_BUILD; then
     echo ""
-    echo "   To build using these settings, hit ENTER"
+    echo "   To build and analyze using these settings, hit ENTER"
     read confirm
   fi
 }
@@ -71,16 +71,12 @@ fi
 # installed.
 
 # Configure with default release build settings:
-mkdir -p $BUILD_DIR
-mkdir -p $REPORT_DIR
+mkdir -p $BUILD_DIR/$REPORT_DIR
 rm -Rf $BUILD_DIR/*
-rm -Rf $REPORT_DIR/*
 (cd $BUILD_DIR && $BUILD_WRAPPER $ANALYZE_OPTS \
                   cmake -DCMAKE_BUILD_TYPE=Release \
                         -DENVIRONMENT_TYPE=default \
-                        \
-                        -DCMAKE_C_COMPILER=clang \
-                        -DCMAKE_CXX_COMPILER=clang++ \
+                        -DENABLE_COMPTIME_RED=OFF \
                         \
                         -DDART_IF_VERSION=3.2 \
                         -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0/ \

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -11,6 +11,18 @@ REPORT_DIR=report            # relative to BUILD_DIR
 BUILD_WRAPPER="${SCANBUILD_BIN}";
 
 
+
+## !! NOTE !!
+#
+#  See documentation of scan-build for details on recommended build
+#  configuration:
+#
+#  https://clang-analyzer.llvm.org/scan-build.html#recommended_debug
+#
+##
+
+
+
 # try to find build wrapper
 if [ "$BUILD_WRAPPER" = "" ]; then
   BUILD_WRAPPER="scan-build"
@@ -19,7 +31,7 @@ if [ "$SCANBUILD_OPTS" = "" ]; then
   SCANBUILD_OPTS="-analyze-headers -plist-html"
 fi
 SCANBUILD_OPTS="-o $REPORT_DIR ${SCANBUILD_OPTS}"
-
+SCANBUILD_OPTS="--force-analyze-debug-code ${SCANBUILD_OPTS}"
 
 which $BUILD_WRAPPER ||
   (echo "This build requires $BUILD_WRAPPER. Set env. var SCANBUILD_BIN" \
@@ -78,7 +90,7 @@ fi
 rm -Rf $BUILD_DIR/*
 mkdir -p $BUILD_DIR/$REPORT_DIR
 (cd $BUILD_DIR && $BUILD_WRAPPER $SCANBUILD_OPTS \
-                  cmake3 -DCMAKE_BUILD_TYPE=Release \
+                  cmake3 -DCMAKE_BUILD_TYPE=Debug \
                         -DENVIRONMENT_TYPE=default \
                         -DENABLE_COMPTIME_RED=OFF \
                         \
@@ -120,7 +132,7 @@ mkdir -p $BUILD_DIR/$REPORT_DIR
                         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                         ../ && \
  await_confirm && \
- $BUILD_WRAPPER $SCANBUILD_OPTS make -j 4) && \
+ $BUILD_WRAPPER $SCANBUILD_OPTS make) && \
  (cp $BUILD_DIR/compile_commands.json .) && \
 exit_message
 

--- a/dart-impl/base/include/dash/dart/base/assert.h
+++ b/dart-impl/base/include/dash/dart/base/assert.h
@@ -15,23 +15,23 @@
 #define DART_ASSERT(expr) do { \
   if (!(expr)) { \
     DART_LOG_ERROR("Assertion failed: %s", dart__tostr(expr)); \
-    assert(expr); \
   } \
+  assert(expr); \
 } while(0)
 
 #define DART_ASSERT_MSG(expr, msg) do { \
   if (!(expr)) { \
     DART_LOG_ERROR("Assertion failed: %s: %s", dart__tostr(expr), (msg)); \
-    assert(expr); \
   } \
+  assert(expr); \
 } while(0)
 
 #define DART_ASSERT_RETURNS(expr, exp_value) do { \
   if ((expr) != (exp_value)) { \
     DART_LOG_ERROR("Assertion failed: %s -- Expected return value %d", \
                    dart__tostr(expr), (exp_value)); \
-    assert((expr) == (exp_value)); \
   } \
+  assert((expr) == (exp_value)); \
 } while(0)
 
 #else /* DART_ENABLE_ASSERTIONS */

--- a/dart-impl/base/include/dash/dart/base/internal/host_topology.h
+++ b/dart-impl/base/include/dash/dart/base/internal/host_topology.h
@@ -77,7 +77,7 @@ dart_ret_t dart__base__host_topology__node_module(
  * "some-node" would also include units from "sub-node-*":
  *
  * NOTE: Array returned in output parameter `units` is allocated in
- *       this function and must be deallcoated by the caller.
+ *       this function and must be deallocated by the caller.
  */
 dart_ret_t dart__base__host_topology__node_units(
   dart_host_topology_t  * topo,
@@ -95,7 +95,7 @@ dart_ret_t dart__base__host_topology__node_units(
 dart_ret_t dart__base__host_topology__host_domain(
   dart_host_topology_t      * topo,
   const char                * hostname,
-  const dart_global_unit_t ** unit_ids,
+  const dart_global_unit_t ** units,
   int                       * num_units,
   const int                ** numa_ids,
   int                       * num_numa_domains);

--- a/dart-impl/base/src/internal/domain_locality.c
+++ b/dart-impl/base/src/internal/domain_locality.c
@@ -141,7 +141,7 @@ dart_ret_t dart__base__locality__domain__copy(
                      domain_src->domain_tag, domain_src->num_units);
       return DART_ERR_OTHER;
     }
-    domain_dst->unit_ids = malloc(sizeof(dart_unit_t) *
+    domain_dst->unit_ids = malloc(sizeof(dart_global_unit_t) *
                                   domain_src->num_units);
     for (int u = 0; u < domain_src->num_units; u++) {
       domain_dst->unit_ids[u] = domain_src->unit_ids[u];
@@ -227,11 +227,6 @@ dart_ret_t dart__base__locality__domain__update_subdomains(
       domain->num_units += subdomain->num_units;
     }
   }
-  if (domain->num_units   == 0 && domain->unit_ids != NULL) {
-    DART_LOG_DEBUG("dart__base__locality__domain__destruct: "
-                   "free(domain->unit_ids)");
-    free(domain->unit_ids);
-  }
   if (domain->num_domains == 0 && domain->domains  != NULL) {
     DART_LOG_DEBUG("dart__base__locality__domain__destruct: "
                    "free(domain->domains)");
@@ -257,9 +252,7 @@ dart_ret_t dart__base__locality__domain__update_subdomains(
       }
     }
   } else {
-    if (NULL != domain->unit_ids) {
-      free(domain->unit_ids);
-    }
+    free(domain->unit_ids);
     domain->unit_ids = NULL;
   }
   DART_LOG_TRACE("dart__base__locality__domain__update_subdomains > "
@@ -449,7 +442,7 @@ dart_ret_t dart__base__locality__domain__filter_subdomains(
       memcpy(domain->unit_ids + unit_idx,
              domain->domains[subdomain_idx].unit_ids,
              domain->domains[subdomain_idx].num_units *
-               sizeof(dart_unit_t));
+               sizeof(dart_global_unit_t));
       unit_idx += domain->domains[subdomain_idx].num_units;
     }
 
@@ -468,25 +461,27 @@ dart_ret_t dart__base__locality__domain__filter_subdomains(
 
   if (NULL != domain->unit_ids) {
     if (domain->num_units != unit_idx) {
-      dart_global_unit_t * tmp =
-        realloc(domain->unit_ids, unit_idx * sizeof(dart_global_unit_t));
       if (unit_idx == 0) {
+        free(domain->unit_ids);
         domain->unit_ids = NULL;
-      } else if (tmp != NULL) {
-        domain->unit_ids = tmp;
+      } else {
+        domain->unit_ids =
+            realloc(domain->unit_ids, unit_idx * sizeof(dart_global_unit_t));
+        DART_ASSERT(domain->unit_ids != NULL);
       }
       domain->num_units = unit_idx;
     }
   }
   if (NULL != domain->domains) {
     if (domain->num_domains != subdomain_idx) {
-      dart_domain_locality_t * tmp =
-        realloc(domain->domains,
-                subdomain_idx * sizeof(dart_domain_locality_t));
       if (subdomain_idx == 0) {
+        free(domain->domains);
         domain->domains = NULL;
-      } else if (tmp != NULL) {
-        domain->domains = tmp;
+      } else {
+        domain->domains =
+            realloc(domain->domains,
+                    subdomain_idx * sizeof(dart_domain_locality_t));
+        DART_ASSERT(domain->domains != NULL);
       }
       domain->num_domains = subdomain_idx;
     }
@@ -556,7 +551,7 @@ dart_ret_t dart__base__locality__domain__create_subdomains(
                                            sizeof(dart_global_unit_t));
       memcpy(node_domain->unit_ids + node_num_units_prev,
              node_subdomain->unit_ids,
-             node_subdomain->num_units * sizeof(dart_unit_t));
+             node_subdomain->num_units * sizeof(dart_global_unit_t));
     }
 
     /* Bottom-up recursion operations: */
@@ -632,9 +627,9 @@ dart_ret_t dart__base__locality__domain__create_node_subdomains(
       DART_OK);
 
     module_domain->unit_ids =
-      malloc(module_domain->num_units * sizeof(dart_unit_t));
+      malloc(module_domain->num_units * sizeof(dart_global_unit_t));
     memcpy(module_domain->unit_ids, module_unit_ids,
-           module_domain->num_units * sizeof(dart_unit_t));
+           module_domain->num_units * sizeof(dart_global_unit_t));
 
     DART_ASSERT_RETURNS(
       dart__base__locality__domain__create_module_subdomains(
@@ -868,7 +863,7 @@ dart_ret_t dart__base__locality__domain__create_module_subdomains(
      * global index of the subdomain of this iteration: */
     subdomain->num_units = 0;
     subdomain->unit_ids  = malloc(module_domain->num_units *
-                                         sizeof(dart_unit_t));
+                                         sizeof(dart_global_unit_t));
     for (int u_idx = 0; u_idx < module_domain->num_units; u_idx++) {
       dart_global_unit_t unit_gid = module_domain->unit_ids[u_idx];
       dart_team_unit_t   unit_lid;
@@ -899,9 +894,14 @@ dart_ret_t dart__base__locality__domain__create_module_subdomains(
                    "-- module->domains[%d].num_units:%d",
                    sd, subdomain->num_units);
 
-    subdomain->unit_ids = realloc(subdomain->unit_ids,
-                                  subdomain->num_units * sizeof(dart_unit_t));
-    DART_ASSERT(NULL != subdomain->unit_ids);
+    if (subdomain->num_units) {
+      subdomain->unit_ids = realloc(subdomain->unit_ids,
+                            subdomain->num_units * sizeof(dart_global_unit_t));
+      DART_ASSERT(NULL != subdomain->unit_ids);
+    } else {
+      free(subdomain->unit_ids);
+      subdomain->unit_ids = NULL;
+    }
 
     /* Number of units in subdomain is set at this point.
      * Below module level, a module subdomain's number of affine cores is:

--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -607,6 +607,10 @@ dart_ret_t dart__base__host_topology__create(
     /* All units mapped to same host: */
     max_host_units = num_host_units;
   }
+
+  DART_ASSERT_MSG(max_host_units > 0,
+                  "Resolved max. units per host is <= 0");
+
   /* All entries after index last_host_ids are duplicates now: */
   int num_hosts = last_host_idx + 1;
   DART_LOG_TRACE("dart__base__host_topology__init: number of hosts: %d",

--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -687,6 +687,10 @@ dart_ret_t dart__base__host_topology__create(
       DART_LOG_TRACE("dart__base__host_topology__init: shrinking node unit "
                      "array from %d to %d elements",
                      max_host_units, host_units->num_units);
+      // Either   realloc(addr != 0, n >= 0) -> free or realloc
+      // or       realloc(addr  = 0, n >  0) -> malloc
+      DART_ASSERT(host_units->units     != NULL ||
+                  host_units->num_units  > 0);
       host_units->units = realloc(host_units->units,
                                   host_units->num_units *
                                     sizeof(dart_global_unit_t));

--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -691,10 +691,17 @@ dart_ret_t dart__base__host_topology__create(
       // or       realloc(addr  = 0, n >  0) -> malloc
       DART_ASSERT(host_units->units     != NULL ||
                   host_units->num_units  > 0);
-      host_units->units = realloc(host_units->units,
-                                  host_units->num_units *
-                                    sizeof(dart_global_unit_t));
-      DART_ASSERT(host_units->units != NULL);
+      // Note: realloc with zero-size is argued unsafe in certain scenarios:
+      // https://www.securecoding.cert.org/confluence/display/c/\
+      //   MEM04-C.+Beware+of+zero-length+allocations
+      if (host_units->num_units > 0) {
+        host_units->units = realloc(host_units->units,
+                                    host_units->num_units *
+                                      sizeof(dart_global_unit_t));
+        DART_ASSERT(host_units->units != NULL);
+      } else {
+        free(host_units->units);
+      }
     }
   }
 

--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -624,7 +624,8 @@ dart_ret_t dart__base__host_topology__create(
     /* Histogram of NUMA ids: */
     int numa_id_hist[DART_LOCALITY_MAX_NUMA_ID] = { 0 };
     /* Allocate array with capacity of maximum units on a single host: */
-    host_units->units      = malloc(sizeof(dart_unit_t) * max_host_units);
+    host_units->units      = malloc(sizeof(dart_global_unit_t)
+                                          * max_host_units);
     host_units->num_units  = 0;
     host_domain->host[0]   = '\0';
     host_domain->parent[0] = '\0';
@@ -684,7 +685,7 @@ dart_ret_t dart__base__host_topology__create(
                      max_host_units, host_units->num_units);
       host_units->units = realloc(host_units->units,
                                   host_units->num_units *
-                                    sizeof(dart_unit_t));
+                                    sizeof(dart_global_unit_t));
       DART_ASSERT(host_units->units != NULL);
     }
   }

--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -701,6 +701,7 @@ dart_ret_t dart__base__host_topology__create(
         DART_ASSERT(host_units->units != NULL);
       } else {
         free(host_units->units);
+        host_units->units = NULL;
       }
     }
   }

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -817,9 +817,12 @@ dart_ret_t dart__base__locality__group_subdomains(
   int num_ungrouped       = domain->num_domains - num_grouped;
   int num_subdomains_new  = num_ungrouped + 1;
 
-  DART_ASSERT_MSG(
-    num_grouped > 0,
-    "requested to group <= 0 domains");
+  if (num_grouped <= 0) {
+    DART_LOG_ERROR("dart__base__locality__group_subdomains ! "
+                   "requested to group %d <= 0 domains",
+                   num_grouped);
+    return DART_ERR_INVAL;
+  }
 
   /* The domain tag of the group to be added must be a successor of the last
    * subdomain's (the group domain's last sibling) tag to avoid collisions.

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -330,6 +330,12 @@ dart_ret_t dart__base__locality__scope_domain_tags(
     free(dart_scope_domains);
     return ret;
   }
+  if (*num_domains_out <= 0) {
+    DART_LOG_ERROR("dart__base__locality__scope_domain_tags ! "
+                   "num_domains result at scope %d is %d <= 0",
+                   scope, *num_domains_out);
+    return DART_ERR_INVAL;
+  }
 
   *domain_tags_out = (char **)(malloc(sizeof(char *) * (*num_domains_out)));
   for (int sd = 0; sd < *num_domains_out; sd++) {
@@ -341,6 +347,12 @@ dart_ret_t dart__base__locality__scope_domain_tags(
   }
 
   free(dart_scope_domains);
+
+  if (*domain_tags_out == NULL) {
+    DART_LOG_ERROR("dart__base__locality__scope_domain_tags ! "
+                   "domain_tags result is undefined");
+    return DART_ERR_OTHER;
+  }
 
   return DART_OK;
 }
@@ -373,7 +385,7 @@ dart_ret_t dart__base__locality__domain_split_tags(
 
   /* Get total number and tags of domains in split scope: */
   int     num_domains;
-  char ** domain_tags;
+  char ** domain_tags = NULL;
   DART_ASSERT_RETURNS(
     dart__base__locality__scope_domain_tags(
       domain_in, scope, &num_domains, &domain_tags),
@@ -383,6 +395,12 @@ dart_ret_t dart__base__locality__domain_split_tags(
     DART_LOG_ERROR("dart__base__locality__domain_split_tags ! "
                    "domain_tags is undefined");
     return DART_ERR_OTHER;
+  }
+  if (num_domains <= 0) {
+    DART_LOG_ERROR("dart__base__locality__domain_split_tags ! "
+                   "num_domains at scope %d is %d <= 0",
+                   scope, num_domains);
+    return DART_ERR_INVAL;
   }
 
   DART_LOG_TRACE("dart__base__locality__domain_split_tags: "
@@ -885,6 +903,7 @@ dart_ret_t dart__base__locality__group_subdomains(
       domain_copy = &ungrouped_domains[ungrouped_idx];
       ungrouped_idx++;
     }
+    DART_ASSERT(domain_copy != NULL);
     memcpy(domain_copy, subdom, sizeof(dart_domain_locality_t));
   }
 
@@ -981,12 +1000,14 @@ dart_ret_t dart__base__locality__group_subdomains(
   }
 
   for (int sd = 0; sd < num_ungrouped; sd++) {
-    DART_LOG_TRACE(
-      "dart__base__locality__group_subdomains: ==> domains[%d] u: %s",
-      sd, domain->domains[sd].domain_tag);
+    DART_ASSERT(
+      domain->domains != NULL);
     DART_ASSERT_MSG(
       ungrouped_domains != NULL,
       "No ungrouped subdomains at group locality scope");
+    DART_LOG_TRACE(
+      "dart__base__locality__group_subdomains: ==> domains[%d] u: %s",
+      sd, domain->domains[sd].domain_tag);
     memcpy(&domain->domains[sd],
            &ungrouped_domains[sd],
            sizeof(dart_domain_locality_t));

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -890,7 +890,7 @@ dart_ret_t dart__base__locality__group_subdomains(
 
   for (int sd = 0; sd < domain->num_domains; sd++) {
     dart_domain_locality_t * subdom        = &domain->domains[sd];
-    dart_domain_locality_t * domain_copy;
+    dart_domain_locality_t * domain_copy   = NULL;
 
     if (subdom->scope == DART_LOCALITY_SCOPE_GROUP) {
       DART_ASSERT_MSG(

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -394,12 +394,16 @@ dart_ret_t dart__base__locality__domain_split_tags(
   if (domain_tags == NULL) {
     DART_LOG_ERROR("dart__base__locality__domain_split_tags ! "
                    "domain_tags is undefined");
+    free(group_domain_tags);
+    free(group_sizes);
     return DART_ERR_OTHER;
   }
   if (num_domains <= 0) {
     DART_LOG_ERROR("dart__base__locality__domain_split_tags ! "
                    "num_domains at scope %d is %d <= 0",
                    scope, num_domains);
+    free(group_domain_tags);
+    free(group_sizes);
     return DART_ERR_INVAL;
   }
 
@@ -560,10 +564,11 @@ dart_ret_t dart__base__locality__domain_group(
         DART_LOG_ERROR("dart__base__locality__domain_group ! "
                        "group subdomain %s with invalid parent domain %s",
                        group_subdomain_tags[sd], group_parent_domain_tag);
-        /*
-         * TODO TF: this will leak immediate_subdomain_tags and all
-         *          previously allocated subdomain_tags!
-         */
+
+        for (int sd_p = 0; sd_p <= sd; sd_p++) {
+          free(immediate_subdomain_tags[sd_p]);
+        }
+        free(immediate_subdomain_tags);
 
         return DART_ERR_INVAL;
       }

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -938,7 +938,7 @@ dart_ret_t dart__base__locality__group_subdomains(
   /*
    * Collect unit ids of group domain:
    */
-  group_domain->unit_ids = malloc(sizeof(dart_unit_t) *
+  group_domain->unit_ids = malloc(sizeof(dart_global_unit_t) *
                                   group_domain->num_units);
   int group_domain_unit_idx = 0;
   for (int gd = 0; gd < num_grouped; gd++) {

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -379,6 +379,12 @@ dart_ret_t dart__base__locality__domain_split_tags(
       domain_in, scope, &num_domains, &domain_tags),
     DART_OK);
 
+  if (domain_tags == NULL) {
+    DART_LOG_ERROR("dart__base__locality__domain_split_tags ! "
+                   "domain_tags is undefined");
+    return DART_ERR_OTHER;
+  }
+
   DART_LOG_TRACE("dart__base__locality__domain_split_tags: "
                  "number of domains in scope %d: %d", scope, num_domains);
 
@@ -898,6 +904,13 @@ dart_ret_t dart__base__locality__group_subdomains(
    */
   dart_domain_locality_t * group_domain =
     &domain->domains[group_domain_rel_idx];
+
+  if (group_domain == NULL) {
+    DART_LOG_ERROR("dart__base__locality__group_subdomains: "
+                   "Group domain at relative index %d not defined",
+                   group_domain_rel_idx);
+    return DART_ERR_NOTFOUND;
+  }
 
   dart__base__locality__domain__init(group_domain);
 

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_globmem_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_globmem_priv.h
@@ -3,15 +3,6 @@
 
 #include <stdint.h>
 
-#define DART_GPTR_COPY(gptr_, gptrt_)                       \
-  do {                                                      \
-    gptr_.unitid = gptrt_.unitid;                           \
-    gptr_.flags  = gptrt_.flags;                            \
-    gptr_.segid  = gptrt_.segid;                            \
-    gptr_.teamid = gptrt_.teamid;                           \
-    gptr_.addr_or_offs.offset = gptrt_.addr_or_offs.offset; \
-  } while(0)
-
 /* Global object for one-sided communication on memory region allocated with 'local allocation'. */
 extern MPI_Win dart_win_local_alloc;
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_globmem_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_globmem_priv.h
@@ -6,6 +6,7 @@
 #define DART_GPTR_COPY(gptr_, gptrt_)                       \
   do {                                                      \
     gptr_.unitid = gptrt_.unitid;                           \
+    gptr_.flags  = gptrt_.flags;                            \
     gptr_.segid  = gptrt_.segid;                            \
     gptr_.teamid = gptrt_.teamid;                           \
     gptr_.addr_or_offs.offset = gptrt_.addr_or_offs.offset; \

--- a/dart-impl/mpi/src/dart_communication.c
+++ b/dart-impl/mpi/src/dart_communication.c
@@ -1166,6 +1166,8 @@ dart_ret_t dart_waitall_local(
       }
     } else {
       DART_LOG_DEBUG("dart_waitall_local > number of requests = 0");
+      free(mpi_req);
+      free(mpi_sta);
       return DART_OK;
     }
     /*
@@ -1283,6 +1285,8 @@ dart_ret_t dart_waitall(
       }
     } else {
       DART_LOG_DEBUG("dart_waitall > number of requests = 0");
+      free(mpi_req);
+      free(mpi_sta);
       return DART_OK;
     }
     /*

--- a/dart-impl/mpi/src/dart_locality.c
+++ b/dart-impl/mpi/src/dart_locality.c
@@ -43,13 +43,17 @@ dart_ret_t dart_domain_team_locality(
                  team, domain_tag);
   dart_ret_t ret;
 
-  dart_domain_locality_t * team_domain;
+  *team_domain_out = NULL;
+
+  dart_domain_locality_t * team_domain = NULL;
   ret = dart__base__locality__team_domain(team, &team_domain);
   if (ret != DART_OK) {
     DART_LOG_ERROR("dart_domain_team_locality: "
                    "dart__base__locality__team_domain failed (%d)", ret);
     return ret;
   }
+  DART_ASSERT(team_domain != NULL);
+
   *team_domain_out = team_domain;
 
   if (strcmp(domain_tag, team_domain->domain_tag) != 0) {
@@ -60,10 +64,13 @@ dart_ret_t dart_domain_team_locality(
       DART_LOG_ERROR("dart_domain_team_locality: "
                      "dart__base__locality__domain failed "
                      "for domain tag '%s' -> (%d)", domain_tag, ret);
+      *team_domain_out = NULL;
       return ret;
     }
     *team_domain_out = team_subdomain;
   }
+
+  DART_ASSERT(*team_domain_out != NULL);
 
   DART_LOG_DEBUG("dart_domain_team_locality > team(%d) domain(%s) -> %p",
                  team, domain_tag, (void *)(*team_domain_out));

--- a/dart-impl/mpi/src/dart_mem.c
+++ b/dart-impl/mpi/src/dart_mem.c
@@ -42,8 +42,8 @@ struct dart_buddy  *  dart_localpool;
 static inline int
 num_level(size_t size)
 {
-  int level = 1;
-  while ((1 << level) < size) {
+  unsigned int level = 1;
+  while ((((unsigned int) 1) << level) < size) {
     level++;
   }
   return level;
@@ -58,8 +58,8 @@ struct dart_buddy *
 dart_buddy_new(size_t size)
 {
   DART_ASSERT(is_pow_of_2(size));
-  int level = num_level(size) - DART_MEM_ALIGN_BITS;
-	int lsize = 1 << level;
+  unsigned int level = num_level(size) - DART_MEM_ALIGN_BITS;
+  unsigned int lsize = ((unsigned int) 1) << level;
 	struct dart_buddy * self =
     malloc(sizeof(struct dart_buddy) + sizeof(uint8_t) * (lsize * 2 - 2));
 	self->level = level;

--- a/dart-impl/mpi/src/dart_mem.c
+++ b/dart-impl/mpi/src/dart_mem.c
@@ -171,11 +171,12 @@ dart_buddy_alloc(struct dart_buddy * self, size_t s) {
 		}
 		for (;;) {
 			level--;
-//    length *= 2;
+//			length *= 2;
 			index = (index + 1) / 2 - 1;
-			if (index < 0)
+			if (index < 0) {
 			  dart_mutex_unlock(&self->mutex);
-				return -1;
+			  return -1;
+			}
 			if (index & 1) {
 				++index;
 				break;

--- a/dart-impl/mpi/src/dart_mem.c
+++ b/dart-impl/mpi/src/dart_mem.c
@@ -171,7 +171,7 @@ dart_buddy_alloc(struct dart_buddy * self, size_t s) {
 		}
 		for (;;) {
 			level--;
-//			length *= 2;
+			length *= 2;
 			index = (index + 1) / 2 - 1;
 			if (index < 0) {
 			  dart_mutex_unlock(&self->mutex);

--- a/dart-impl/mpi/src/dart_mem.c
+++ b/dart-impl/mpi/src/dart_mem.c
@@ -42,7 +42,7 @@ struct dart_buddy  *  dart_localpool;
 static inline int
 num_level(size_t size)
 {
-  unsigned int level = 1;
+  unsigned int level  = 1;
   while ((((unsigned int) 1) << level) < size) {
     level++;
   }
@@ -58,8 +58,13 @@ struct dart_buddy *
 dart_buddy_new(size_t size)
 {
   DART_ASSERT(is_pow_of_2(size));
-  unsigned int level = num_level(size) - DART_MEM_ALIGN_BITS;
-  unsigned int lsize = ((unsigned int) 1) << level;
+  unsigned int level  = num_level(size) - DART_MEM_ALIGN_BITS;
+  // do not shift more than 31 bit
+  if(level > sizeof(unsigned int) * 8){
+    DART_LOG_ERROR("Level of buddy allocator invalid");
+    return NULL;
+  }
+  unsigned int lsize  = (((unsigned int) 1) << level);
 	struct dart_buddy * self =
     malloc(sizeof(struct dart_buddy) + sizeof(uint8_t) * (lsize * 2 - 2));
 	self->level = level;
@@ -166,7 +171,7 @@ dart_buddy_alloc(struct dart_buddy * self, size_t s) {
 		}
 		for (;;) {
 			level--;
-			length *= 2;
+//    length *= 2;
 			index = (index + 1) / 2 - 1;
 			if (index < 0)
 			  dart_mutex_unlock(&self->mutex);

--- a/dart-impl/mpi/src/dart_synchronization.c
+++ b/dart-impl/mpi/src/dart_synchronization.c
@@ -66,10 +66,10 @@ dart_ret_t dart_team_lock_init (dart_team_t teamid, dart_lock_t* lock)
 	*addr = -1;
 	MPI_Win_sync (win);
 
-	DART_GPTR_COPY((*lock) -> gptr_tail, gptr_tail);
-	DART_GPTR_COPY((*lock) -> gptr_list, gptr_list);
-	(*lock) -> teamid = teamid;
-	(*lock) -> is_acquired = 0;
+  (*lock)->gptr_tail   = gptr_tail;
+  (*lock)->gptr_list   = gptr_list;
+  (*lock)->teamid      = teamid;
+  (*lock)->is_acquired = 0;
 
 	DART_LOG_DEBUG ("INIT - done");
 
@@ -78,8 +78,8 @@ dart_ret_t dart_team_lock_init (dart_team_t teamid, dart_lock_t* lock)
 
 dart_ret_t dart_lock_acquire (dart_lock_t lock)
 {
-	dart_team_unit_t unitid;
-	dart_team_myid(lock->teamid, &unitid);
+  dart_team_unit_t unitid;
+  dart_team_myid(lock->teamid, &unitid);
 
 	if (lock->is_acquired == 1)
 	{
@@ -87,15 +87,12 @@ dart_ret_t dart_lock_acquire (dart_lock_t lock)
 		return DART_OK;
 	}
 
-	dart_gptr_t gptr_tail;
-	dart_gptr_t gptr_list;
-	int32_t predecessor[1], result[1];
 
-	MPI_Win win;
-	MPI_Status status;
-
-	DART_GPTR_COPY(gptr_tail, lock -> gptr_tail);
-	DART_GPTR_COPY(gptr_list, lock -> gptr_list);
+  int32_t predecessor[1], result[1];
+  MPI_Win win;
+  MPI_Status status;
+  dart_gptr_t gptr_tail = lock->gptr_tail;
+  dart_gptr_t gptr_list = lock->gptr_list;
 
   uint64_t offset_tail = gptr_tail.addr_or_offs.offset;
   int16_t seg_id       = gptr_list.segid;
@@ -148,14 +145,13 @@ dart_ret_t dart_lock_try_acquire (dart_lock_t lock, int32_t *is_acquired)
 		printf ("Warning: TRYLOCK - %2d has acquired the lock already\n", unitid.id);
 		return DART_OK;
 	}
-	dart_gptr_t gptr_tail;
 
 	int32_t result[1];
 	int32_t compare[1] = {-1};
 
-	DART_GPTR_COPY(gptr_tail, lock -> gptr_tail);
-	dart_unit_t tail = gptr_tail.unitid;
-	uint64_t offset  = gptr_tail.addr_or_offs.offset;
+	dart_gptr_t gptr_tail = lock->gptr_tail;
+	dart_unit_t tail      = gptr_tail.unitid;
+	uint64_t offset       = gptr_tail.addr_or_offs.offset;
 
 	/* Atomicity: Check if the lock is available and claim it if it is. */
   MPI_Compare_and_swap (&unitid.id, compare, result, MPI_INT32_T, tail, offset, dart_win_local_alloc);
@@ -185,16 +181,15 @@ dart_ret_t dart_lock_release (dart_lock_t lock)
     printf("Warning: RELEASE - %2d has not yet required the lock\n", unitid.id);
     return DART_OK;
   }
-  dart_gptr_t gptr_tail;
-  dart_gptr_t gptr_list;
+
   MPI_Win win;
   int32_t * addr2, next, result[1];
 
   MPI_Aint disp_list;
   int32_t origin[1] = { -1};
 
-  DART_GPTR_COPY(gptr_tail, lock -> gptr_tail);
-  DART_GPTR_COPY(gptr_list, lock -> gptr_list);
+  dart_gptr_t gptr_tail = lock->gptr_tail;
+  dart_gptr_t gptr_list = lock->gptr_list;
 
   uint64_t offset_tail = gptr_tail.addr_or_offs.offset;
   int16_t  seg_id      = gptr_list.segid;
@@ -250,11 +245,9 @@ dart_ret_t dart_lock_release (dart_lock_t lock)
 
 dart_ret_t dart_team_lock_free (dart_team_t teamid, dart_lock_t* lock)
 {
-	dart_gptr_t gptr_tail;
-	dart_gptr_t gptr_list;
+	dart_gptr_t gptr_tail = (*lock)->gptr_tail;
+	dart_gptr_t gptr_list = (*lock)->gptr_list;
 	dart_team_unit_t unitid;
-	DART_GPTR_COPY(gptr_tail, (*lock) -> gptr_tail);
-	DART_GPTR_COPY(gptr_list, (*lock) -> gptr_list);
 
 	dart_team_myid(teamid, &unitid);
 	if (unitid.id == 0)

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -27,8 +27,7 @@
 
 static struct dart_group_struct* allocate_group()
 {
-  struct dart_group_struct* group = (struct dart_group_struct *) malloc(
-                                      sizeof(struct dart_group_struct));
+  struct dart_group_struct* group = malloc(sizeof(struct dart_group_struct));
   return group;
 };
 
@@ -116,18 +115,16 @@ dart_ret_t dart_group_union(
               &res->mpi_group) == MPI_SUCCESS)
   {
     int i, j, k, size_in, size_out;
-    dart_global_unit_t *pre_unitidsout;
-    dart_unit_t *post_unitidsout;
 
     MPI_Group group_all;
     MPI_Comm_group(DART_COMM_WORLD, &group_all);
     MPI_Group_size(res->mpi_group, &size_out);
     if (size_out > 1) {
       MPI_Group_size(g1->mpi_group, &size_in);
-      pre_unitidsout  = (dart_global_unit_t *)malloc(
-                          size_out * sizeof (dart_global_unit_t));
-      post_unitidsout = (dart_unit_t *)malloc(
-                          size_out * sizeof (dart_unit_t));
+      dart_global_unit_t *pre_unitidsout = malloc(size_out
+                                            * sizeof(*pre_unitidsout));
+      dart_unit_t *post_unitidsout = malloc(size_out
+                                            * sizeof(*post_unitidsout));
       dart_group_getmembers (res, pre_unitidsout);
 
       /* Sort gout by the method of 'merge sort'. */
@@ -264,7 +261,6 @@ dart_ret_t dart_group_getmembers(
   dart_global_unit_t * unitids)
 {
   int size;
-  int *array;
   MPI_Group group_all;
 
   if (g == NULL) {
@@ -274,7 +270,7 @@ dart_ret_t dart_group_getmembers(
 
   MPI_Group_size(g->mpi_group, &size);
   MPI_Comm_group(DART_COMM_WORLD, &group_all);
-  array = (int*) malloc(sizeof (int) * size);
+  int *array = malloc(sizeof(*array) * size);
   for (int i = 0; i < size; i++) {
     array[i] = i;
   }
@@ -386,9 +382,7 @@ dart_ret_t dart_group_locality_split(
   /* create a group for every domain in the specified scope: */
 
   int total_domains_units           = 0;
-  dart_domain_locality_t ** domains = (dart_domain_locality_t **) malloc(
-                                        num_domains *
-                                        sizeof(dart_domain_locality_t *));
+  dart_domain_locality_t ** domains = malloc(num_domains * sizeof(*domains));
   for (int d = 0; d < num_domains; ++d) {
     DART_ASSERT_RETURNS(
       dart_domain_team_locality(team, domain_tags[d], &domains[d]),
@@ -410,7 +404,7 @@ dart_ret_t dart_group_locality_split(
       dart_global_unit_t * unit_ids        = domains[g]->unit_ids;
 
       /* convert relative unit ids from domain to global unit ids: */
-      int * group_global_unit_ids = (int *) malloc(group_num_units * sizeof(int));
+      int * group_global_unit_ids = malloc(group_num_units * sizeof(int));
       for (int u = 0; u < group_num_units; ++u) {
         group_global_unit_ids[u] = unit_ids[u].id;
         DART_LOG_TRACE("dart_group_locality_split: group[%zu].units[%d] "
@@ -490,8 +484,7 @@ dart_ret_t dart_group_locality_split(
 
       dart_global_unit_t * group_team_unit_ids = NULL;
       if(group_num_units != 0){
-        group_team_unit_ids = (dart_global_unit_t *)
-                                malloc(sizeof(dart_global_unit_t) *
+        group_team_unit_ids = malloc(sizeof(dart_global_unit_t) *
                                        group_num_units);
       }
       int group_unit_idx = 0;
@@ -503,7 +496,7 @@ dart_ret_t dart_group_locality_split(
       }
 
       /* convert relative unit ids from domain to global unit ids: */
-      int * group_global_unit_ids = (int *) malloc(group_num_units * sizeof(int));
+      int * group_global_unit_ids = malloc(group_num_units * sizeof(int));
       for (int u = 0; u < group_num_units; ++u) {
         // TODO TF: why is there no actual conversion happening here?!
         group_global_unit_ids[u] = group_team_unit_ids[u].id;
@@ -539,7 +532,6 @@ dart_ret_t dart_group_ismember(
   int32_t            * ismember)
 {
   int                 i, size;
-  dart_global_unit_t* ranks;
 
 
   if (g == NULL) {
@@ -549,7 +541,7 @@ dart_ret_t dart_group_ismember(
   }
 
   MPI_Group_size(g->mpi_group, &size);
-  ranks = (dart_global_unit_t *)malloc(size * sizeof(dart_global_unit_t));
+  dart_global_unit_t* ranks = malloc(size * sizeof(dart_global_unit_t));
   dart_group_getmembers (g, ranks);
   for (i = 0; i < size; i++) {
     if (ranks[i].id == unitid.id) {

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -35,7 +35,8 @@ dart_ret_t dart_group_create(
   dart_group_t *group)
 {
   struct dart_group_struct* res = allocate_group();
-  // Initialize the group as empty but not directly assign MPI_GROUP_EMPTY as it might lead to invalid free later
+  // Initialize the group as empty but not directly assign MPI_GROUP_EMPTY
+  // as it might lead to invalid free later
   MPI_Group g;
   MPI_Comm_group(DART_COMM_WORLD, &g);
   MPI_Group_incl(g, 0, NULL, &res->mpi_group);
@@ -46,21 +47,21 @@ dart_ret_t dart_group_create(
 dart_ret_t dart_group_destroy(
   dart_group_t *group)
 {
-
-  if (group == NULL || *group == NULL) {
-    DART_LOG_ERROR("Invalid group argument: %p -> %p", group, (group) ? (void*)*group : (void*)group);
+  if (group == NULL) {
+    DART_LOG_ERROR("Invalid group argument");
     return DART_ERR_INVAL;
   }
 
-  struct dart_group_struct** g = group;
-  if ((*g)->mpi_group != MPI_GROUP_NULL) {
-    MPI_Group_free(&(*g)->mpi_group);
-    (*g)->mpi_group = MPI_GROUP_NULL;
+  if (*group != NULL) {
+    struct dart_group_struct** g = group;
+    if ((*g)->mpi_group != MPI_GROUP_NULL) {
+      MPI_Group_free(&(*g)->mpi_group);
+      (*g)->mpi_group = MPI_GROUP_NULL;
+    }
+
+    free(*g);
+    *g = NULL;
   }
-
-  free(*g);
-  *g = NULL;
-
   return DART_OK;
 }
 
@@ -182,10 +183,6 @@ dart_ret_t dart_group_intersect(
   return DART_OK;
 }
 
-/**
- * <fuchst>   Does this function expect global or local unit ids (relative
- *            to a team)?
- */
 dart_ret_t dart_group_addmember(
   dart_group_t        g,
   dart_global_unit_t  unitid)
@@ -403,23 +400,26 @@ dart_ret_t dart_group_locality_split(
       int                  group_num_units = domains[g]->num_units;
       dart_global_unit_t * unit_ids        = domains[g]->unit_ids;
 
-      /* convert relative unit ids from domain to global unit ids: */
-      int * group_global_unit_ids = malloc(group_num_units * sizeof(int));
-      for (int u = 0; u < group_num_units; ++u) {
-        group_global_unit_ids[u] = unit_ids[u].id;
-        DART_LOG_TRACE("dart_group_locality_split: group[%zu].units[%d] "
-                       "global unit id: %d",
-                       g, u, group_global_unit_ids[u]);
+      if (group_num_units <= 0) {
+        DART_LOG_DEBUG("dart_group_locality_split: no units in group %d", g);
+        gout[g] = NULL;
+      } else {
+        int * group_unit_ids = malloc(group_num_units * sizeof(int));
+        for (int u = 0; u < group_num_units; ++u) {
+          group_unit_ids[u] = unit_ids[u].id;
+          DART_LOG_TRACE("dart_group_locality_split: group[%zu].units[%d] "
+                         "global unit id: %d",
+                         g, u, group_unit_ids[u]);
+        }
+        gout[g] = allocate_group();
+        MPI_Group_incl(
+          group->mpi_group,
+          group_num_units,
+          group_unit_ids,
+          &(gout[g]->mpi_group));
+
+        free(group_unit_ids);
       }
-
-      gout[g] = allocate_group();
-      MPI_Group_incl(
-        group->mpi_group,
-        group_num_units,
-        group_global_unit_ids,
-        &(gout[g]->mpi_group));
-
-      free(group_global_unit_ids);
     }
   } else if (num_groups < (size_t)num_domains) {
     /* Multiple domains per group. */
@@ -482,41 +482,35 @@ dart_ret_t dart_group_locality_split(
         group_num_units += domains[d]->num_units;
       }
 
-      dart_global_unit_t * group_team_unit_ids = NULL;
-      if(group_num_units != 0){
-        group_team_unit_ids = malloc(sizeof(dart_global_unit_t) *
-                                       group_num_units);
+      int * group_unit_ids = NULL;
+      if (group_num_units > 0) {
+        group_unit_ids = malloc(sizeof(dart_global_unit_t) *
+                                  group_num_units);
       } else {
-        DART_LOG_DEBUG("dart_group_locality_split: no units in group %zu",
-                       g);
+        DART_LOG_DEBUG("dart_group_locality_split: no units in group %d", g);
+        gout[g] = NULL;
         continue;
       }
       int group_unit_idx = 0;
       for (int d = group_first_dom_idx; d < group_last_dom_idx; ++d) {
-        for (int u = 0; u < domains[d]->num_units; ++u) {
-          group_team_unit_ids[group_unit_idx + u] = domains[d]->unit_ids[u];
+        for (int du = 0; du < domains[d]->num_units; ++du) {
+          int u = group_unit_idx + du;
+          group_unit_ids[group_unit_idx + u] = domains[d]->unit_ids[du].id;
+          DART_LOG_TRACE("dart_group_locality_split: "
+                         "group[%zu].unit_ids[%d] = domain[%d].unit_ids[%d]",
+                         g, u, d, du);
         }
         group_unit_idx += domains[d]->num_units;
-      }
-
-      /* convert relative unit ids from domain to global unit ids: */
-      int * group_global_unit_ids = malloc(group_num_units * sizeof(int));
-      for (int u = 0; u < group_num_units; ++u) {
-        group_global_unit_ids[u] = (int)group_team_unit_ids[u].id;
-        DART_LOG_TRACE("dart_group_locality_split: group[%zu].units[%d] "
-                       "global unit id: %d",
-                       g, u, group_global_unit_ids[u]);
       }
 
       gout[g] = allocate_group();
       MPI_Group_incl(
         group->mpi_group,
         group_num_units,
-        group_global_unit_ids,
+        group_unit_ids,
         &(gout[g]->mpi_group));
 
-      free(group_team_unit_ids);
-      free(group_global_unit_ids);
+      free(group_unit_ids);
     }
 #endif
   }

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -396,7 +396,11 @@ dart_ret_t dart_group_locality_split(
     num_groups = num_domains;
     *nout      = num_groups;
   }
-
+  if(num_groups <= 0) {
+    DART_LOG_ERROR("num_groups has to be greater than 0");
+    free(domains);
+    return DART_ERR_OTHER;
+  }
   if (num_groups == (size_t)num_domains) {
     /* one domain per group: */
     for (size_t g = 0; g < num_groups; ++g) {
@@ -465,7 +469,6 @@ dart_ret_t dart_group_locality_split(
     }
 #else
     /* Preliminary implementation */
-    DART_ASSERT_MSG(num_groups > 0, "num_groups has to be greater than 0");
     int max_group_domains = (num_domains + (num_groups-1)) / num_groups;
     DART_LOG_TRACE("dart_group_locality_split: max. domains per group: %d",
                    max_group_domains);
@@ -482,9 +485,13 @@ dart_ret_t dart_group_locality_split(
       for (int d = group_first_dom_idx; d < group_last_dom_idx; ++d) {
         group_num_units += domains[d]->num_units;
       }
-      dart_global_unit_t * group_team_unit_ids = (dart_global_unit_t *)
-                              malloc(sizeof(dart_global_unit_t) *
-                                     group_num_units);
+
+      dart_global_unit_t * group_team_unit_ids = NULL;
+      if(group_num_units != 0){
+        group_team_unit_ids = (dart_global_unit_t *)
+                                malloc(sizeof(dart_global_unit_t) *
+                                       group_num_units);
+      }
       int group_unit_idx = 0;
       for (int d = group_first_dom_idx; d < group_last_dom_idx; ++d) {
         for (int u = 0; u < domains[d]->num_units; ++u) {

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -502,8 +502,7 @@ dart_ret_t dart_group_locality_split(
       /* convert relative unit ids from domain to global unit ids: */
       int * group_global_unit_ids = malloc(group_num_units * sizeof(int));
       for (int u = 0; u < group_num_units; ++u) {
-        // TODO TF: why is there no actual conversion happening here?!
-        group_global_unit_ids[u] = group_team_unit_ids[u].id;
+        group_global_unit_ids[u] = (int)group_team_unit_ids[u];
         DART_LOG_TRACE("dart_group_locality_split: group[%zu].units[%d] "
                        "global unit id: %d",
                        g, u, group_global_unit_ids[u]);

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -27,9 +27,10 @@
 
 static struct dart_group_struct* allocate_group()
 {
-  struct dart_group_struct* group = malloc(sizeof(struct dart_group_struct));
+  struct dart_group_struct* group = (struct dart_group_struct *) malloc(
+                                      sizeof(struct dart_group_struct));
   return group;
-}
+};
 
 dart_ret_t dart_group_create(
   dart_group_t *group)
@@ -373,7 +374,7 @@ dart_ret_t dart_group_locality_split(
   /* create a group for every domain in the specified scope: */
 
   int total_domains_units           = 0;
-  dart_domain_locality_t ** domains = malloc(
+  dart_domain_locality_t ** domains = (dart_domain_locality_t **) malloc(
                                         num_domains *
                                         sizeof(dart_domain_locality_t *));
   for (int d = 0; d < num_domains; ++d) {
@@ -403,7 +404,7 @@ dart_ret_t dart_group_locality_split(
       dart_global_unit_t * unit_ids        = domains[g]->unit_ids;
 
       /* convert relative unit ids from domain to global unit ids: */
-      int * group_global_unit_ids = malloc(group_num_units * sizeof(int));
+      int * group_global_unit_ids = (int *) malloc(group_num_units * sizeof(int));
       for (int u = 0; u < group_num_units; ++u) {
         group_global_unit_ids[u] = unit_ids[u].id;
         DART_LOG_TRACE("dart_group_locality_split: group[%zu].units[%d] "
@@ -464,6 +465,7 @@ dart_ret_t dart_group_locality_split(
     }
 #else
     /* Preliminary implementation */
+    DART_ASSERT_MSG(num_groups > 0, "num_groups has to be greater than 0");
     int max_group_domains = (num_domains + (num_groups-1)) / num_groups;
     DART_LOG_TRACE("dart_group_locality_split: max. domains per group: %d",
                    max_group_domains);
@@ -480,7 +482,7 @@ dart_ret_t dart_group_locality_split(
       for (int d = group_first_dom_idx; d < group_last_dom_idx; ++d) {
         group_num_units += domains[d]->num_units;
       }
-      dart_global_unit_t * group_team_unit_ids =
+      dart_global_unit_t * group_team_unit_ids = (dart_global_unit_t *)
                               malloc(sizeof(dart_global_unit_t) *
                                      group_num_units);
       int group_unit_idx = 0;
@@ -492,7 +494,7 @@ dart_ret_t dart_group_locality_split(
       }
 
       /* convert relative unit ids from domain to global unit ids: */
-      int * group_global_unit_ids = malloc(group_num_units * sizeof(int));
+      int * group_global_unit_ids = (int *) malloc(group_num_units * sizeof(int));
       for (int u = 0; u < group_num_units; ++u) {
         group_global_unit_ids[u] = group_team_unit_ids[u].id;
         DART_LOG_TRACE("dart_group_locality_split: group[%zu].units[%d] "

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -502,7 +502,7 @@ dart_ret_t dart_group_locality_split(
       /* convert relative unit ids from domain to global unit ids: */
       int * group_global_unit_ids = malloc(group_num_units * sizeof(int));
       for (int u = 0; u < group_num_units; ++u) {
-        group_global_unit_ids[u] = (int)group_team_unit_ids[u];
+        group_global_unit_ids[u] = (int)group_team_unit_ids[u].id;
         DART_LOG_TRACE("dart_group_locality_split: group[%zu].units[%d] "
                        "global unit id: %d",
                        g, u, group_global_unit_ids[u]);

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -610,7 +610,7 @@ dart_ret_t dart_team_create(
 
   dart_team_data_t *parent_team_data = dart_adapt_teamlist_get(teamid);
   if (parent_team_data == NULL) {
-    DART_LOG_ERROR("Invalid team argument: %p", teamid);
+    DART_LOG_ERROR("Invalid team argument: %d", teamid);
     return DART_ERR_INVAL;
   }
   comm = parent_team_data->comm;
@@ -799,7 +799,7 @@ dart_ret_t dart_team_unit_l2g(
 
   dart_team_get_group (teamid, &group);
   if (group == NULL) {
-    DART_LOG_EROR("Unknown teamid: %i", teamid);
+    DART_LOG_ERROR("Unknown teamid: %i", teamid);
     return DART_ERR_INVAL;
   }
   MPI_Group_size (group->mpi_group, &size);

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -486,6 +486,10 @@ dart_ret_t dart_group_locality_split(
       if(group_num_units != 0){
         group_team_unit_ids = malloc(sizeof(dart_global_unit_t) *
                                        group_num_units);
+      } else {
+        DART_LOG_DEBUG("dart_group_locality_split: no units in group %zu",
+                       g);
+        continue;
       }
       int group_unit_idx = 0;
       for (int d = group_first_dom_idx; d < group_last_dom_idx; ++d) {

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -495,7 +495,7 @@ dart_ret_t dart_group_locality_split(
       for (int d = group_first_dom_idx; d < group_last_dom_idx; ++d) {
         for (int du = 0; du < domains[d]->num_units; ++du) {
           int u = group_unit_idx + du;
-          group_unit_ids[group_unit_idx + u] = domains[d]->unit_ids[du].id;
+          group_unit_ids[u] = domains[d]->unit_ids[du].id;
           DART_LOG_TRACE("dart_group_locality_split: "
                          "group[%zu].unit_ids[%d] = domain[%d].unit_ids[%d]",
                          g, u, d, du);

--- a/dart-impl/mpi/src/dart_team_private.c
+++ b/dart-impl/mpi/src/dart_team_private.c
@@ -285,12 +285,11 @@ dart_ret_t dart_allocate_shared_comm(dart_team_data_t *team_data)
     MPI_Comm_group(sharedmem_comm, &sharedmem_group);
     MPI_Comm_group(DART_COMM_WORLD, &group_all);
 
-    int * dart_unit_mapping = (int *) malloc(
+    int * dart_unit_mapping  = malloc(
         team_data->sharedmem_nodesize * sizeof(int));
-    int * sharedmem_ranks = (int *) malloc(
+    int * sharedmem_ranks    = malloc(
         team_data->sharedmem_nodesize * sizeof(int));
-    team_data->sharedmem_tab = (dart_team_unit_t *) malloc(
-                                 size * sizeof(dart_team_unit_t));
+    team_data->sharedmem_tab = malloc(size * sizeof(dart_team_unit_t));
 
     for (i = 0; i < team_data->sharedmem_nodesize; i++) {
       sharedmem_ranks[i] = i;

--- a/dart-impl/mpi/src/dart_team_private.c
+++ b/dart-impl/mpi/src/dart_team_private.c
@@ -289,7 +289,8 @@ dart_ret_t dart_allocate_shared_comm(dart_team_data_t *team_data)
         team_data->sharedmem_nodesize * sizeof(int));
     int * sharedmem_ranks = (int *) malloc(
         team_data->sharedmem_nodesize * sizeof(int));
-    team_data->sharedmem_tab = (int *) malloc(size * sizeof(int));
+    team_data->sharedmem_tab = (dart_team_unit_t *) malloc(
+                                 size * sizeof(dart_team_unit_t));
 
     for (i = 0; i < team_data->sharedmem_nodesize; i++) {
       sharedmem_ranks[i] = i;

--- a/dart-impl/mpi/src/dart_team_private.c
+++ b/dart-impl/mpi/src/dart_team_private.c
@@ -285,11 +285,11 @@ dart_ret_t dart_allocate_shared_comm(dart_team_data_t *team_data)
     MPI_Comm_group(sharedmem_comm, &sharedmem_group);
     MPI_Comm_group(DART_COMM_WORLD, &group_all);
 
-    int * dart_unit_mapping = malloc(
+    int * dart_unit_mapping = (int *) malloc(
         team_data->sharedmem_nodesize * sizeof(int));
-    int * sharedmem_ranks = malloc(
+    int * sharedmem_ranks = (int *) malloc(
         team_data->sharedmem_nodesize * sizeof(int));
-    team_data->sharedmem_tab = malloc(size * sizeof(int));
+    team_data->sharedmem_tab = (int *) malloc(size * sizeof(int));
 
     for (i = 0; i < team_data->sharedmem_nodesize; i++) {
       sharedmem_ranks[i] = i;

--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -443,6 +443,7 @@ public:
     while (t && level > 0 && !(t->is_leaf())) {
       t = t->_child;
       level--;
+      DASH_ASSERT_MSG(t, "node is neither leaf nor has child");
     }
     return *t;
   }
@@ -452,6 +453,7 @@ public:
     Team *t = this;
     while (t && !(t->is_leaf())) {
       t = t->_child;
+      DASH_ASSERT_MSG(t, "node is neither leaf nor has child");
     }
     return *t;
   }

--- a/dash/include/dash/util/UnitLocality.h
+++ b/dash/include/dash/util/UnitLocality.h
@@ -130,15 +130,20 @@ public:
       return node_domain();
     }
 
-    dart_domain_locality_t * parent_domain = nullptr;
+    dart_domain_locality_t * parent_domain = _unit_domain;
     for (int rlevel = _unit_locality->hwinfo.num_scopes;
          rlevel >= 0;
          rlevel--) {
-      parent_domain = parent_domain->parent;
+      if (parent_domain == nullptr) {
+        DASH_THROW(
+          dash::exception::InvalidArgument,
+          "Unit domain is undefined");
+      }
       if (static_cast<int>(_unit_locality->hwinfo.scopes[rlevel].scope) <=
           static_cast<int>(scope)) {
         return dash::util::LocalityDomain(*parent_domain);
       }
+      parent_domain = parent_domain->parent;
     }
     DASH_THROW(
       dash::exception::InvalidArgument,

--- a/dash/src/exception/StackTrace.cc
+++ b/dash/src/exception/StackTrace.cc
@@ -65,9 +65,8 @@ void dash__print_stacktrace(
                     &funcnamesize,
                     &status);
       if (status == 0) {
-        funcname = ret; // use possibly realloc()-ed string
         fprintf(out, "  %s : %s+%s\n",
-                symbollist[i], funcname, begin_offset);
+                symbollist[i], ret, begin_offset);
       } else {
         // demangling failed. Output function name as a
         // C function with no arguments.

--- a/dash/src/util/TimestampClockPosix.cc
+++ b/dash/src/util/TimestampClockPosix.cc
@@ -31,7 +31,6 @@ namespace internal {
 
 TimestampClockPosix::TimestampClockPosix()
 {
-  struct timespec ts;
 #if defined(DASH__UTIL__TIMER_UX)
 // HP-UX, Solaris
   value = static_cast<Timestamp::counter_t>(gethrtime());
@@ -53,6 +52,7 @@ TimestampClockPosix::TimestampClockPosix()
 // POSIX
 #if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0)
 // POSIX clock_gettime
+  struct timespec ts;
   if (clockId != (clockid_t)-1 && clock_gettime(clockId, &ts) != -1) {
     value = static_cast<Timestamp::counter_t>(
               static_cast<double>(ts.tv_sec * 1000000) +
@@ -66,8 +66,8 @@ TimestampClockPosix::TimestampClockPosix()
   struct timeval tm;
   gettimeofday(&tm, NULL);
   value = static_cast<Timestamp::counter_t>(
-            static_cast<double>(ts.tv_sec * 1000000) +
-            static_cast<double>(ts.tv_nsec / 1000));
+            static_cast<double>(tm.tv_sec * 1000000) +
+            static_cast<double>(tm.tv_usec));
 #else
 // No POSIX-compliant time mechanism found.
   throw std::runtime_error("Could not resolve timer");

--- a/dash/src/util/TimestampClockPosix.cc
+++ b/dash/src/util/TimestampClockPosix.cc
@@ -31,6 +31,7 @@ namespace internal {
 
 TimestampClockPosix::TimestampClockPosix()
 {
+  struct timespec ts;
 #if defined(DASH__UTIL__TIMER_UX)
 // HP-UX, Solaris
   value = static_cast<Timestamp::counter_t>(gethrtime());
@@ -52,8 +53,6 @@ TimestampClockPosix::TimestampClockPosix()
 // POSIX
 #if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0)
 // POSIX clock_gettime
-  struct timespec ts;
-
   if (clockId != (clockid_t)-1 && clock_gettime(clockId, &ts) != -1) {
     value = static_cast<Timestamp::counter_t>(
               static_cast<double>(ts.tv_sec * 1000000) +

--- a/dash/test/MatrixTest.cc
+++ b/dash/test/MatrixTest.cc
@@ -1272,15 +1272,28 @@ TEST_F(MatrixTest, ConstMatrixRefs)
   
   int el = matrix(0,0);
   el = matrix[0][0];
+  ASSERT_EQ_U(el, 0);
+  
   el = matrix.local[0][0];
+  ASSERT_EQ_U(el, 0);
+
   el = *(matrix.local.lbegin());
+  ASSERT_EQ_U(el, 0);
+
   dash::barrier();
   el = ++(*(matrix.local.lbegin()));
+  ASSERT_EQ_U(el, 1);
   el = ++(*(matrix.local.row(0).lbegin()));
-  
+  ASSERT_EQ_U(el, 2);
+  matrix.barrier();
+
   // test access using const & matrix
   el = matrix_by_ref[0][0];
+  ASSERT_EQ_U(el, 2);
+
   el = matrix_by_ref.local[0][0];
+  ASSERT_EQ_U(el, 2);
+
   // should not compile
   // el = ++(*(matrix_by_ref.local.lbegin()));
   // el = ++(*(matrix_by_ref.local.row(0).lbegin()));

--- a/dash/test/MatrixTest.cc
+++ b/dash/test/MatrixTest.cc
@@ -1300,6 +1300,7 @@ TEST_F(MatrixTest, ConstMatrixRefs)
   // matrix_by_ref.local.row(0)[0] = 5;
   
   // test access using non-const & matrix.local
+  matrix.barrier();
   *(matrix_local.lbegin()) = 5;
 }
 


### PR DESCRIPTION
This PR fixes all errors (DART and DASH) reported by clang-analyze except the following:
- locality module (both DASH and DART)
- dead initialization (=unused variable) in examples and tests (this cannot be 100% avoided as different build modes read them)

This PR also coveres some serious bugs and a huge amount of memory leaks. Also have a look at the reports:
- [before fixes](https://felixmoessbauer.de/temp/build-report/)
- [after fixes](https://felixmoessbauer.de/temp/build-report-new/)

@devreal please review the fixes on the DART side carefully, especially `DART_GPTR_COPY` and the level calculation in dart buddy allocator.

If you want to generate the build report on your machine, just execute `build.analyze.sh` and get a cup of coffee. It will take roughly 15 minutes to complete. However you can speed it up by disabling tests and examples.