### PR TITLE
fixed circular includes in matrix classes

### DIFF
--- a/dash/examples/ex.11.halo-stencil/main.cpp
+++ b/dash/examples/ex.11.halo-stencil/main.cpp
@@ -18,6 +18,7 @@
 #include <dash/Dimensional.h>
 #include <dash/TeamSpec.h>
 
+#include <dash/algorithm/Copy.h>
 #include <dash/algorithm/Fill.h>
 
 #include <dash/experimental/HaloMatrix.h>

--- a/dash/include/dash/Matrix.h
+++ b/dash/include/dash/Matrix.h
@@ -9,7 +9,6 @@
 #include <dash/GlobMem.h>
 #include <dash/Allocator.h>
 #include <dash/HView.h>
-#include <dash/Container.h>
 
 #include <dash/iterator/GlobIter.h>
 

--- a/dash/include/dash/io/hdf5/InputStream.h
+++ b/dash/include/dash/io/hdf5/InputStream.h
@@ -4,6 +4,7 @@
 #ifdef DASH_ENABLE_HDF5
 
 #include <string>
+#include <future>
 
 #include <dash/Matrix.h>
 #include <dash/Array.h>

--- a/dash/include/dash/io/hdf5/internal/DriverImplNdBlock.h
+++ b/dash/include/dash/io/hdf5/internal/DriverImplNdBlock.h
@@ -4,6 +4,7 @@
 #include <hdf5.h>
 #include <hdf5_hl.h>
 
+#include <dash/algorithm/LocalRange.h>
 #include <vector>
 
 namespace dash {

--- a/dash/include/dash/matrix/LocalMatrixRef.h
+++ b/dash/include/dash/matrix/LocalMatrixRef.h
@@ -7,7 +7,6 @@
 #include <dash/Pattern.h>
 #include <dash/GlobRef.h>
 #include <dash/HView.h>
-#include <dash/Container.h>
 
 #include <dash/iterator/GlobIter.h>
 #include <dash/iterator/GlobViewIter.h>

--- a/dash/include/dash/matrix/MatrixRef.h
+++ b/dash/include/dash/matrix/MatrixRef.h
@@ -9,7 +9,9 @@
 #include <dash/Pattern.h>
 #include <dash/GlobRef.h>
 #include <dash/HView.h>
-#include <dash/Container.h>
+
+#include <dash/view/Local.h>
+#include <dash/view/Sub.h>
 
 #include <dash/iterator/GlobIter.h>
 #include <dash/iterator/GlobViewIter.h>

--- a/dash/include/dash/matrix/MatrixRef.h
+++ b/dash/include/dash/matrix/MatrixRef.h
@@ -10,7 +10,6 @@
 #include <dash/GlobRef.h>
 #include <dash/HView.h>
 
-#include <dash/view/Local.h>
 #include <dash/view/Sub.h>
 
 #include <dash/iterator/GlobIter.h>

--- a/dash/include/dash/matrix/MatrixRefView.h
+++ b/dash/include/dash/matrix/MatrixRefView.h
@@ -7,7 +7,6 @@
 #include <dash/Pattern.h>
 #include <dash/GlobRef.h>
 #include <dash/HView.h>
-#include <dash/Container.h>
 
 #include <dash/iterator/GlobIter.h>
 

--- a/dash/test/MatrixTest.cc
+++ b/dash/test/MatrixTest.cc
@@ -5,6 +5,7 @@
 #include <dash/Dimensional.h>
 #include <dash/Cartesian.h>
 #include <dash/Distribution.h>
+#include <dash/algorithm/Copy.h>
 #include <dash/algorithm/Fill.h>
 #include <dash/algorithm/Generate.h>
 


### PR DESCRIPTION
removed circular includes of `dash/Container.h` and updated missing includes