### PR TITLE
Fixed type conflict of dart_buddy_alloc on 32bit machines

### DIFF
--- a/dart-impl/mpi/include/dash/dart/mpi/dart_mem.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_mem.h
@@ -42,7 +42,7 @@ void     dart_buddy_delete(struct dart_buddy *);
  * \return The offset relative to the starting adddress of the external
  *         memory block where the allocated memory begins.
  */
-uint64_t dart_buddy_alloc(struct dart_buddy *, size_t size);
+size_t dart_buddy_alloc(struct dart_buddy *, size_t size);
 
 /**
  * Return the previously allocated memory chunk to the allocator for reuse.


### PR DESCRIPTION
Reflected type change of dart_buddy_alloc in the header from commit 500abc9