### PR TITLE
Mark DART functions as nothrow 

### DIFF
--- a/dart-if/include/dash/dart/if/dart_communication.h
+++ b/dart-if/include/dash/dart/if/dart_communication.h
@@ -2,6 +2,7 @@
 #define DART__COMMUNICATION_H_
 
 #include <dash/dart/if/dart_types.h>
+#include <dash/dart/if/dart_util.h>
 #include <dash/dart/if/dart_globmem.h>
 
 /**
@@ -43,7 +44,7 @@ extern "C" {
  * \ingroup DartCommunication
  */
 dart_ret_t dart_barrier(
-  dart_team_t team);
+  dart_team_t team) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI broadcast.
@@ -65,7 +66,7 @@ dart_ret_t dart_bcast(
   size_t              nelem,
   dart_datatype_t     dtype,
   dart_team_unit_t    root,
-  dart_team_t         team);
+  dart_team_t         team) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI scatter.
@@ -89,7 +90,7 @@ dart_ret_t dart_scatter(
   size_t               nelem,
   dart_datatype_t      dtype,
   dart_team_unit_t     root,
-  dart_team_t          team);
+  dart_team_t          team) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI gather.
@@ -113,7 +114,7 @@ dart_ret_t dart_gather(
   size_t              nelem,
   dart_datatype_t     dtype,
   dart_team_unit_t    root,
-  dart_team_t         team);
+  dart_team_t         team) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI allgather.
@@ -135,7 +136,7 @@ dart_ret_t dart_allgather(
   void            * recvbuf,
   size_t            nelem,
   dart_datatype_t   dtype,
-	dart_team_t       team);
+	dart_team_t       team) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI allgatherv.
@@ -162,7 +163,7 @@ dart_ret_t dart_allgatherv(
   void            * recvbuf,
   const size_t    * nrecvelem,
   const size_t    * recvdispls,
-  dart_team_t       teamid);
+  dart_team_t       teamid) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI allreduce.
@@ -185,7 +186,7 @@ dart_ret_t dart_allreduce(
   size_t           nelem,
   dart_datatype_t  dtype,
   dart_operation_t op,
-  dart_team_t      team);
+  dart_team_t      team) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI_Reduce.
@@ -210,7 +211,7 @@ dart_ret_t dart_reduce(
   dart_datatype_t     dtype,
   dart_operation_t    op,
   dart_team_unit_t    root,
-  dart_team_t         team);
+  dart_team_t         team) DART_NOTHROW;
 
 /** \} */
 
@@ -242,7 +243,7 @@ dart_ret_t dart_accumulate(
   const void     * values,
   size_t           nelem,
   dart_datatype_t  dtype,
-  dart_operation_t op);
+  dart_operation_t op) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI_Fetch_and_op.
@@ -268,7 +269,7 @@ dart_ret_t dart_fetch_and_op(
   const void *     value,
   void *           result,
   dart_datatype_t  dtype,
-  dart_operation_t op);
+  dart_operation_t op) DART_NOTHROW;
 
 
 /**
@@ -296,7 +297,7 @@ dart_ret_t dart_compare_and_swap(
   const void     * value,
   const void     * compare,
   void           * result,
-  dart_datatype_t  dtype);
+  dart_datatype_t  dtype) DART_NOTHROW;
 
 
 /** \} */
@@ -331,7 +332,7 @@ dart_ret_t dart_get(
   void            * dest,
   dart_gptr_t       gptr,
   size_t            nelem,
-  dart_datatype_t   dtype);
+  dart_datatype_t   dtype) DART_NOTHROW;
 
 /**
  * 'REGULAR' variant of dart_put.
@@ -354,7 +355,7 @@ dart_ret_t dart_put(
   dart_gptr_t       gptr,
   const void      * src,
   size_t            nelem,
-  dart_datatype_t   dtype);
+  dart_datatype_t   dtype) DART_NOTHROW;
 
 
 /**
@@ -372,7 +373,7 @@ dart_ret_t dart_put(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_flush(
-  dart_gptr_t gptr);
+  dart_gptr_t gptr) DART_NOTHROW;
 
 /**
  * Guarantee completion of all outstanding operations involving a segment on all units
@@ -389,7 +390,7 @@ dart_ret_t dart_flush(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_flush_all(
-  dart_gptr_t gptr);
+  dart_gptr_t gptr) DART_NOTHROW;
 
 /**
  * Guarantee local completion of all outstanding operations involving a segment on a certain unit
@@ -406,7 +407,7 @@ dart_ret_t dart_flush_all(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_flush_local(
-  dart_gptr_t gptr);
+  dart_gptr_t gptr) DART_NOTHROW;
 
 /**
  * Guarantee completion of all outstanding operations involving a segment on all units
@@ -423,7 +424,7 @@ dart_ret_t dart_flush_local(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_flush_local_all(
-  dart_gptr_t gptr);
+  dart_gptr_t gptr) DART_NOTHROW;
 
 
 /** \} */
@@ -463,7 +464,7 @@ dart_ret_t dart_get_handle(
   dart_gptr_t       gptr,
   size_t            nelem,
   dart_datatype_t   dtype,
-  dart_handle_t   * handle);
+  dart_handle_t   * handle) DART_NOTHROW;
 
 /**
  * 'HANDLE' variant of dart_put.
@@ -487,7 +488,7 @@ dart_ret_t dart_put_handle(
   const void      * src,
   size_t            nelem,
   dart_datatype_t   dtype,
-  dart_handle_t   * handle);
+  dart_handle_t   * handle) DART_NOTHROW;
 
 /**
  * Wait for the local and remote completion of an operation.
@@ -501,7 +502,7 @@ dart_ret_t dart_put_handle(
  */
 
 dart_ret_t dart_wait(
-  dart_handle_t handle);
+  dart_handle_t handle) DART_NOTHROW;
 /**
  * Wait for the local and remote completion of operations.
  *
@@ -514,8 +515,8 @@ dart_ret_t dart_wait(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_waitall(
-  dart_handle_t *handles,
-  size_t n);
+  dart_handle_t * handles,
+  size_t          n) DART_NOTHROW;
 
 /**
  * Wait for the local completion of an operation.
@@ -542,8 +543,8 @@ dart_ret_t dart_wait_local(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_waitall_local(
-    dart_handle_t *handles,
-    size_t n);
+    dart_handle_t * handles,
+    size_t          n) DART_NOTHROW;
 
 /**
  * Test for the local completion of an operation.
@@ -557,8 +558,8 @@ dart_ret_t dart_waitall_local(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_test_local(
-  dart_handle_t handle,
-  int32_t *result);
+  dart_handle_t   handle,
+  int32_t       * result) DART_NOTHROW;
 
 /**
  * Test for the local completion of operations.
@@ -573,9 +574,9 @@ dart_ret_t dart_test_local(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_testall_local(
-  dart_handle_t *handles,
-  size_t n,
-  int32_t *result);
+  dart_handle_t * handles,
+  size_t          n,
+  int32_t       * result) DART_NOTHROW;
 
 /** \} */
 
@@ -604,7 +605,7 @@ dart_ret_t dart_get_blocking(
   void         *  dest,
   dart_gptr_t     gptr,
   size_t          nelem,
-  dart_datatype_t dtype);
+  dart_datatype_t dtype) DART_NOTHROW;
 
 /**
  * 'BLOCKING' variant of dart_put.
@@ -621,10 +622,10 @@ dart_ret_t dart_get_blocking(
  * \ingroup DartCommunication
  */
 dart_ret_t dart_put_blocking(
-  dart_gptr_t     gptr,
-  const void    * src,
-  size_t          nelem,
-  dart_datatype_t dtype);
+  dart_gptr_t       gptr,
+  const void      * src,
+  size_t            nelem,
+  dart_datatype_t   dtype) DART_NOTHROW;
 
 /** \} */
 
@@ -656,7 +657,7 @@ dart_ret_t dart_send(
   size_t               nelem,
   dart_datatype_t      dtype,
 	int                  tag,
-	dart_global_unit_t   unit);
+	dart_global_unit_t   unit) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI recv.
@@ -677,7 +678,7 @@ dart_ret_t dart_recv(
   size_t               nelem,
   dart_datatype_t      dtype,
 	int                  tag,
-	dart_global_unit_t   unit);
+	dart_global_unit_t   unit) DART_NOTHROW;
 
 /**
  * DART Equivalent to MPI sendrecv.
@@ -711,7 +712,7 @@ dart_ret_t dart_sendrecv(
   size_t               recv_nelem,
   dart_datatype_t      recv_dtype,
   int                  recv_tag,
-  dart_global_unit_t   src);
+  dart_global_unit_t   src) DART_NOTHROW;
 
 
 /** \} */

--- a/dart-if/include/dash/dart/if/dart_config.h
+++ b/dart-if/include/dash/dart/if/dart_config.h
@@ -2,6 +2,7 @@
 #define DART__IF__CONFIG_H__
 
 #include <dash/dart/if/dart_types.h>
+#include <dash/dart/if/dart_util.h>
 
 /**
  * \file dart_config.h
@@ -23,7 +24,7 @@ extern "C" {
  * \ingroup DartConfig
  */
 void dart_config(
-  dart_config_t ** config_out);
+  dart_config_t ** config_out) DART_NOTHROW;
 
 #define DART_INTERFACE_OFF
 

--- a/dart-if/include/dash/dart/if/dart_globmem.h
+++ b/dart-if/include/dash/dart/if/dart_globmem.h
@@ -11,6 +11,9 @@
  *
  */
 
+#include <dash/dart/if/dart_util.h>
+#include <dash/dart/if/dart_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -150,7 +153,9 @@ typedef struct
  * \threadsafe
  * \ingroup DartGlobMem
  */
-dart_ret_t dart_gptr_getaddr(const dart_gptr_t gptr, void **addr);
+dart_ret_t dart_gptr_getaddr(
+  const dart_gptr_t    gptr,
+        void        ** addr) DART_NOTHROW;
 
 /**
  * Set the local memory address for the specified global pointer such
@@ -164,7 +169,9 @@ dart_ret_t dart_gptr_getaddr(const dart_gptr_t gptr, void **addr);
  * \threadsafe
  * \ingroup DartGlobMem
  */
-dart_ret_t dart_gptr_setaddr(dart_gptr_t *gptr, void *addr);
+dart_ret_t dart_gptr_setaddr(
+  dart_gptr_t * gptr,
+  void        * addr) DART_NOTHROW;
 
 /**
  * Add 'offs' to the address specified by the global pointer
@@ -177,7 +184,16 @@ dart_ret_t dart_gptr_setaddr(dart_gptr_t *gptr, void *addr);
  * \threadsafe
  * \ingroup DartGlobMem
  */
-dart_ret_t dart_gptr_incaddr(dart_gptr_t *gptr, int64_t offs);
+static inline
+DART_MAYBE_UNUSED DART_NOTHROW
+dart_ret_t
+dart_gptr_incaddr(
+  dart_gptr_t * gptr,
+  int64_t       offs)
+{
+  gptr->addr_or_offs.offset += offs;
+  return DART_OK;
+}
 
 /**
  * Set the unit information for the specified global pointer.
@@ -190,7 +206,15 @@ dart_ret_t dart_gptr_incaddr(dart_gptr_t *gptr, int64_t offs);
  * \threadsafe
  * \ingroup DartGlobMem
  */
-dart_ret_t dart_gptr_setunit(dart_gptr_t *gptr, dart_team_unit_t unit);
+static inline
+DART_MAYBE_UNUSED DART_NOTHROW
+dart_ret_t dart_gptr_setunit(
+  dart_gptr_t      * gptr,
+  dart_team_unit_t   unit)
+{
+  gptr->unitid = unit.id;
+  return DART_OK;
+}
 
 /**
  * Get the flags field for the segment specified by the global pointer.
@@ -203,7 +227,9 @@ dart_ret_t dart_gptr_setunit(dart_gptr_t *gptr, dart_team_unit_t unit);
  * \threadsafe
  * \ingroup DartGlobMem
  */
-dart_ret_t dart_gptr_getflags(dart_gptr_t gptr, uint16_t *flags);
+dart_ret_t dart_gptr_getflags(
+  dart_gptr_t   gptr,
+  uint16_t    * flags) DART_NOTHROW;
 
 
 /**
@@ -221,7 +247,9 @@ dart_ret_t dart_gptr_getflags(dart_gptr_t gptr, uint16_t *flags);
  * \threadsafe
  * \ingroup DartGlobMem
  */
-dart_ret_t dart_gptr_setflags(dart_gptr_t *gptr, uint16_t flags);
+dart_ret_t dart_gptr_setflags(
+  dart_gptr_t * gptr,
+  uint16_t      flags) DART_NOTHROW;
 
 /**
  * Allocates memory for \c nelem elements of type \c dtype in the global
@@ -242,7 +270,7 @@ dart_ret_t dart_gptr_setflags(dart_gptr_t *gptr, uint16_t flags);
 dart_ret_t dart_memalloc(
   size_t            nelem,
   dart_datatype_t   dtype,
-  dart_gptr_t     * gptr);
+  dart_gptr_t     * gptr) DART_NOTHROW;
 
 /**
  * Frees memory in the global address space allocated by a previous call
@@ -256,7 +284,7 @@ dart_ret_t dart_memalloc(
  * \threadsafe
  * \ingroup DartGlobMem
  */
-dart_ret_t dart_memfree(dart_gptr_t gptr);
+dart_ret_t dart_memfree(dart_gptr_t gptr) DART_NOTHROW;
 
 /**
  * Collective function on the specified team to allocate \c nelem elements
@@ -292,7 +320,7 @@ dart_ret_t dart_team_memalloc_aligned(
   dart_team_t       teamid,
 	size_t            nelem,
   dart_datatype_t   dtype,
-  dart_gptr_t     * gptr);
+  dart_gptr_t     * gptr) DART_NOTHROW;
 
 /**
  * Collective function to free global memory previously allocated
@@ -312,7 +340,7 @@ dart_ret_t dart_team_memalloc_aligned(
  * \ingroup DartGlobMem
  */
 dart_ret_t dart_team_memfree(
-  dart_gptr_t gptr);
+  dart_gptr_t gptr) DART_NOTHROW;
 
 /**
  * Collective function similar to \ref dart_team_memalloc_aligned but on
@@ -337,7 +365,7 @@ dart_ret_t dart_team_memregister_aligned(
 	size_t            nelem,
   dart_datatype_t   dtype,
 	void            * addr,
-	dart_gptr_t     * gptr);
+	dart_gptr_t     * gptr) DART_NOTHROW;
 
 /**
  * Attaches external memory previously allocated by the user.
@@ -359,7 +387,7 @@ dart_ret_t dart_team_memregister(
 	size_t            nelem,
   dart_datatype_t   dtype,
 	void            * addr,
-	dart_gptr_t     * gptr);
+	dart_gptr_t     * gptr) DART_NOTHROW;
 
 /**
  * Collective function similar to dart_team_memfree() but on previously
@@ -377,7 +405,7 @@ dart_ret_t dart_team_memregister(
  * \threadsafe_none
  * \ingroup DartGlobMem
  */
-dart_ret_t dart_team_memderegister(dart_gptr_t gptr);
+dart_ret_t dart_team_memderegister(dart_gptr_t gptr) DART_NOTHROW;
 
 
 /** \cond DART_HIDDEN_SYMBOLS */

--- a/dart-if/include/dash/dart/if/dart_globmem.h
+++ b/dart-if/include/dash/dart/if/dart_globmem.h
@@ -184,8 +184,7 @@ dart_ret_t dart_gptr_setaddr(
  * \threadsafe
  * \ingroup DartGlobMem
  */
-static inline
-DART_MAYBE_UNUSED DART_NOTHROW
+DART_INLINE DART_NOTHROW
 dart_ret_t
 dart_gptr_incaddr(
   dart_gptr_t * gptr,
@@ -206,8 +205,7 @@ dart_gptr_incaddr(
  * \threadsafe
  * \ingroup DartGlobMem
  */
-static inline
-DART_MAYBE_UNUSED DART_NOTHROW
+DART_INLINE DART_NOTHROW
 dart_ret_t dart_gptr_setunit(
   dart_gptr_t      * gptr,
   dart_team_unit_t   unit)

--- a/dart-if/include/dash/dart/if/dart_initialization.h
+++ b/dart-if/include/dash/dart/if/dart_initialization.h
@@ -1,7 +1,9 @@
 #ifndef DART_INITIALIZATION_H_INCLUDED
 #define DART_INITIALIZATION_H_INCLUDED
 
-#include "dart_types.h"
+#include <stdbool.h>
+#include <dash/dart/if/dart_types.h>
+#include <dash/dart/if/dart_util.h>
 
 /**
  * \file dart_initialization.h
@@ -34,7 +36,7 @@ extern "C" {
  * \threadsafe_none
  * \ingroup DartInitialization
 */
-dart_ret_t dart_init(int *argc, char ***argv);
+dart_ret_t dart_init(int *argc, char ***argv) DART_NOTHROW;
 
 /**
  * Initialize the DART runtime with support for thread-based concurrency.
@@ -50,9 +52,9 @@ dart_ret_t dart_init(int *argc, char ***argv);
  * \ingroup DartInitialization
  */
 dart_ret_t dart_init_thread(
-  int*                  argc,
-  char***               argv,
-  dart_thread_support_level_t * thread_safety);
+  int*                          argc,
+  char***                       argv,
+  dart_thread_support_level_t * thread_safety) DART_NOTHROW;
 
 /**
  * Finalize the DASH runtime.
@@ -62,17 +64,18 @@ dart_ret_t dart_init_thread(
  * \threadsafe_none
  * \ingroup DartInitialization
  */
-dart_ret_t dart_exit();
+dart_ret_t dart_exit() DART_NOTHROW;
 
 /**
  * Whether the DASH runtime has been initialized.
  *
- * \return 0 if DART has not been initialized or has been shut down already, >0 otherwise.
+ * \return false if DART has not been initialized or has been shut down already,
+ *         true  otherwise.
  *
  * \threadsafe
  * \ingroup DartInitialization
  */
-char       dart_initialized();
+bool       dart_initialized() DART_NOTHROW;
 
 /** \cond DART_HIDDEN_SYMBOLS */
 #define DART_INTERFACE_OFF

--- a/dart-if/include/dash/dart/if/dart_io.h
+++ b/dart-if/include/dash/dart/if/dart_io.h
@@ -8,6 +8,7 @@
 #define DART__IO_H_
 
 #include <dash/dart/if/dart_types.h>
+#include <dash/dart/if/dart_util.h>
 
 
 /**
@@ -24,7 +25,7 @@ extern "C" {
  */
 dart_ret_t dart__io__hdf5__prep_mpio(
     hid_t plist_id,
-    dart_team_t teamid);
+    dart_team_t teamid) DART_NOTHROW;
 
 #define DART_INTERFACE_OFF
 

--- a/dart-if/include/dash/dart/if/dart_locality.h
+++ b/dart-if/include/dash/dart/if/dart_locality.h
@@ -11,6 +11,7 @@
 #define DART__LOCALITY_H_
 
 #include <dash/dart/if/dart_types.h>
+#include <dash/dart/if/dart_util.h>
 
 
 /**
@@ -32,7 +33,7 @@ extern "C" {
  * \ingroup DartLocality
  */
 dart_ret_t dart_team_locality_init(
-  dart_team_t                     team);
+  dart_team_t                     team)                 DART_NOTHROW;
 
 /**
  * Initialize information of the specified team.
@@ -41,7 +42,7 @@ dart_ret_t dart_team_locality_init(
  * \ingroup DartLocality
  */
 dart_ret_t dart_team_locality_finalize(
-  dart_team_t                     team);
+  dart_team_t                     team)                 DART_NOTHROW;
 
 /**
  * Locality information of the team domain with the specified id tag.
@@ -52,7 +53,7 @@ dart_ret_t dart_team_locality_finalize(
 dart_ret_t dart_domain_team_locality(
   dart_team_t                     team,
   const char                    * domain_tag,
-  dart_domain_locality_t       ** team_domain_out);
+  dart_domain_locality_t       ** team_domain_out)      DART_NOTHROW;
 
 /**
  * Default constructor.
@@ -62,7 +63,7 @@ dart_ret_t dart_domain_team_locality(
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_create(
-  dart_domain_locality_t       ** domain_out);
+  dart_domain_locality_t       ** domain_out)           DART_NOTHROW;
 
 /**
  * Copy-constructor.
@@ -74,7 +75,7 @@ dart_ret_t dart_domain_create(
  */
 dart_ret_t dart_domain_clone(
   const dart_domain_locality_t  * domain_in,
-  dart_domain_locality_t       ** domain_out);
+  dart_domain_locality_t       ** domain_out)           DART_NOTHROW;
 
 /**
  * Destructor.
@@ -84,7 +85,7 @@ dart_ret_t dart_domain_clone(
  * \ingroup DartLocality
  */
 dart_ret_t dart_domain_destroy(
-  dart_domain_locality_t        * domain);
+  dart_domain_locality_t        * domain)               DART_NOTHROW;
 
 /**
  * Assignment operator.
@@ -96,7 +97,7 @@ dart_ret_t dart_domain_destroy(
  */
 dart_ret_t dart_domain_assign(
   dart_domain_locality_t        * domain_lhs,
-  const dart_domain_locality_t  * domain_rhs);
+  const dart_domain_locality_t  * domain_rhs)           DART_NOTHROW;
 
 /**
  * Locality information of the subdomain with the specified id tag.
@@ -107,7 +108,7 @@ dart_ret_t dart_domain_assign(
 dart_ret_t dart_domain_find(
   const dart_domain_locality_t  * domain_in,
   const char                    * domain_tag,
-  dart_domain_locality_t       ** subdomain_out);
+  dart_domain_locality_t       ** subdomain_out)        DART_NOTHROW;
 
 /**
  * Remove domains in locality domain hierarchy that do not match the
@@ -119,7 +120,7 @@ dart_ret_t dart_domain_find(
 dart_ret_t dart_domain_select(
   dart_domain_locality_t        * domain_in,
   int                             num_subdomain_tags,
-  const char                   ** subdomain_tags);
+  const char                   ** subdomain_tags)       DART_NOTHROW;
 
 /**
  * Remove domains in locality domain hierarchy matching the specified domain
@@ -131,7 +132,7 @@ dart_ret_t dart_domain_select(
 dart_ret_t dart_domain_exclude(
   dart_domain_locality_t        * domain_in,
   int                             num_subdomain_tags,
-  const char                   ** subdomain_tags);
+  const char                   ** subdomain_tags)       DART_NOTHROW;
 
 /**
  * Insert locality domain into subdomains of a domain at the specified
@@ -148,7 +149,7 @@ dart_ret_t dart_domain_exclude(
 dart_ret_t dart_domain_add_subdomain(
   dart_domain_locality_t        * domain,
   dart_domain_locality_t        * subdomain,
-  int                             subdomain_rel_id);
+  int                             subdomain_rel_id)     DART_NOTHROW;
 
 /**
  * Move locality domain in the locality hierarchy.
@@ -167,7 +168,7 @@ dart_ret_t dart_domain_add_subdomain(
 dart_ret_t dart_domain_move_subdomain(
   dart_domain_locality_t        * domain,
   dart_domain_locality_t        * new_parent_domain,
-  int                             new_domain_rel_id);
+  int                             new_domain_rel_id)    DART_NOTHROW;
 
 /**
  * Split locality domain hierarchy at given domain tag into \c num_parts
@@ -180,7 +181,7 @@ dart_ret_t dart_domain_split_scope(
   const dart_domain_locality_t  * domain_in,
   dart_locality_scope_t           scope,
   int                             num_parts,
-  dart_domain_locality_t        * split_domain_out);
+  dart_domain_locality_t        * split_domain_out)     DART_NOTHROW;
 
 /**
  * Domain tags of domains at the specified locality scope.
@@ -192,7 +193,7 @@ dart_ret_t dart_domain_scope_tags(
   const dart_domain_locality_t  * domain_in,
   dart_locality_scope_t           scope,
   int                           * num_domains_out,
-  char                        *** domain_tags_out);
+  char                        *** domain_tags_out)      DART_NOTHROW;
 
 /**
  * Locality domains at the specified locality scope.
@@ -204,7 +205,7 @@ dart_ret_t dart_domain_scope_domains(
   const dart_domain_locality_t  * domain_in,
   dart_locality_scope_t           scope,
   int                           * num_domains_out,
-  dart_domain_locality_t      *** domains_out);
+  dart_domain_locality_t      *** domains_out)          DART_NOTHROW;
 
 /**
  * Adds entries to locality hierarchy to group locality domains.
@@ -216,7 +217,7 @@ dart_ret_t dart_domain_group(
   dart_domain_locality_t        * domain_in,
   int                             num_group_subdomains,
   const char                   ** group_subdomain_tags,
-  char                          * group_domain_tag_out);
+  char                          * group_domain_tag_out) DART_NOTHROW;
 
 /**
  * Locality information of the unit with the specified team-relative id.
@@ -227,7 +228,7 @@ dart_ret_t dart_domain_group(
 dart_ret_t dart_unit_locality(
   dart_team_t                     team,
   dart_team_unit_t                unit,
-  dart_unit_locality_t         ** loc);
+  dart_unit_locality_t         ** loc)                  DART_NOTHROW;
 
 /** \cond DART_HIDDEN_SYMBOLS */
 #define DART_INTERFACE_OFF

--- a/dart-if/include/dash/dart/if/dart_synchronization.h
+++ b/dart-if/include/dash/dart/if/dart_synchronization.h
@@ -10,6 +10,8 @@
  *
  */
 
+#include <dash/dart/if/dart_util.h>
+#include <dash/dart/if/dart_types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,8 +39,9 @@ typedef struct dart_lock_struct *dart_lock_t;
  * \threadsafe_none
  * \ingroup DartSync
  */
-dart_ret_t dart_team_lock_init(dart_team_t teamid,
-			       dart_lock_t* lock);
+dart_ret_t dart_team_lock_init(
+  dart_team_t   teamid,
+  dart_lock_t * lock)   DART_NOTHROW;
 
 /**
  * Free a \c lock initialized using \ref dart_team_lock_init.
@@ -50,8 +53,9 @@ dart_ret_t dart_team_lock_init(dart_team_t teamid,
  * \threadsafe_none
  * \ingroup DartSync
  */
-dart_ret_t dart_team_lock_free(dart_team_t teamid,
-			       dart_lock_t* lock);
+dart_ret_t dart_team_lock_free(
+  dart_team_t   teamid,
+  dart_lock_t * lock)   DART_NOTHROW;
 
 /**
  * Block until the \c lock was acquired.
@@ -62,7 +66,8 @@ dart_ret_t dart_team_lock_free(dart_team_t teamid,
  * \threadsafe_none
  * \ingroup DartSync
  */
-dart_ret_t dart_lock_acquire(dart_lock_t lock);
+dart_ret_t dart_lock_acquire(
+  dart_lock_t   lock)   DART_NOTHROW;
 
 /**
  * Try to acquire the lock and return immediately.
@@ -75,7 +80,9 @@ dart_ret_t dart_lock_acquire(dart_lock_t lock);
  * \threadsafe_none
  * \ingroup DartSync
  */
-dart_ret_t dart_lock_try_acquire(dart_lock_t lock, int32_t *result);
+dart_ret_t dart_lock_try_acquire(
+  dart_lock_t   lock,
+  int32_t     * result) DART_NOTHROW;
 
 /**
  * Release the lock acquired through \ref dart_lock_acquire or \ref dart_lock_try_acquire.
@@ -86,7 +93,8 @@ dart_ret_t dart_lock_try_acquire(dart_lock_t lock, int32_t *result);
  * \threadsafe_none
  * \ingroup DartSync
  */
-dart_ret_t dart_lock_release(dart_lock_t lock);
+dart_ret_t dart_lock_release(
+  dart_lock_t   lock)   DART_NOTHROW;
 
 
 /** \cond DART_HIDDEN_SYMBOLS */

--- a/dart-if/include/dash/dart/if/dart_team_group.h
+++ b/dart-if/include/dash/dart/if/dart_team_group.h
@@ -1,7 +1,8 @@
 #ifndef DART_TEAM_GROUP_H_INCLUDED
 #define DART_TEAM_GROUP_H_INCLUDED
 
-#include "dart_types.h"
+#include <dash/dart/if/dart_types.h>
+#include <dash/dart/if/dart_util.h>
 
 
 /**
@@ -71,7 +72,7 @@ typedef struct dart_group_struct* dart_group_t;
  * \threadsafe
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_create(dart_group_t *group);
+dart_ret_t dart_group_create(dart_group_t *group) DART_NOTHROW;
 
 /**
  * Reclaim resources that might be associated with the group.
@@ -83,7 +84,8 @@ dart_ret_t dart_group_create(dart_group_t *group);
  * \threadsafe
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_destroy(dart_group_t *group);
+dart_ret_t dart_group_destroy(
+  dart_group_t *group) DART_NOTHROW;
 
 
 /**
@@ -97,8 +99,9 @@ dart_ret_t dart_group_destroy(dart_group_t *group);
  * \threadsafe
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_clone(const dart_group_t   gin,
-                            dart_group_t       * gout);
+dart_ret_t dart_group_clone(
+  const dart_group_t   gin,
+  dart_group_t       * gout) DART_NOTHROW;
 
 
 /**
@@ -113,9 +116,10 @@ dart_ret_t dart_group_clone(const dart_group_t   gin,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_union(const dart_group_t   g1,
-                            const dart_group_t   g2,
-                            dart_group_t       * gout);
+dart_ret_t dart_group_union(
+  const dart_group_t   g1,
+  const dart_group_t   g2,
+  dart_group_t       * gout) DART_NOTHROW;
 
 
 /**
@@ -130,9 +134,10 @@ dart_ret_t dart_group_union(const dart_group_t   g1,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_intersect(const dart_group_t   g1,
-                                const dart_group_t   g2,
-                                dart_group_t       * gout);
+dart_ret_t dart_group_intersect(
+  const dart_group_t   g1,
+  const dart_group_t   g2,
+  dart_group_t       * gout) DART_NOTHROW;
 
 
 /**
@@ -146,8 +151,9 @@ dart_ret_t dart_group_intersect(const dart_group_t   g1,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_addmember(dart_group_t       g,
-                                dart_global_unit_t unitid);
+dart_ret_t dart_group_addmember(
+  dart_group_t       g,
+  dart_global_unit_t unitid) DART_NOTHROW;
 
 
 /**
@@ -161,8 +167,9 @@ dart_ret_t dart_group_addmember(dart_group_t       g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_delmember(dart_group_t        g,
-                                dart_global_unit_t  unitid);
+dart_ret_t dart_group_delmember(
+  dart_group_t        g,
+  dart_global_unit_t  unitid) DART_NOTHROW;
 
 
 /**
@@ -177,9 +184,10 @@ dart_ret_t dart_group_delmember(dart_group_t        g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_ismember(const dart_group_t   g,
-                               dart_global_unit_t   unitid,
-                               int32_t            * ismember);
+dart_ret_t dart_group_ismember(
+  const dart_group_t   g,
+  dart_global_unit_t   unitid,
+  int32_t            * ismember) DART_NOTHROW;
 
 
 /**
@@ -193,8 +201,9 @@ dart_ret_t dart_group_ismember(const dart_group_t   g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_size(const dart_group_t   g,
-                           size_t             * size);
+dart_ret_t dart_group_size(
+  const dart_group_t   g,
+  size_t             * size) DART_NOTHROW;
 
 
 /**
@@ -210,8 +219,9 @@ dart_ret_t dart_group_size(const dart_group_t   g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_getmembers(const dart_group_t   g,
-                                 dart_global_unit_t * unitids);
+dart_ret_t dart_group_getmembers(
+  const dart_group_t   g,
+  dart_global_unit_t * unitids) DART_NOTHROW;
 
 
 /**
@@ -230,10 +240,11 @@ dart_ret_t dart_group_getmembers(const dart_group_t   g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_group_split(const dart_group_t    g,
-                            size_t                n,
-                            size_t              * nout,
-                            dart_group_t        * gout);
+dart_ret_t dart_group_split(
+  const dart_group_t    g,
+  size_t                n,
+  size_t              * nout,
+  dart_group_t        * gout) DART_NOTHROW;
 
 /**
  * Split the group \c g into \c n groups by the specified locality scope.
@@ -257,12 +268,13 @@ dart_ret_t dart_group_split(const dart_group_t    g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
 */
-dart_ret_t dart_group_locality_split(const dart_group_t        g,
-                                     dart_domain_locality_t  * domain,
-                                     dart_locality_scope_t     scope,
-                                     size_t                    n,
-                                     size_t                  * nout,
-                                     dart_group_t            * gout);
+dart_ret_t dart_group_locality_split(
+  const dart_group_t        g,
+  dart_domain_locality_t  * domain,
+  dart_locality_scope_t     scope,
+  size_t                    n,
+  size_t                  * nout,
+  dart_group_t            * gout) DART_NOTHROW;
 
 /** \} */
 
@@ -306,7 +318,9 @@ dart_ret_t dart_group_locality_split(const dart_group_t        g,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_get_group(dart_team_t teamid, dart_group_t *group);
+dart_ret_t dart_team_get_group(
+  dart_team_t    teamid,
+  dart_group_t * group) DART_NOTHROW;
 
 
 /**
@@ -353,9 +367,10 @@ dart_ret_t dart_team_get_group(dart_team_t teamid, dart_group_t *group);
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_create(dart_team_t          teamid,
-                            const dart_group_t   group,
-                            dart_team_t        * newteam);
+dart_ret_t dart_team_create(
+  dart_team_t          teamid,
+  const dart_group_t   group,
+  dart_team_t        * newteam) DART_NOTHROW;
 
 /**
  * Free up resources associated with the specified team
@@ -367,7 +382,8 @@ dart_ret_t dart_team_create(dart_team_t          teamid,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_destroy(dart_team_t * teamid);
+dart_ret_t dart_team_destroy(
+  dart_team_t * teamid) DART_NOTHROW;
 
 
 /**
@@ -380,7 +396,9 @@ dart_ret_t dart_team_destroy(dart_team_t * teamid);
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_clone(dart_team_t team, dart_team_t *newteam);
+dart_ret_t dart_team_clone(
+  dart_team_t   team,
+  dart_team_t * newteam) DART_NOTHROW;
 
 /**
  * Return the unit id of the caller in the specified team.
@@ -424,7 +442,9 @@ dart_ret_t dart_team_clone(dart_team_t team, dart_team_t *newteam);
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_myid(dart_team_t teamid, dart_team_unit_t *myid);
+dart_ret_t dart_team_myid(
+  dart_team_t        teamid,
+  dart_team_unit_t * myid) DART_NOTHROW;
 
 /**
  * Return the size of the specified team.
@@ -437,7 +457,9 @@ dart_ret_t dart_team_myid(dart_team_t teamid, dart_team_unit_t *myid);
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_size(dart_team_t teamid, size_t *size);
+dart_ret_t dart_team_size(
+  dart_team_t   teamid,
+  size_t      * size) DART_NOTHROW;
 
 /**
  * Return the id in the default team \ref DART_TEAM_ALL
@@ -449,7 +471,7 @@ dart_ret_t dart_team_size(dart_team_t teamid, size_t *size);
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_myid(dart_global_unit_t *myid);
+dart_ret_t dart_myid(dart_global_unit_t *myid) DART_NOTHROW;
 
 /**
  * Return the size of the default team \ref DART_TEAM_ALL
@@ -461,7 +483,7 @@ dart_ret_t dart_myid(dart_global_unit_t *myid);
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_size(size_t *size);
+dart_ret_t dart_size(size_t *size) DART_NOTHROW;
 
 
 /**
@@ -477,9 +499,10 @@ dart_ret_t dart_size(size_t *size);
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_unit_l2g(dart_team_t          team,
-                              dart_team_unit_t     localid,
-                              dart_global_unit_t * globalid);
+dart_ret_t dart_team_unit_l2g(
+  dart_team_t          team,
+  dart_team_unit_t     localid,
+  dart_global_unit_t * globalid) DART_NOTHROW;
 
 /**
  * Convert from a global to a local unit ID
@@ -494,9 +517,10 @@ dart_ret_t dart_team_unit_l2g(dart_team_t          team,
  * \threadsafe_none
  * \ingroup DartGroupTeam
  */
-dart_ret_t dart_team_unit_g2l(dart_team_t         team,
-                              dart_global_unit_t  globalid,
-                              dart_team_unit_t * localid);
+dart_ret_t dart_team_unit_g2l(
+  dart_team_t          team,
+  dart_global_unit_t   globalid,
+  dart_team_unit_t   * localid) DART_NOTHROW;
 
 /** \} */
 

--- a/dart-if/include/dash/dart/if/dart_util.h
+++ b/dart-if/include/dash/dart/if/dart_util.h
@@ -7,15 +7,32 @@
 #ifndef DART_UTIL_H_
 #define DART_UTIL_H_
 
+/** \cond DART_HIDDEN_SYMBOLS */
+#define DART_INTERFACE_ON
+/** \endcond */
 
+/**
+ * Mark a function as not throwing C++ exceptions.
+ */
 #ifdef __cplusplus
 #define DART_NOTHROW __attribute__((nothrow))
 #else 
 #define DART_NOTHROW
 #endif
 
+/**
+ * Mark a function (or variable) as possibly unused
+ * (to suppress compiler warnings).
+ */
 #define DART_MAYBE_UNUSED __attribute__((unused))
 
+/**
+ * Mark a (public) function as inline (and potentially unused).
+ */
 #define DART_INLINE static inline DART_MAYBE_UNUSED
+
+/** \cond DART_HIDDEN_SYMBOLS */
+#define DART_INTERFACE_OFF
+/** \endcond */
 
 #endif /* DART_UTIL_H_ */

--- a/dart-if/include/dash/dart/if/dart_util.h
+++ b/dart-if/include/dash/dart/if/dart_util.h
@@ -1,0 +1,19 @@
+/*
+ * \file dart_util.h
+ * 
+ * utility macros for the DART interface
+ */
+
+#ifndef DART_UTIL_H_
+#define DART_UTIL_H_
+
+
+#ifdef __cplusplus
+#define DART_NOTHROW __attribute__((nothrow))
+#else 
+#define DART_NOTHROW
+#endif
+
+#define DART_MAYBE_UNUSED __attribute__((unused))
+
+#endif /* DART_UTIL_H_ */

--- a/dart-if/include/dash/dart/if/dart_util.h
+++ b/dart-if/include/dash/dart/if/dart_util.h
@@ -16,4 +16,6 @@
 
 #define DART_MAYBE_UNUSED __attribute__((unused))
 
+#define DART_INLINE static inline DART_MAYBE_UNUSED
+
 #endif /* DART_UTIL_H_ */

--- a/dart-impl/mpi/src/dart_globmem.c
+++ b/dart-impl/mpi/src/dart_globmem.c
@@ -19,6 +19,7 @@
 #include <dash/dart/mpi/dart_mem.h>
 #include <dash/dart/mpi/dart_team_private.h>
 #include <dash/dart/mpi/dart_segment.h>
+#include <dash/dart/mpi/dart_globmem_priv.h>
 
 #include <stdio.h>
 #include <mpi.h>
@@ -66,17 +67,6 @@ dart_ret_t dart_gptr_getaddr(const dart_gptr_t gptr, void **addr)
   return DART_OK;
 }
 
-
-/**
- * TODO: Put this in the header file to allow inlining?
- */
-dart_ret_t dart_gptr_incaddr(dart_gptr_t *gptr, int64_t offs)
-{
-  gptr->addr_or_offs.offset += offs;
-  return DART_OK;
-}
-
-
 dart_ret_t dart_gptr_setaddr(dart_gptr_t* gptr, void* addr)
 {
   int16_t segid = gptr->segid;
@@ -100,15 +90,6 @@ dart_ret_t dart_gptr_setaddr(dart_gptr_t* gptr, void* addr)
   } else {
     gptr->addr_or_offs.offset = (char *)addr - dart_mempool_localalloc;
   }
-  return DART_OK;
-}
-
-/**
- * TODO: Put this in the header file to allow inlining?
- */
-dart_ret_t dart_gptr_setunit(dart_gptr_t *gptr, dart_team_unit_t unit)
-{
-  gptr->unitid = unit.id;
   return DART_OK;
 }
 


### PR DESCRIPTION
Mark DART functions as `nothrow` and inline `dart_gptr_incaddr` and `dart_gptr_setunit` (marked as possibly unused). 

No (current) DART function can throw a C++ exception, hence the `nothrow` hint allows the compiler to omit exception handling code around the calls. This likely has only an effect when building with `ENABLE_ASSERTIONS=OFF`, since the assertions themselves throw exceptions. 
