### PR TITLE
Cache the size of DART data types

### DIFF
--- a/dart-if/include/dash/dart/if/dart_types.h
+++ b/dart-if/include/dash/dart/if/dart_types.h
@@ -93,7 +93,9 @@ typedef enum
     DART_TYPE_LONGLONG,
     /** floating point data types */
     DART_TYPE_FLOAT,
-    DART_TYPE_DOUBLE
+    DART_TYPE_DOUBLE,
+    /** Reserved, do not use! */
+    DART_TYPE_COUNT
 } dart_datatype_t;
 
 

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_communication_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_communication_priv.h
@@ -8,19 +8,27 @@
 #include <stdio.h>
 #include <mpi.h>
 
+#include <dash/dart/base/macro.h>
+
 #include <dash/dart/if/dart_types.h>
 #include <dash/dart/if/dart_globmem.h>
 #include <dash/dart/if/dart_communication.h>
 
+DART_INTERNAL
+int dart__mpi__datatype_sizes[DART_TYPE_COUNT];
+
 /** DART handle type for non-blocking one-sided operations. */
 struct dart_handle_struct
 {
-	MPI_Request request;
-	MPI_Win	    win;
-	dart_unit_t dest;
+  MPI_Request request;
+  MPI_Win     win;
+  dart_unit_t dest;
 };
 
-static inline MPI_Op dart_mpi_op(dart_operation_t dart_op) {
+dart_ret_t
+dart__mpi__datatype_init() DART_INTERNAL;
+
+static inline MPI_Op dart__mpi__op(dart_operation_t dart_op) {
   switch (dart_op) {
     case DART_OP_MIN     : return MPI_MIN;
     case DART_OP_MAX     : return MPI_MAX;
@@ -38,7 +46,7 @@ static inline MPI_Op dart_mpi_op(dart_operation_t dart_op) {
   }
 }
 
-static inline MPI_Datatype dart_mpi_datatype(dart_datatype_t dart_datatype) {
+static inline MPI_Datatype dart__mpi__datatype(dart_datatype_t dart_datatype) {
   switch (dart_datatype) {
     case DART_TYPE_BYTE     : return MPI_BYTE;
     case DART_TYPE_SHORT    : return MPI_SHORT;
@@ -53,14 +61,15 @@ static inline MPI_Datatype dart_mpi_datatype(dart_datatype_t dart_datatype) {
   }
 }
 
-static inline int dart_mpi_sizeof_datatype(dart_datatype_t dart_datatype) {
+static inline int dart__mpi__datatype_sizeof(dart_datatype_t dart_datatype) {
   int native_size;
-  if (MPI_Type_size(dart_mpi_datatype(dart_datatype), &native_size)
+  if (MPI_Type_size(dart__mpi__datatype(dart_datatype), &native_size)
       == MPI_SUCCESS) {
     return native_size;
   }
   return -1;
 }
+
 
 #if 0
 static inline int dart_mpi_datatype_disp_unit(dart_datatype_t dart_datatype) {

--- a/dart-impl/mpi/src/dart_communication.c
+++ b/dart-impl/mpi/src/dart_communication.c
@@ -29,6 +29,23 @@
 #include <limits.h>
 #include <math.h>
 
+int dart__mpi__datatype_sizes[DART_TYPE_COUNT];
+
+dart_ret_t
+dart__mpi__datatype_init()
+{
+  for (int i = DART_TYPE_UNDEFINED+1; i < DART_TYPE_COUNT; i++) {
+    int ret = MPI_Type_size(
+                dart__mpi__datatype(i),
+                &dart__mpi__datatype_sizes[i]);
+    if (ret != MPI_SUCCESS) {
+      DART_LOG_ERROR("Failed to query size of DART data type %i", i);
+      return DART_ERR_INVAL;
+    }
+  }
+  return DART_OK;
+}
+
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)
 static dart_ret_t get_shared_mem(
   dart_team_data_t * team_data,
@@ -57,8 +74,8 @@ static dart_ret_t get_shared_mem(
     baseptr = dart_sharedmem_local_baseptr_set[luid.id];
   }
   baseptr += offset;
-  DART_LOG_DEBUG("dart_get: memcpy %zu bytes", nelem * dart_mpi_sizeof_datatype(dtype));
-  memcpy((char*)dest, baseptr, nelem * dart_mpi_sizeof_datatype(dtype));
+  DART_LOG_DEBUG("dart_get: memcpy %zu bytes", nelem * dart__mpi__datatype_sizeof(dtype));
+  memcpy((char*)dest, baseptr, nelem * dart__mpi__datatype_sizeof(dtype));
   return DART_OK;
 }
 #endif // !defined(DART_MPI_DISABLE_SHARED_WINDOWS)
@@ -70,7 +87,7 @@ dart_ret_t dart_get(
   dart_datatype_t   dtype)
 {
   MPI_Win          win;
-  MPI_Datatype     mpi_dtype    = dart_mpi_datatype(dtype);
+  MPI_Datatype     mpi_dtype    = dart__mpi__datatype(dtype);
   uint64_t         offset       = gptr.addr_or_offs.offset;
   int16_t          seg_id       = gptr.segid;
   dart_team_unit_t team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
@@ -157,7 +174,7 @@ dart_ret_t dart_put(
   dart_datatype_t   dtype)
 {
   MPI_Win          win;
-  MPI_Datatype     mpi_dtype    = dart_mpi_datatype(dtype);
+  MPI_Datatype     mpi_dtype    = dart__mpi__datatype(dtype);
   uint64_t         offset       = gptr.addr_or_offs.offset;
   int16_t          seg_id       = gptr.segid;
   dart_team_unit_t team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
@@ -227,8 +244,8 @@ dart_ret_t dart_accumulate(
   dart_team_unit_t  team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
   uint64_t offset   = gptr.addr_or_offs.offset;
   int16_t  seg_id   = gptr.segid;
-  mpi_dtype         = dart_mpi_datatype(dtype);
-  mpi_op            = dart_mpi_op(op);
+  mpi_dtype         = dart__mpi__datatype(dtype);
+  mpi_op            = dart__mpi__op(op);
 
   if (gptr.unitid < 0) {
     DART_LOG_ERROR("dart_accumulate ! failed: gptr.unitid < 0");
@@ -304,8 +321,8 @@ dart_ret_t dart_fetch_and_op(
   dart_team_unit_t  team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
   uint64_t offset   = gptr.addr_or_offs.offset;
   int16_t  seg_id   = gptr.segid;
-  mpi_dtype         = dart_mpi_datatype(dtype);
-  mpi_op            = dart_mpi_op(op);
+  mpi_dtype         = dart__mpi__datatype(dtype);
+  mpi_op            = dart__mpi__op(op);
 
   if (gptr.unitid < 0) {
     DART_LOG_ERROR("dart_fetch_and_op ! failed: gptr.unitid < 0");
@@ -370,7 +387,7 @@ dart_ret_t dart_compare_and_swap(
   dart_team_unit_t  team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
   uint64_t offset   = gptr.addr_or_offs.offset;
   int16_t  seg_id   = gptr.segid;
-  MPI_Datatype mpi_dtype         = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_dtype         = dart__mpi__datatype(dtype);
 
   if (gptr.unitid < 0) {
     DART_LOG_ERROR("dart_compare_and_swap ! failed: gptr.unitid < 0");
@@ -434,7 +451,7 @@ dart_ret_t dart_get_handle(
   dart_datatype_t dtype,
   dart_handle_t * handle)
 {
-  MPI_Datatype mpi_type = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_type = dart__mpi__datatype(dtype);
   MPI_Win      win;
   dart_team_unit_t    team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
   uint64_t     offset = gptr.addr_or_offs.offset;
@@ -557,7 +574,7 @@ dart_ret_t dart_put_handle(
   dart_handle_t   * handle)
 {
   MPI_Request  mpi_req;
-  MPI_Datatype mpi_type = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_type = dart__mpi__datatype(dtype);
   dart_team_unit_t  team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
   uint64_t     offset   = gptr.addr_or_offs.offset;
   int16_t      seg_id   = gptr.segid;
@@ -645,7 +662,7 @@ dart_ret_t dart_put_blocking(
   dart_datatype_t dtype)
 {
   MPI_Win           win;
-  MPI_Datatype      mpi_dtype    = dart_mpi_datatype(dtype);
+  MPI_Datatype      mpi_dtype    = dart__mpi__datatype(dtype);
   dart_team_unit_t  team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
   uint64_t          offset       = gptr.addr_or_offs.offset;
   int16_t           seg_id       = gptr.segid;
@@ -699,8 +716,8 @@ dart_ret_t dart_put_blocking(
       }
       baseptr += offset;
       DART_LOG_DEBUG("dart_put_blocking: memcpy %zu bytes",
-                        nelem * dart_mpi_sizeof_datatype(dtype));
-      memcpy(baseptr, src, nelem * dart_mpi_sizeof_datatype(dtype));
+                        nelem * dart__mpi__datatype_sizeof(dtype));
+      memcpy(baseptr, src, nelem * dart__mpi__datatype_sizeof(dtype));
       return DART_OK;
     }
   }
@@ -775,7 +792,7 @@ dart_ret_t dart_get_blocking(
   dart_datatype_t dtype)
 {
   MPI_Win           win;
-  MPI_Datatype      mpi_dtype    = dart_mpi_datatype(dtype);
+  MPI_Datatype      mpi_dtype    = dart__mpi__datatype(dtype);
   dart_team_unit_t  team_unit_id = DART_TEAM_UNIT_ID(gptr.unitid);
   uint64_t          offset       = gptr.addr_or_offs.offset;
   int16_t           seg_id       = gptr.segid;
@@ -1462,7 +1479,7 @@ dart_ret_t dart_bcast(
   dart_team_t         teamid)
 {
   MPI_Comm comm;
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
 
   DART_LOG_TRACE("dart_bcast() root:%d team:%d nelem:%"PRIu64"",
                  root.id, teamid, nelem);
@@ -1510,7 +1527,7 @@ dart_ret_t dart_scatter(
   dart_team_unit_t    root,
   dart_team_t         teamid)
 {
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
   MPI_Comm     comm;
 
   if (root.id < 0) {
@@ -1558,7 +1575,7 @@ dart_ret_t dart_gather(
   dart_team_unit_t     root,
   dart_team_t          teamid)
 {
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
   MPI_Comm     comm;
 
   if (root.id < 0) {
@@ -1605,7 +1622,7 @@ dart_ret_t dart_allgather(
   dart_datatype_t   dtype,
   dart_team_t       teamid)
 {
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
   MPI_Comm     comm;
   DART_LOG_TRACE("dart_allgather() team:%d nelem:%"PRIu64"",
                  teamid, nelem);
@@ -1659,7 +1676,7 @@ dart_ret_t dart_allgatherv(
   const size_t    * recvdispls,
   dart_team_t       teamid)
 {
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
   MPI_Comm     comm;
   int          comm_size;
   DART_LOG_TRACE("dart_allgatherv() team:%d nsendelem:%"PRIu64"",
@@ -1735,8 +1752,8 @@ dart_ret_t dart_allreduce(
   dart_team_t        team)
 {
   MPI_Comm     comm;
-  MPI_Op       mpi_op    = dart_mpi_op(op);
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Op       mpi_op    = dart__mpi__op(op);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
 
   if (team == DART_UNDEFINED_TEAM_ID) {
     DART_LOG_ERROR("dart_allreduce ! failed: team may not be DART_UNDEFINED_TEAM_ID");
@@ -1778,8 +1795,8 @@ dart_ret_t dart_reduce(
   dart_team_t         team)
 {
   MPI_Comm     comm;
-  MPI_Op       mpi_op    = dart_mpi_op(op);
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Op       mpi_op    = dart__mpi__op(op);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
 
   if (root.id < 0) {
     DART_LOG_ERROR("dart_reduce ! failed: root < 0");
@@ -1825,7 +1842,7 @@ dart_ret_t dart_send(
   dart_global_unit_t  unit)
 {
   MPI_Comm comm;
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
   dart_team_t team = DART_TEAM_ALL;
 
   if (unit.id < 0) {
@@ -1867,7 +1884,7 @@ dart_ret_t dart_recv(
   dart_global_unit_t    unit)
 {
   MPI_Comm comm;
-  MPI_Datatype mpi_dtype = dart_mpi_datatype(dtype);
+  MPI_Datatype mpi_dtype = dart__mpi__datatype(dtype);
   dart_team_t team = DART_TEAM_ALL;
 
   if (unit.id < 0) {
@@ -1915,8 +1932,8 @@ dart_ret_t dart_sendrecv(
   dart_global_unit_t   src)
 {
   MPI_Comm comm;
-  MPI_Datatype mpi_send_dtype = dart_mpi_datatype(send_dtype);
-  MPI_Datatype mpi_recv_dtype = dart_mpi_datatype(recv_dtype);
+  MPI_Datatype mpi_send_dtype = dart__mpi__datatype(send_dtype);
+  MPI_Datatype mpi_recv_dtype = dart__mpi__datatype(recv_dtype);
   dart_team_t team = DART_TEAM_ALL;
 
   if (src.id < 0 || dest.id < 0) {

--- a/dart-impl/mpi/src/dart_globmem.c
+++ b/dart-impl/mpi/src/dart_globmem.c
@@ -130,7 +130,7 @@ dart_ret_t dart_memalloc(
   dart_datatype_t   dtype,
   dart_gptr_t     * gptr)
 {
-  size_t      nbytes = nelem * dart_mpi_sizeof_datatype(dtype);
+  size_t      nbytes = nelem * dart__mpi__datatype_sizeof(dtype);
   dart_global_unit_t unitid;
   dart_myid(&unitid);
   gptr->unitid  = unitid.id;
@@ -176,9 +176,8 @@ dart_team_memalloc_aligned(
 {
   char * sub_mem;
   dart_unit_t gptr_unitid = 0; // the team-local ID 0 has the beginning
-  int         dtype_size  = dart_mpi_sizeof_datatype(dtype);
+  int         dtype_size  = dart__mpi__datatype_sizeof(dtype);
   MPI_Aint    nbytes      = nelem * dtype_size;
-  char     ** baseptr_set = NULL;
   size_t      team_size;
   MPI_Win     sharedmem_win = MPI_WIN_NULL;
   dart_team_size(teamid, &team_size);
@@ -202,6 +201,7 @@ dart_team_memalloc_aligned(
 
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)
 
+  char     ** baseptr_set = NULL;
 	/* Allocate shared memory on sharedmem_comm, and create the related
    * sharedmem_win */
   /* NOTE:
@@ -438,7 +438,7 @@ dart_team_memregister_aligned(
    dart_gptr_t     * gptr)
 {
   size_t   size;
-  int      dtype_size = dart_mpi_sizeof_datatype(dtype);
+  int      dtype_size = dart__mpi__datatype_sizeof(dtype);
   size_t   nbytes     = nelem * dtype_size;
   MPI_Aint disp;
   dart_unit_t gptr_unitid = 0;
@@ -504,7 +504,7 @@ dart_team_memregister(
 {
   int    nil;
   size_t size;
-  int    dtype_size = dart_mpi_sizeof_datatype(dtype);
+  int    dtype_size = dart__mpi__datatype_sizeof(dtype);
   size_t nbytes     = nelem * dtype_size;
   dart_unit_t gptr_unitid = 0;
   dart_team_size(teamid, &size);

--- a/dart-impl/mpi/src/dart_initialization.c
+++ b/dart-impl/mpi/src/dart_initialization.c
@@ -15,6 +15,7 @@
 #include <dash/dart/mpi/dart_mem.h>
 #include <dash/dart/mpi/dart_team_private.h>
 #include <dash/dart/mpi/dart_globmem_priv.h>
+#include <dash/dart/mpi/dart_communication_priv.h>
 #include <dash/dart/mpi/dart_locality_priv.h>
 #include <dash/dart/mpi/dart_segment.h>
 
@@ -38,8 +39,12 @@ dart_ret_t do_init()
   }
 
   dart_ret_t ret = dart_adapt_teamlist_alloc(DART_TEAM_ALL);
-	if (ret != DART_OK) {
+  if (ret != DART_OK) {
     DART_LOG_ERROR("dart_adapt_teamlist_alloc failed");
+    return DART_ERR_OTHER;
+  }
+
+  if (dart__mpi__datatype_init() != DART_OK) {
     return DART_ERR_OTHER;
   }
 


### PR DESCRIPTION
... to avoid repeatedly calling `MPI_Type_size`, as reported by @fuerlinger. 