### PR TITLE
Fixes incorrect team in Pattern/Array by calling the wrong ctor unintended

### DIFF
--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -108,7 +108,6 @@ public:
   } local_coords_t;
 
 private:
-  PatternArguments_t          _arguments;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
   /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
   /// dimensions
@@ -187,30 +186,7 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    _teamspec(_arguments.teamspec()),
-    _nunits(_teamspec.size()),
-    _memory_layout(_arguments.sizespec().extents()),
-    _blocksize_spec(initialize_blocksizespec(
-        _arguments.sizespec(),
-        _distspec,
-        _teamspec)),
-    _blockspec(initialize_blockspec(
-        _arguments.sizespec(),
-        _distspec,
-        _blocksize_spec,
-        _teamspec)),
-    _local_memory_layout(
-        initialize_local_extents(_team->myid())),
-    _local_blockspec(initialize_local_blockspec(
-        _blockspec,
-        _blocksize_spec,
-        _distspec,
-        _teamspec,
-        _local_memory_layout)),
-    _local_capacity(initialize_local_capacity())
+  : BlockPattern(PatternArguments_t(arg, args...))
   {
     DASH_LOG_TRACE("BlockPattern()", "Constructor with argument list");
     initialize_local_range();
@@ -1425,6 +1401,33 @@ public:
   }
 
 private:
+
+  BlockPattern(const PatternArguments_t & arguments)
+  :  _distspec(arguments.distspec()),
+     _team(&arguments.team()),
+     _teamspec(arguments.teamspec()),
+     _nunits(_teamspec.size()),
+     _memory_layout(arguments.sizespec().extents()),
+     _blocksize_spec(initialize_blocksizespec(
+         arguments.sizespec(),
+         _distspec,
+         _teamspec)),
+     _blockspec(initialize_blockspec(
+         arguments.sizespec(),
+         _distspec,
+         _blocksize_spec,
+         _teamspec)),
+     _local_memory_layout(
+         initialize_local_extents(_team->myid())),
+     _local_blockspec(initialize_local_blockspec(
+         _blockspec,
+         _blocksize_spec,
+         _distspec,
+         _teamspec,
+         _local_memory_layout)),
+     _local_capacity(initialize_local_capacity())
+  {}
+
   /**
    * Initialize block size specs from memory layout, team spec and
    * distribution spec.

--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -249,11 +249,10 @@ public:
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t         & sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
-    /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
-    /// dimensions
-    const DistributionSpec_t & dist     = DistributionSpec_t(),
+    /// all dimensions.
+    const DistributionSpec_t & dist,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t         & teamspec = TeamSpec_t::TeamSpec(),
+    const TeamSpec_t         & teamspec,
     /// Team containing units to which this pattern maps its elements
     dash::Team               & team     = dash::Team::All())
   : _distspec(dist),

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -102,7 +102,6 @@ public:
   } local_coords_t;
 
 private:
-  PatternArguments_t          _arguments;
   /// Extent of the linear pattern.
   SizeType                    _size            = 0;
   /// Global memory layout of the pattern.
@@ -156,7 +155,7 @@ public:
    * \endcode
    */
   template<typename ... Args>
-  constexpr BlockPattern(
+  BlockPattern(
     /// Argument list consisting of the pattern size (extent, number of
     /// elements) in every dimension followed by optional distribution
     /// types.
@@ -165,32 +164,7 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _size(_arguments.sizespec().size()),
-    _memory_layout(std::array<SizeType, 1> {{ _size }}),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    _teamspec(_arguments.teamspec()),
-    _nunits(_team->size()),
-    _blocksize(initialize_blocksize(
-        _size,
-        _distspec,
-        _nunits)),
-    _nblocks(initialize_num_blocks(
-        _size,
-        _blocksize,
-        _nunits)),
-    _local_size(
-        initialize_local_extent(_team->myid())),
-    _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
-    _nlblocks(initialize_num_local_blocks(
-        _nblocks,
-        _blocksize,
-        _distspec,
-        _nunits,
-        _local_size)),
-    _local_capacity(initialize_local_capacity()),
-    _lbegin_lend(initialize_local_range(_local_size))
+  : BlockPattern(PatternArguments_t(arg, args...))
   { }
 
   /**
@@ -1128,6 +1102,35 @@ public:
   }
 
 private:
+
+  BlockPattern(const PatternArguments_t & arguments)
+  :  _size(arguments.sizespec().size()),
+     _memory_layout(std::array<SizeType, 1> {{ _size }}),
+     _distspec(arguments.distspec()),
+     _team(&arguments.team()),
+     _teamspec(arguments.teamspec()),
+     _nunits(_team->size()),
+     _blocksize(initialize_blocksize(
+         _size,
+         _distspec,
+         _nunits)),
+     _nblocks(initialize_num_blocks(
+         _size,
+         _blocksize,
+         _nunits)),
+     _local_size(
+         initialize_local_extent(_team->myid())),
+     _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
+     _nlblocks(initialize_num_local_blocks(
+         _nblocks,
+         _blocksize,
+         _distspec,
+         _nunits,
+         _local_size)),
+     _local_capacity(initialize_local_capacity()),
+     _lbegin_lend(initialize_local_range(_local_size))
+  {}
+
   /**
    * Initialize block size specs from memory layout, team spec and
    * distribution spec.

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -233,7 +233,7 @@ public:
 
   /**
    * Constructor, initializes a pattern from explicit instances of
-   * \c SizeSpec, \c DistributionSpec, \c TeamSpec and a \c Team.
+   * \c SizeSpec, \c DistributionSpec and a \c Team.
    *
    * Examples:
    *
@@ -259,9 +259,8 @@ public:
   BlockPattern(
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t         sizespec,
-    /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
-    /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
-    /// dimensions
+    /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE).
+    /// Defaults to BLOCKED.
     const DistributionSpec_t dist = DistributionSpec_t(),
     /// Team containing units to which this pattern maps its elements
     Team &                   team = dash::Team::All())

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -259,6 +259,67 @@ public:
   { }
 
   /**
+   * Constructor, initializes a pattern from explicit instances of
+   * \c SizeSpec, \c DistributionSpec, \c TeamSpec and a \c Team.
+   *
+   * Examples:
+   *
+   * \code
+   *   // 500 elements with blocked distribution:
+   *   Pattern p1(SizeSpec<1>(500),
+   *              DistributionSpec<1>(BLOCKED),
+   *              TeamSpec<1>(dash::Team::All()),
+   *              // The team containing the units to which the pattern
+   *              // maps the global indices. Defaults to all all units:
+   *              dash::Team::All());
+   *   // Same as
+   *   Pattern p1(500, BLOCKED);
+   *   // Same as
+   *   Pattern p1(SizeSpec<1>(500),
+   *              DistributionSpec<1>(BLOCKED));
+   *   // Same as
+   *   Pattern p1(SizeSpec<1>(500),
+   *              DistributionSpec<1>(BLOCKED),
+   *              TeamSpec<1>(dash::Team::All()));
+   * \endcode
+   */
+  BlockPattern(
+    /// Pattern size (extent, number of elements) in every dimension
+    const SizeSpec_t         sizespec,
+    /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
+    /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
+    /// dimensions
+    const DistributionSpec_t dist = DistributionSpec_t(),
+    /// Team containing units to which this pattern maps its elements
+    Team &                   team = dash::Team::All())
+  : _size(sizespec.size()),
+    _memory_layout(std::array<SizeType, 1> {{ _size }}),
+    _distspec(dist),
+    _team(&team),
+    _teamspec(_distspec, *_team),
+    _nunits(_team->size()),
+    _blocksize(initialize_blocksize(
+        _size,
+        _distspec,
+        _nunits)),
+    _nblocks(initialize_num_blocks(
+        _size,
+        _blocksize,
+        _nunits)),
+    _local_size(
+        initialize_local_extent(_team->myid())),
+    _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
+    _nlblocks(initialize_num_local_blocks(
+        _nblocks,
+        _blocksize,
+        _distspec,
+        _nunits,
+        _local_size)),
+    _local_capacity(initialize_local_capacity()),
+    _lbegin_lend(initialize_local_range(_local_size))
+  { }
+
+  /**
    * Move constructor.
    */
   constexpr BlockPattern(self_t && other)      = default;

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -222,10 +222,9 @@ public:
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t         sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE).
-    /// Defaults to BLOCKED.
-    const DistributionSpec_t dist     = DistributionSpec_t(),
+    const DistributionSpec_t dist,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t         teamspec = TeamSpec_t::TeamSpec(),
+    const TeamSpec_t         teamspec,
     /// Team containing units to which this pattern maps its elements
     dash::Team &             team     = dash::Team::All())
   : _size(sizespec.size()),

--- a/dash/include/dash/pattern/CSRPattern.h
+++ b/dash/include/dash/pattern/CSRPattern.h
@@ -203,6 +203,54 @@ public:
 
   /**
    * Constructor, initializes a pattern from explicit instances of
+   * \c SizeSpec, \c DistributionSpec, \c TeamSpec and \c Team.
+   *
+   */
+  CSRPattern(
+    /// Size spec of the pattern.
+    const SizeSpec_t         & sizespec,
+    /// Distribution spec.
+    const DistributionSpec_t & distspec,
+    /// Cartesian arrangement of units within the team
+    const TeamSpec_t         & teamspec,
+    /// Team containing units to which this pattern maps its elements.
+    Team                     & team = dash::Team::All())
+  : _size(sizespec.size()),
+    _local_sizes(initialize_local_sizes(
+        _size,
+        distspec,
+        team)),
+    _block_offsets(initialize_block_offsets(
+        _local_sizes)),
+    _memory_layout(std::array<SizeType, 1> {{ _size }}),
+    _blockspec(initialize_blockspec(
+        _size,
+        _local_sizes)),
+    _distspec(DistributionSpec_t()),
+    _team(&team),
+    _teamspec(
+      teamspec,
+      _distspec,
+      *_team),
+    _nunits(_team->size()),
+    _local_size(
+        initialize_local_extent(
+          _team->myid(),
+          _local_sizes)),
+    _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
+    _local_capacity(initialize_local_capacity(_local_sizes))
+  {
+    DASH_LOG_TRACE("CSRPattern()", "(sizespec, dist, team)");
+    DASH_ASSERT_EQ(
+      _local_sizes.size(), _nunits,
+      "Number of given local sizes "   << _local_sizes.size() << " " <<
+      "does not match number of units" << _nunits);
+    initialize_local_range();
+    DASH_LOG_TRACE("CSRPattern()", "CSRPattern initialized");
+  }
+
+  /**
+   * Constructor, initializes a pattern from explicit instances of
    * \c SizeSpec, \c DistributionSpec and \c Team.
    *
    */

--- a/dash/include/dash/pattern/CSRPattern.h
+++ b/dash/include/dash/pattern/CSRPattern.h
@@ -121,7 +121,6 @@ public:
   } local_coords_t;
 
 private:
-  PatternArguments_t          _arguments;
   /// Extent of the linear pattern.
   SizeType                    _size            = 0;
   /// Number of local elements for every unit in the active team.
@@ -169,28 +168,7 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _size(_arguments.sizespec().size()),
-    _local_sizes(initialize_local_sizes(
-        _size,
-        _arguments.distspec(),
-        _arguments.team())),
-    _block_offsets(initialize_block_offsets(
-        _local_sizes)),
-    _memory_layout(std::array<SizeType, 1> {{ _size }}),
-    _blockspec(initialize_blockspec(
-        _size,
-        _local_sizes)),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    _teamspec(_arguments.teamspec()),
-    _nunits(_team->size()),
-    _local_size(
-        initialize_local_extent(
-          _team->myid(),
-          _local_sizes)),
-    _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
-    _local_capacity(initialize_local_capacity(_local_sizes))
+  : CSRPattern(PatternArguments_t(arg, args...))
   {
     DASH_LOG_TRACE("CSRPattern()", "Constructor with argument list");
     DASH_ASSERT_EQ(
@@ -310,25 +288,7 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _size(_arguments.sizespec().size()),
-    _local_sizes(local_sizes),
-    _block_offsets(initialize_block_offsets(
-        _local_sizes)),
-    _memory_layout(std::array<SizeType, 1> {{ _size }}),
-    _blockspec(initialize_blockspec(
-        _size,
-        _local_sizes)),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    _teamspec(_arguments.teamspec()),
-    _nunits(_team->size()),
-    _local_size(
-        initialize_local_extent(
-          _team->myid(),
-          _local_sizes)),
-    _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
-    _local_capacity(initialize_local_capacity(_local_sizes))
+  : CSRPattern(local_sizes, PatternArguments_t(arg, args...))
   {
     DASH_LOG_TRACE("CSRPattern()", "Constructor with argument list");
     DASH_ASSERT_EQ(
@@ -1179,6 +1139,39 @@ public:
   }
 
 private:
+
+  CSRPattern(
+    const PatternArguments_t & arguments)
+  : CSRPattern(
+      initialize_local_sizes(
+        arguments.sizespec().size(),
+        arguments.distspec(),
+        arguments.team()),
+      arguments)
+  {}
+
+  CSRPattern(
+    const std::vector<size_type> & local_sizes,
+    const PatternArguments_t     & arguments)
+  : _size(arguments.sizespec().size()),
+    _local_sizes(local_sizes),
+    _block_offsets(initialize_block_offsets(
+        _local_sizes)),
+    _memory_layout(std::array<SizeType, 1> {{ _size }}),
+    _blockspec(initialize_blockspec(
+        _size,
+        _local_sizes)),
+    _distspec(arguments.distspec()),
+    _team(&arguments.team()),
+    _teamspec(arguments.teamspec()),
+    _nunits(_team->size()),
+    _local_size(
+        initialize_local_extent(
+          _team->myid(),
+          _local_sizes)),
+    _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
+    _local_capacity(initialize_local_capacity(_local_sizes))
+  {}
 
   /**
    * Initialize the size (number of mapped elements) of the Pattern.

--- a/dash/include/dash/pattern/CSRPattern.h
+++ b/dash/include/dash/pattern/CSRPattern.h
@@ -565,7 +565,23 @@ public:
       "Expected dimension = 0, got " << dim);
     return _local_size;
   }
-
+  
+  /**
+   * The actual number of elements in this pattern that are local to the
+   * calling unit, by dimension.
+   *
+   * \see  local_extent()
+   * \see  blocksize()
+   * \see  local_size()
+   * \see  extent()
+   *
+   * \see  DashPatternConcept
+   */
+  constexpr std::array<SizeType, NumDimensions>
+  local_extents() const noexcept
+  {
+    return std::array<SizeType, 1> {{ _local_sizes[_team->myid()] }};
+  }
   /**
    * The actual number of elements in this pattern that are local to the
    * given unit, by dimension.
@@ -1047,7 +1063,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr const std::array<SizeType, NumDimensions> &
+  constexpr const std::array<SizeType, NumDimensions>
     extents() const noexcept
   {
     return std::array<SizeType, 1> {{ _size }};

--- a/dash/include/dash/pattern/DynamicPattern.h
+++ b/dash/include/dash/pattern/DynamicPattern.h
@@ -148,6 +148,58 @@ public:
 
   /**
    * Constructor, initializes a pattern from explicit instances of
+   * \c SizeSpec, \c DistributionSpec, \c TeamSpec and \c Team.
+   *
+   */
+  DynamicPattern(
+    /// Size spec of the pattern.
+    const SizeSpec_t         & sizespec,
+    /// Distribution spec.
+    const DistributionSpec_t & distspec,
+    /// Cartesian arrangement of units within the team
+    const TeamSpec_t         & teamspec,
+    /// Team containing units to which this pattern maps its elements.
+    Team                     & team = dash::Team::All())
+  : _size(sizespec.size()),
+    _local_sizes(initialize_local_sizes(
+        _size,
+        distspec,
+        team)),
+    _block_offsets(initialize_block_offsets(
+        _local_sizes)),
+    _memory_layout(std::array<SizeType, 1> { _size }),
+    _blockspec(initialize_blockspec(
+        _size,
+        _local_sizes)),
+    _distspec(DistributionSpec_t()),
+    _team(&team),
+    _myid(_team->myid()),
+    _teamspec(
+      teamspec,
+      _distspec,
+      *_team),
+    _nunits(_team->size()),
+    _blocksize(initialize_blocksize(
+        _size,
+        _distspec,
+        _nunits)),
+    _nblocks(_nunits),
+    _local_size(
+        initialize_local_extent(_team->myid())),
+    _local_memory_layout(std::array<SizeType, 1> { _local_size }),
+    _local_capacity(initialize_local_capacity())
+  {
+    DASH_LOG_TRACE("DynamicPattern()", "(sizespec, dist, team)");
+    DASH_ASSERT_EQ(
+      _local_sizes.size(), _nunits,
+      "Number of given local sizes "   << _local_sizes.size() << " " <<
+      "does not match number of units" << _nunits);
+    initialize_local_range();
+    DASH_LOG_TRACE("DynamicPattern()", "DynamicPattern initialized");
+  }
+
+  /**
+   * Constructor, initializes a pattern from explicit instances of
    * \c SizeSpec, \c DistributionSpec and \c Team.
    *
    */

--- a/dash/include/dash/pattern/LoadBalancePattern.h
+++ b/dash/include/dash/pattern/LoadBalancePattern.h
@@ -1281,7 +1281,6 @@ private:
   }
 
 private:
-  PatternArguments_t          _arguments;
   /// Extent of the linear pattern.
   SizeType                    _size;
   /// Load balance weight by CPU capacity of every unit in the team.

--- a/dash/include/dash/pattern/SeqTilePattern.h
+++ b/dash/include/dash/pattern/SeqTilePattern.h
@@ -119,7 +119,6 @@ public:
   } local_coords_t;
 
 private:
-  PatternArguments_t          _arguments;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
   /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
   /// dimensions
@@ -197,30 +196,8 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    _myid(_team->myid()),
-    _teamspec(_arguments.teamspec()),
-    _memory_layout(_arguments.sizespec().extents()),
-    _nunits(_teamspec.size()),
-    _blocksize_spec(initialize_blocksizespec(
-        _arguments.sizespec(),
-        _distspec,
-        _teamspec)),
-    _blockspec(initialize_blockspec(
-        _arguments.sizespec(),
-        _distspec,
-        _blocksize_spec,
-        _teamspec)),
-    _local_blockspec(initialize_local_blockspec(
-        _blockspec,
-        _blocksize_spec,
-        _teamspec)),
-    _local_memory_layout(
-        initialize_local_extents(_myid)),
-    _local_capacity(
-        initialize_local_capacity(_local_memory_layout)) {
+  : SeqTilePattern(PatternArguments_t(arg, args...))
+  {
     DASH_LOG_TRACE("SeqTilePattern()", "Constructor with Argument list");
     initialize_local_range();
   }
@@ -1495,6 +1472,33 @@ public:
   }
 
 private:
+
+  SeqTilePattern(const PatternArguments_t & arguments)
+  : _distspec(arguments.distspec()),
+    _team(&arguments.team()),
+    _myid(_team->myid()),
+    _teamspec(arguments.teamspec()),
+    _memory_layout(arguments.sizespec().extents()),
+    _nunits(_teamspec.size()),
+    _blocksize_spec(initialize_blocksizespec(
+        arguments.sizespec(),
+        _distspec,
+        _teamspec)),
+    _blockspec(initialize_blockspec(
+        arguments.sizespec(),
+        _distspec,
+        _blocksize_spec,
+        _teamspec)),
+    _local_blockspec(initialize_local_blockspec(
+        _blockspec,
+        _blocksize_spec,
+        _teamspec)),
+    _local_memory_layout(
+        initialize_local_extents(_myid)),
+    _local_capacity(
+        initialize_local_capacity(_local_memory_layout))
+  {}
+
   /**
    * Initialize block size specs from memory layout, team spec and
    * distribution spec.

--- a/dash/include/dash/pattern/ShiftTilePattern.h
+++ b/dash/include/dash/pattern/ShiftTilePattern.h
@@ -113,7 +113,6 @@ public:
   } local_coords_t;
 
 private:
-  PatternArguments_t          _arguments;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
   /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
   /// dimensions
@@ -195,32 +194,7 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    // Degrading to 1-dimensional team spec for now:
-//  _teamspec(_distspec, *_team),
-    _teamspec(_arguments.teamspec()),
-    _memory_layout(_arguments.sizespec().extents()),
-    _nunits(_teamspec.size()),
-    _major_tiled_dim(initialize_major_tiled_dim(_distspec)),
-    _minor_tiled_dim((_major_tiled_dim + 1) % NumDimensions),
-    _blocksize_spec(initialize_blocksizespec(
-        _arguments.sizespec(),
-        _distspec,
-        _teamspec)),
-    _blockspec(initialize_blockspec(
-        _arguments.sizespec(),
-        _distspec,
-        _blocksize_spec,
-        _teamspec)),
-    _local_blockspec(initialize_local_blockspec(
-        _blockspec,
-        _major_tiled_dim,
-        _nunits)),
-    _local_memory_layout(
-        initialize_local_extents(_team->myid())),
-    _local_capacity(initialize_local_capacity()) {
+  : ShiftTilePattern(PatternArguments_t(arg, args...)) {
     DASH_LOG_TRACE("ShiftTilePattern()", "Constructor with Argument list");
     initialize_local_range();
   }
@@ -1470,6 +1444,32 @@ public:
   }
 
 private:
+
+  ShiftTilePattern(const PatternArguments_t & arguments)
+  : _distspec(arguments.distspec()),
+    _team(&arguments.team()),
+    _teamspec(arguments.teamspec()),
+    _memory_layout(arguments.sizespec().extents()),
+    _nunits(_teamspec.size()),
+    _major_tiled_dim(initialize_major_tiled_dim(_distspec)),
+    _minor_tiled_dim((_major_tiled_dim + 1) % NumDimensions),
+    _blocksize_spec(initialize_blocksizespec(
+        arguments.sizespec(),
+        _distspec,
+        _teamspec)),
+    _blockspec(initialize_blockspec(
+        arguments.sizespec(),
+        _distspec,
+        _blocksize_spec,
+        _teamspec)),
+    _local_blockspec(initialize_local_blockspec(
+        _blockspec,
+        _major_tiled_dim,
+        _nunits)),
+    _local_memory_layout(
+        initialize_local_extents(_team->myid())),
+    _local_capacity(initialize_local_capacity())
+  {}
   /**
    * Initialize block size specs from memory layout, team spec and
    * distribution spec.

--- a/dash/include/dash/pattern/ShiftTilePattern.h
+++ b/dash/include/dash/pattern/ShiftTilePattern.h
@@ -236,8 +236,7 @@ public:
     /// ShiftTilePattern size (extent, number of elements) in every dimension
     const SizeSpec_t         & sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
-    /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
-    /// dimensions
+    /// all dimensions.
     const DistributionSpec_t & dist,
     /// Cartesian arrangement of units within the team
     const TeamSpec_t         & teamspec,

--- a/dash/include/dash/pattern/ShiftTilePattern1D.h
+++ b/dash/include/dash/pattern/ShiftTilePattern1D.h
@@ -201,10 +201,9 @@ public:
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t &         sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE).
-    /// Defaults to BLOCKED.
-    const DistributionSpec_t & dist     = DistributionSpec_t(),
+    const DistributionSpec_t & dist,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t &         teamspec = TeamSpec_t::TeamSpec(),
+    const TeamSpec_t &         teamspec,
     /// Team containing units to which this pattern maps its elements
     dash::Team &               team     = dash::Team::All())
   : _size(sizespec.size()),

--- a/dash/include/dash/pattern/ShiftTilePattern1D.h
+++ b/dash/include/dash/pattern/ShiftTilePattern1D.h
@@ -240,7 +240,7 @@ public:
 
   /**
    * Constructor, initializes a pattern from explicit instances of
-   * \c SizeSpec, \c DistributionSpec, \c TeamSpec and a \c Team.
+   * \c SizeSpec, \c DistributionSpec and a \c Team.
    *
    * Examples:
    *
@@ -266,9 +266,8 @@ public:
   ShiftTilePattern(
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t &         sizespec,
-    /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
-    /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
-    /// dimensions
+    /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE).
+    /// Defaults to BLOCKED in first.
     const DistributionSpec_t & dist = DistributionSpec_t(),
     /// Team containing units to which this pattern maps its elements
     Team &                     team = dash::Team::All())

--- a/dash/include/dash/pattern/ShiftTilePattern1D.h
+++ b/dash/include/dash/pattern/ShiftTilePattern1D.h
@@ -106,7 +106,6 @@ public:
   } local_coords_t;
 
 private:
-  PatternArguments_t          _arguments;
   /// Extent of the linear pattern.
   SizeType                    _size;
   /// Global memory layout of the pattern.
@@ -167,31 +166,7 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _size(_arguments.sizespec().size()),
-    _memory_layout(std::array<SizeType, 1> { _size }),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    _teamspec(_arguments.teamspec()),
-    _nunits(_team->size()),
-    _blocksize(initialize_blocksize(
-        _size,
-        _distspec,
-        _nunits)),
-    _nblocks(initialize_num_blocks(
-        _size,
-        _blocksize,
-        _nunits)),
-    _local_size(
-        initialize_local_extent(_team->myid())),
-    _local_memory_layout(std::array<SizeType, 1> { _local_size }),
-    _nlblocks(initialize_num_local_blocks(
-        _nblocks,
-        _blocksize,
-        _distspec,
-        _nunits,
-        _local_size)),
-    _local_capacity(initialize_local_capacity()) {
+  : ShiftTilePattern(PatternArguments_t(arg, args...)) {
     DASH_LOG_TRACE("ShiftTilePattern<1>()", "Constructor with argument list");
     initialize_local_range();
     DASH_LOG_TRACE("ShiftTilePattern<1>()", "ShiftTilePattern initialized");
@@ -1106,6 +1081,35 @@ public:
   constexpr static dim_t ndim() {
     return 1;
   }
+
+private:
+
+  ShiftTilePattern(const PatternArguments_t &arguments)
+  : _size(arguments.sizespec().size()),
+    _memory_layout(std::array<SizeType, 1> { _size }),
+    _distspec(arguments.distspec()),
+    _team(&arguments.team()),
+    _teamspec(arguments.teamspec()),
+    _nunits(_team->size()),
+    _blocksize(initialize_blocksize(
+        _size,
+        _distspec,
+        _nunits)),
+    _nblocks(initialize_num_blocks(
+        _size,
+        _blocksize,
+        _nunits)),
+    _local_size(
+        initialize_local_extent(_team->myid())),
+    _local_memory_layout(std::array<SizeType, 1> { _local_size }),
+    _nlblocks(initialize_num_local_blocks(
+        _nblocks,
+        _blocksize,
+        _distspec,
+        _nunits,
+        _local_size)),
+    _local_capacity(initialize_local_capacity())
+  {}
 
   /**
    * Initialize block size specs from memory layout, team spec and

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -234,8 +234,7 @@ public:
     /// TilePattern size (extent, number of elements) in every dimension
     const SizeSpec_t         & sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
-    /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
-    /// dimensions
+    /// all dimensions.
     const DistributionSpec_t & dist,
     /// Cartesian arrangement of units within the team
     const TeamSpec_t         & teamspec,

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -114,7 +114,6 @@ public:
   } local_coords_t;
 
 private:
-  PatternArguments_t          _arguments;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
   /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
   /// dimensions
@@ -192,30 +191,7 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    _myid(_team->myid()),
-    _teamspec(_arguments.teamspec()),
-    _memory_layout(_arguments.sizespec().extents()),
-    _nunits(_teamspec.size()),
-    _blocksize_spec(initialize_blocksizespec(
-        _arguments.sizespec(),
-        _distspec,
-        _teamspec)),
-    _blockspec(initialize_blockspec(
-        _arguments.sizespec(),
-        _distspec,
-        _blocksize_spec,
-        _teamspec)),
-    _local_blockspec(initialize_local_blockspec(
-        _blockspec,
-        _blocksize_spec,
-        _teamspec)),
-    _local_memory_layout(
-        initialize_local_extents(_myid)),
-    _local_capacity(
-        initialize_local_capacity(_local_memory_layout))
+  : TilePattern(PatternArguments_t(arg, args...))
   {
     DASH_LOG_TRACE("TilePattern()", "Constructor with Argument list");
     initialize_local_range();
@@ -1521,6 +1497,33 @@ public:
   }
 
 private:
+
+  TilePattern(const PatternArguments_t & arguments)
+  : _distspec(arguments.distspec()),
+    _team(&arguments.team()),
+    _myid(_team->myid()),
+    _teamspec(arguments.teamspec()),
+    _memory_layout(arguments.sizespec().extents()),
+    _nunits(_teamspec.size()),
+    _blocksize_spec(initialize_blocksizespec(
+        arguments.sizespec(),
+        _distspec,
+        _teamspec)),
+    _blockspec(initialize_blockspec(
+        arguments.sizespec(),
+        _distspec,
+        _blocksize_spec,
+        _teamspec)),
+    _local_blockspec(initialize_local_blockspec(
+        _blockspec,
+        _blocksize_spec,
+        _teamspec)),
+    _local_memory_layout(
+        initialize_local_extents(_myid)),
+    _local_capacity(
+        initialize_local_capacity(_local_memory_layout))
+  {}
+
   /**
    * Initialize block size specs from memory layout, team spec and
    * distribution spec.

--- a/dash/include/dash/pattern/TilePattern1D.h
+++ b/dash/include/dash/pattern/TilePattern1D.h
@@ -104,7 +104,6 @@ public:
   } local_coords_t;
 
 private:
-  PatternArguments_t          _arguments;
   /// Extent of the linear pattern.
   SizeType                    _size;
   /// Global memory layout of the pattern.
@@ -165,31 +164,8 @@ public:
     /// elements) in every dimension followed by optional distribution
     /// types.
     Args && ... args)
-  : _arguments(arg, args...),
-    _size(_arguments.sizespec().size()),
-    _memory_layout(std::array<SizeType, 1> {{ _size }}),
-    _distspec(_arguments.distspec()),
-    _team(&_arguments.team()),
-    _teamspec(_arguments.teamspec()),
-    _nunits(_team->size()),
-    _blocksize(initialize_blocksize(
-        _size,
-        _distspec,
-        _nunits)),
-    _nblocks(initialize_num_blocks(
-        _size,
-        _blocksize,
-        _nunits)),
-    _local_size(
-        initialize_local_extent(_team->myid())),
-    _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
-    _nlblocks(initialize_num_local_blocks(
-        _nblocks,
-        _blocksize,
-        _distspec,
-        _nunits,
-        _local_size)),
-    _local_capacity(initialize_local_capacity()) {
+  : TilePattern(PatternArguments_t(arg, args...))
+  {
     DASH_LOG_TRACE("TilePattern<1>()", "Constructor with argument list");
     initialize_local_range();
     DASH_LOG_TRACE("TilePattern<1>()", "TilePattern initialized");
@@ -1054,6 +1030,34 @@ public:
   constexpr static dim_t ndim() {
     return 1;
   }
+
+private:
+  TilePattern(const PatternArguments_t & arguments)
+  : _size(arguments.sizespec().size()),
+    _memory_layout(std::array<SizeType, 1> {{ _size }}),
+    _distspec(arguments.distspec()),
+    _team(&arguments.team()),
+    _teamspec(arguments.teamspec()),
+    _nunits(_team->size()),
+    _blocksize(initialize_blocksize(
+        _size,
+        _distspec,
+        _nunits)),
+    _nblocks(initialize_num_blocks(
+        _size,
+        _blocksize,
+        _nunits)),
+    _local_size(
+        initialize_local_extent(_team->myid())),
+    _local_memory_layout(std::array<SizeType, 1> {{ _local_size }}),
+    _nlblocks(initialize_num_local_blocks(
+        _nblocks,
+        _blocksize,
+        _distspec,
+        _nunits,
+        _local_size)),
+    _local_capacity(initialize_local_capacity())
+  {}
 
   /**
    * Initialize block size specs from memory layout, team spec and

--- a/dash/include/dash/pattern/TilePattern1D.h
+++ b/dash/include/dash/pattern/TilePattern1D.h
@@ -200,10 +200,9 @@ public:
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t         sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE).
-    /// Defaults to BLOCKED.
-    const DistributionSpec_t dist     = DistributionSpec_t(),
+    const DistributionSpec_t dist,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t         teamspec = TeamSpec_t::TeamSpec(),
+    const TeamSpec_t         teamspec,
     /// Team containing units to which this pattern maps its elements
     dash::Team &             team     = dash::Team::All())
   : _size(sizespec.size()),

--- a/dash/include/dash/pattern/TilePattern1D.h
+++ b/dash/include/dash/pattern/TilePattern1D.h
@@ -239,7 +239,7 @@ public:
 
   /**
    * Constructor, initializes a pattern from explicit instances of
-   * \c SizeSpec, \c DistributionSpec, \c TeamSpec and a \c Team.
+   * \c SizeSpec, \c DistributionSpec and a \c Team.
    *
    * Examples:
    *
@@ -265,9 +265,8 @@ public:
   TilePattern(
     /// Pattern size (extent, number of elements) in every dimension
     const SizeSpec_t &         sizespec,
-    /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
-    /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
-    /// dimensions
+    /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE).
+    /// Defaults to BLOCKED in first.
     const DistributionSpec_t & dist = DistributionSpec_t(),
     /// Team containing units to which this pattern maps its elements
     Team &                     team = dash::Team::All())

--- a/dash/test/container/ArrayTest.cc
+++ b/dash/test/container/ArrayTest.cc
@@ -222,6 +222,7 @@ TEST_F(ArrayTest, TeamSplit)
   LOG_MESSAGE("... Team split finished");
 
   dash::Array<double> array_a(ext_x, myteam);
+  ASSERT_EQ_U(array_a.team(), myteam);
 
   array_a.barrier();
   // Check if array is allocated


### PR DESCRIPTION
This pull request reverts the changes from PR #304 and solves it in a different way.

With the removal of the constructors from `BlockPattern` it got incompatible to the `CSRPattern`,
as the constructor of the `CSRPattern` differs in the signature.

To fix the ambiguity in the constructors this pull request removes some of the default paramters.
See also `TilePattern` for example, it is done there in the same way. [Parameter of `TilePattern` ctor](https://github.com/dash-project/dash/blob/development/dash/include/dash/pattern/TilePattern.h#L260#L265)

Due to the missing constructor the wrong constructor got called from `dash::Array` which lead to always using `dash::Team::All()` as the team of the array. This behaviour is observed in issue #353.

Fixes #353 and a part #292 (`ThreadsafetyTest.ConcurrentAlgorithm`).