### PR TITLE
More fixes for GlobAsyncRef

### DIFF
--- a/dash/include/dash/GlobAsyncRef.h
+++ b/dash/include/dash/GlobAsyncRef.h
@@ -52,6 +52,12 @@ private:
   typedef GlobAsyncRef<T>
     self_t;
 
+  typedef typename std::remove_const<T>::type
+    nonconst_value_type;
+
+  typedef typename std::add_const<T>::type
+    const_value_type;
+
 private:
   /// Pointer to referenced element in global memory
   dart_gptr_t  _gptr        = DART_GPTR_NULL;
@@ -71,7 +77,7 @@ public:
    */
   explicit constexpr GlobAsyncRef(
     /// Pointer to referenced object in local memory
-    T * lptr)
+    nonconst_value_type * lptr)
   : _value(*lptr),
     _lptr(lptr),
     _is_local(true),
@@ -134,7 +140,7 @@ public:
   /**
    * Whether the referenced element is located in local memory.
    */
-  inline bool is_local() const
+  inline bool is_local() const noexcept
   {
     return _is_local;
   }
@@ -142,7 +148,7 @@ public:
   /**
    * Conversion operator to referenced element value.
    */
-  operator T() const
+  operator nonconst_value_type() const
   {
     DASH_LOG_TRACE_VAR("GlobAsyncRef.T()", _gptr);
     if (!_has_value) {
@@ -165,17 +171,118 @@ public:
    * Comparison operator, true if both GlobAsyncRef objects points to same
    * element in local / global memory.
    */
-  bool operator==(const self_t & other) const
+  bool operator==(const self_t & other) const noexcept
   {
     return (_lptr == other._lptr &&
             _gptr == other._gptr);
   }
 
   /**
+   * Inequality comparison operator, true if both GlobAsyncRef objects points
+   * to different elements in local / global memory.
+   */
+  template <class GlobRefT>
+  constexpr bool operator!=(const GlobRefT & other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  /**
+   * Value-based comparison operator, true if the value refernced by the
+   * GlobAsyncRef object is equal to \c value.
+   */
+  constexpr bool operator==(const_value_type & value) const
+  {
+    return static_cast<T>(*this) == value;
+  }
+
+  /**
+   * Value-based inequality comparison operator, true if the value refernced
+   * by the GlobAsyncRef object is not equal to \c value.
+   */
+  constexpr bool operator!=(const nonconst_value_type & value) const
+  {
+    return !(*this == value);
+  }
+
+  friend void swap(GlobAsyncRef<T> a, GlobAsyncRef<T> b) {
+    nonconst_value_type temp = static_cast<nonconst_value_type>(a);
+    a = b;
+    b = temp;
+  }
+
+
+  /**
+   * Set the value referenced by this \c GlobAsyncRef to \c val.
+   *
+   * \see operator=
+   */
+  void set(const_value_type & val) {
+    operator=(val);
+  }
+
+  /**
+   * Return the value referenced by this \c GlobAsyncRef.
+   */
+  nonconst_value_type get() const {
+    return operator nonconst_value_type();
+  }
+
+  /**
+   * Asynchronously write the value referenced by this \c GlobAsyncRef
+   * into \c tptr.
+   * This operation is guaranteed to be complete after a call to \ref flush,
+   * at which point the referenced value can be used.
+   */
+  void get(nonconst_value_type *tptr) const {
+    if (_is_local) {
+      *tptr = *_lptr;
+    } else {
+      dart_storage_t ds = dash::dart_storage<T>(1);
+      dart_get(static_cast<void *>(tptr), _gptr, ds.nelem, ds.dtype);
+    }
+  }
+
+  /**
+   * Asynchronously write  the value referenced by this \c GlobAsyncRef
+   * into \c tref.
+   * This operation is guaranteed to be complete after a call to \ref flush,
+   * at which point the referenced value can be used.
+   */
+  void get(nonconst_value_type& tref) const {
+    get(&tref);
+  }
+
+  /**
+   * Asynchronously set the value referenced by this \c GlobAsyncRef
+   * to the value pointed to by \c tptr.
+   * This operation is guaranteed to be complete after a call to \ref flush,
+   * at which point the pointer can be re-used.
+   */
+  void put(const_value_type* tptr) const {
+    if (_is_local) {
+      *tptr = *_lptr;
+    } else {
+      dart_storage_t ds = dash::dart_storage<T>(1);
+      dart_put(_gptr, static_cast<void *>(tptr), ds.nelem, ds.dtype);
+    }
+  }
+
+  /**
+   * Asynchronously set the value referenced by this \c GlobAsyncRef
+   * to the value pointed to by \c tref.
+   * This operation is guaranteed to be complete after a call to \ref flush,
+   * at which point the reference can be re-used.
+   */
+  void put(const_value_type& tref) const {
+    put(&tref);
+  }
+
+  /**
    * Value assignment operator, sets new value in local memory or calls
    * non-blocking put on remote memory.
    */
-  self_t & operator=(const T & new_value)
+  self_t & operator=(const_value_type & new_value)
   {
     DASH_LOG_TRACE_VAR("GlobAsyncRef.=()", new_value);
     DASH_LOG_TRACE_VAR("GlobAsyncRef.=", _gptr);
@@ -200,9 +307,9 @@ public:
   /**
    * Value increment operator.
    */
-  self_t & operator+=(const T & ref)
+  self_t & operator+=(const_value_type & ref)
   {
-    T val = operator T();
+    T val = operator nonconst_value_type();
     val += ref;
     operator=(val);
     return *this;
@@ -213,7 +320,7 @@ public:
    */
   self_t & operator++()
   {
-    T val = operator T();
+    nonconst_value_type val = operator nonconst_value_type();
     ++val;
     operator=(val);
     return *this;
@@ -224,8 +331,8 @@ public:
    */
   self_t operator++(int)
   {
-    self_t result = *this;
-    T val = operator T();
+    self_t              result = *this;
+    nonconst_value_type val    = operator nonconst_value_type();
     ++val;
     operator=(val);
     return result;
@@ -234,9 +341,9 @@ public:
   /**
    * Value decrement operator.
    */
-  self_t & operator-=(const T & ref)
+  self_t & operator-=(const_value_type & ref)
   {
-    T val = operator T();
+    nonconst_value_type val = operator nonconst_value_type();
     val  -= ref;
     operator=(val);
     return *this;
@@ -247,7 +354,7 @@ public:
    */
   self_t & operator--()
   {
-    T val = operator T();
+    nonconst_value_type val = operator nonconst_value_type();
     --val;
     operator=(val);
     return *this;
@@ -258,16 +365,55 @@ public:
    */
   self_t operator--(int)
   {
-    self_t result = *this;
-    T val = operator T();
+    self_t              result = *this;
+    nonconst_value_type val    = operator nonconst_value_type();
     --val;
     operator=(val);
     return result;
   }
 
+
   /**
-   * Flush all pending assignments on this asynchronous reference and
-   * invalidate cached copies.
+   * Multiplication operator.
+   */
+  GlobRef<T> & operator*=(const_value_type& ref) {
+    nonconst_value_type val = operator nonconst_value_type();
+    val   *= ref;
+    operator=(val);
+    return *this;
+  }
+
+  /**
+   * Division operator.
+   */
+  GlobRef<T> & operator/=(const_value_type& ref) {
+    nonconst_value_type val = operator nonconst_value_type();
+    val   /= ref;
+    operator=(val);
+    return *this;
+  }
+
+  /**
+   * Binary XOR operator.
+   */
+  GlobRef<T> & operator^=(const_value_type& ref) {
+    nonconst_value_type val = operator nonconst_value_type();
+    val   ^= ref;
+    operator=(val);
+    return *this;
+  }
+
+  /**
+   * Return the underlying DART pointer.
+   */
+  constexpr dart_gptr_t dart_gptr() const noexcept {
+    return _gptr;
+  }
+
+
+  /**
+   * Flush all pending asynchronous operations on this asynchronous reference
+   * and invalidate cached copies.
    */
   void flush()
   {

--- a/dash/include/dash/GlobAsyncRef.h
+++ b/dash/include/dash/GlobAsyncRef.h
@@ -138,6 +138,19 @@ public:
   { }
 
   /**
+   * Like native references, global reference types cannot be copied.
+   *
+   * Default definition of copy constructor would conflict with semantics
+   * of \c operator=(const self_t &).
+   */
+  GlobAsyncRef(const self_t & other) = delete;
+
+  /**
+   * Unlike native reference types, global reference types are moveable.
+   */
+  GlobAsyncRef(self_t && other)      = default;
+
+  /**
    * Whether the referenced element is located in local memory.
    */
   inline bool is_local() const noexcept
@@ -371,7 +384,7 @@ public:
   /**
    * Multiplication operator.
    */
-  GlobRef<T> & operator*=(const_value_type& ref) {
+  self_t & operator*=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   *= ref;
     operator=(val);
@@ -381,7 +394,7 @@ public:
   /**
    * Division operator.
    */
-  GlobRef<T> & operator/=(const_value_type& ref) {
+  self_t & operator/=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   /= ref;
     operator=(val);
@@ -391,7 +404,7 @@ public:
   /**
    * Binary XOR operator.
    */
-  GlobRef<T> & operator^=(const_value_type& ref) {
+  self_t & operator^=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   ^= ref;
     operator=(val);

--- a/dash/include/dash/GlobAsyncRef.h
+++ b/dash/include/dash/GlobAsyncRef.h
@@ -257,25 +257,20 @@ public:
    * Asynchronously set the value referenced by this \c GlobAsyncRef
    * to the value pointed to by \c tptr.
    * This operation is guaranteed to be complete after a call to \ref flush,
-   * at which point the pointer can be re-used.
+   * but the pointer \c tptr can be re-used immediately.
    */
-  void put(const_value_type* tptr) const {
-    if (_is_local) {
-      *tptr = *_lptr;
-    } else {
-      dart_storage_t ds = dash::dart_storage<T>(1);
-      dart_put(_gptr, static_cast<void *>(tptr), ds.nelem, ds.dtype);
-    }
+  void put(const_value_type* tptr) {
+    operator=(*tptr);
   }
 
   /**
    * Asynchronously set the value referenced by this \c GlobAsyncRef
    * to the value pointed to by \c tref.
    * This operation is guaranteed to be complete after a call to \ref flush,
-   * at which point the reference can be re-used.
+   * but the value referenced by \c tref can be re-used immediately.
    */
-  void put(const_value_type& tref) const {
-    put(&tref);
+  void put(const_value_type& tref) {
+    operator=(tref);
   }
 
   /**

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -240,7 +240,7 @@ public:
     );
   }
 
-  void put(const_value_type& tref) const {
+  void put(const_value_type& tref) {
     DASH_LOG_TRACE("GlobRef.put(T&)", "explicit put of provided ref");
     DASH_LOG_TRACE_VAR("GlobRef.T()", _gptr);
     dart_storage_t ds = dash::dart_storage<T>(1);
@@ -251,7 +251,7 @@ public:
     );
   }
 
-  void put(const_value_type* tptr) const {
+  void put(const_value_type* tptr) {
     DASH_LOG_TRACE("GlobRef.put(T*)", "explicit put of provided ptr");
     DASH_LOG_TRACE_VAR("GlobRef.T()", _gptr);
     dart_storage_t ds = dash::dart_storage<T>(1);

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -129,7 +129,7 @@ public:
   /**
    * Value-assignment operator.
    */
-  GlobRef<T> & operator=(const T val) {
+  self_t & operator=(const T val) {
     set(val);
     return *this;
   }
@@ -137,7 +137,7 @@ public:
   /**
    * Assignment operator.
    */
-  GlobRef<T> & operator=(const self_t & other)
+  self_t & operator=(const self_t & other)
   {
     set(static_cast<T>(other));
     return *this;
@@ -147,7 +147,7 @@ public:
    * Assignment operator.
    */
   template <typename GlobRefOrElementT>
-  GlobRef<T> & operator=(GlobRefOrElementT && other)
+  self_t & operator=(GlobRefOrElementT && other)
   {
     set(std::forward<GlobRefOrElementT>(other));
     return *this;
@@ -188,7 +188,7 @@ public:
     return !(*this == value);
   }
 
-  friend void swap(GlobRef<T> a, GlobRef<T> b) {
+  friend void swap(GlobRef<T> & a, GlobRef<T> & b) {
     nonconst_value_type temp = static_cast<nonconst_value_type>(a);
     a = b;
     b = temp;
@@ -262,7 +262,7 @@ public:
     );
   }
 
-  GlobRef<T> & operator+=(const nonconst_value_type& ref) {
+  self_t & operator+=(const nonconst_value_type& ref) {
   #if 0
     // TODO: Alternative implementation, possibly more efficient:
     T add_val = ref;
@@ -283,21 +283,21 @@ public:
     return *this;
   }
 
-  GlobRef<T> & operator-=(const nonconst_value_type& ref) {
+  self_t & operator-=(const nonconst_value_type& ref) {
     nonconst_value_type val  = operator nonconst_value_type();
     val   -= ref;
     operator=(val);
     return *this;
   }
 
-  GlobRef<T> & operator++() {
+  self_t & operator++() {
     nonconst_value_type val = operator nonconst_value_type();
     ++val;
     operator=(val);
     return *this;
   }
 
-  GlobRef<T> operator++(int) {
+  self_t operator++(int) {
     GlobRef<T> result = *this;
     nonconst_value_type val = operator nonconst_value_type();
     ++val;
@@ -305,14 +305,14 @@ public:
     return result;
   }
 
-  GlobRef<T> & operator--() {
+  self_t & operator--() {
     nonconst_value_type val = operator nonconst_value_type();
     --val;
     operator=(val);
     return *this;
   }
 
-  GlobRef<T> operator--(int) {
+  self_t operator--(int) {
     GlobRef<T> result = *this;
     nonconst_value_type val = operator nonconst_value_type();
     --val;
@@ -320,21 +320,21 @@ public:
     return result;
   }
 
-  GlobRef<T> & operator*=(const_value_type& ref) {
+  self_t & operator*=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   *= ref;
     operator=(val);
     return *this;
   }
 
-  GlobRef<T> & operator/=(const_value_type& ref) {
+  self_t & operator/=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   /= ref;
     operator=(val);
     return *this;
   }
 
-  GlobRef<T> & operator^=(const_value_type& ref) {
+  self_t & operator^=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   ^= ref;
     operator=(val);

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -35,14 +35,17 @@ class GlobRef
   template <
     typename ElementT >
   friend class GlobRef;
-  
+
   typedef typename std::remove_const<T>::type
     nonconst_value_type;
+
+  typedef typename std::add_const<T>::type
+    const_value_type;
 public:
   typedef T                 value_type;
 
   typedef GlobRef<const T>  const_type;
-  
+
 private:
   typedef GlobRef<T>
     self_t;
@@ -155,7 +158,10 @@ public:
     DASH_LOG_TRACE_VAR("GlobRef.T()", _gptr);
     nonconst_value_type t;
     dart_storage_t ds = dash::dart_storage<T>(1);
-    dart_get_blocking(static_cast<void *>(&t), _gptr, ds.nelem, ds.dtype);
+    DASH_ASSERT_RETURNS(
+      dart_get_blocking(static_cast<void *>(&t), _gptr, ds.nelem, ds.dtype),
+      DART_OK
+    );
     DASH_LOG_TRACE_VAR("GlobRef.T >", _gptr);
     return t;
   }
@@ -172,12 +178,12 @@ public:
     return !(*this == other);
   }
 
-  constexpr bool operator==(const nonconst_value_type & value) const noexcept
+  constexpr bool operator==(const_value_type & value) const
   {
     return static_cast<T>(*this) == value;
   }
 
-  constexpr bool operator!=(const nonconst_value_type & value) const noexcept
+  constexpr bool operator!=(const_value_type & value) const
   {
     return !(*this == value);
   }
@@ -188,14 +194,17 @@ public:
     b = temp;
   }
 
-  void set(const T & val) {
+  void set(const_value_type & val) {
     DASH_LOG_TRACE_VAR("GlobRef.set()", val);
     DASH_LOG_TRACE_VAR("GlobRef.set", _gptr);
     // TODO: Clarify if dart-call can be avoided if
     //       _gptr->is_local()
     dart_storage_t ds = dash::dart_storage<T>(1);
-    dart_put_blocking(
-        _gptr, static_cast<const void *>(&val), ds.nelem, ds.dtype);
+    DASH_ASSERT_RETURNS(
+      dart_put_blocking(
+        _gptr, static_cast<const void *>(&val), ds.nelem, ds.dtype),
+      DART_OK
+    );
     DASH_LOG_TRACE_VAR("GlobRef.set >", _gptr);
   }
 
@@ -204,7 +213,10 @@ public:
     DASH_LOG_TRACE_VAR("GlobRef.T()", _gptr);
     nonconst_value_type t;
     dart_storage_t ds = dash::dart_storage<T>(1);
-    dart_get_blocking(static_cast<void *>(&t), _gptr, ds.nelem, ds.dtype);
+    DASH_ASSERT_RETURNS(
+      dart_get_blocking(static_cast<void *>(&t), _gptr, ds.nelem, ds.dtype),
+      DART_OK
+    );
     return t;
   }
 
@@ -212,28 +224,42 @@ public:
     DASH_LOG_TRACE("GlobRef.get(T*)", "explicit get into provided ptr");
     DASH_LOG_TRACE_VAR("GlobRef.T()", _gptr);
     dart_storage_t ds = dash::dart_storage<T>(1);
-    dart_get_blocking(static_cast<void *>(tptr), _gptr, ds.nelem, ds.dtype);
+    DASH_ASSERT_RETURNS(
+      dart_get_blocking(static_cast<void *>(tptr), _gptr, ds.nelem, ds.dtype),
+      DART_OK
+    );
   }
 
   void get(nonconst_value_type& tref) const {
     DASH_LOG_TRACE("GlobRef.get(T&)", "explicit get into provided ref");
     DASH_LOG_TRACE_VAR("GlobRef.T()", _gptr);
     dart_storage_t ds = dash::dart_storage<T>(1);
-    dart_get_blocking(static_cast<void *>(&tref), _gptr, ds.nelem, ds.dtype);
+    DASH_ASSERT_RETURNS(
+      dart_get_blocking(static_cast<void *>(&tref), _gptr, ds.nelem, ds.dtype),
+      DART_OK
+    );
   }
 
-  void put(nonconst_value_type& tref) const {
+  void put(const_value_type& tref) const {
     DASH_LOG_TRACE("GlobRef.put(T&)", "explicit put of provided ref");
     DASH_LOG_TRACE_VAR("GlobRef.T()", _gptr);
     dart_storage_t ds = dash::dart_storage<T>(1);
-    dart_put_blocking(_gptr, static_cast<void *>(&tref), ds.nelem, ds.dtype);
+    DASH_ASSERT_RETURNS(
+      dart_put_blocking(
+          _gptr, static_cast<const void *>(&tref), ds.nelem, ds.dtype),
+      DART_OK
+    );
   }
 
-  void put(nonconst_value_type* tptr) const {
+  void put(const_value_type* tptr) const {
     DASH_LOG_TRACE("GlobRef.put(T*)", "explicit put of provided ptr");
     DASH_LOG_TRACE_VAR("GlobRef.T()", _gptr);
     dart_storage_t ds = dash::dart_storage<T>(1);
-    dart_put_blocking(_gptr, static_cast<void *>(tptr), ds.nelem, ds.dtype);
+    DASH_ASSERT_RETURNS(
+      dart_put_blocking(
+          _gptr, static_cast<const void *>(tptr), ds.nelem, ds.dtype),
+      DART_OK
+    );
   }
 
   GlobRef<T> & operator+=(const nonconst_value_type& ref) {
@@ -294,21 +320,21 @@ public:
     return result;
   }
 
-  GlobRef<T> & operator*=(const nonconst_value_type& ref) {
+  GlobRef<T> & operator*=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   *= ref;
     operator=(val);
     return *this;
   }
 
-  GlobRef<T> & operator/=(const nonconst_value_type& ref) {
+  GlobRef<T> & operator/=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   /= ref;
     operator=(val);
     return *this;
   }
 
-  GlobRef<T> & operator^=(const nonconst_value_type& ref) {
+  GlobRef<T> & operator^=(const_value_type& ref) {
     nonconst_value_type val = operator nonconst_value_type();
     val   ^= ref;
     operator=(val);

--- a/dash/test/iterator/GlobAsyncRefTest.cc
+++ b/dash/test/iterator/GlobAsyncRefTest.cc
@@ -81,6 +81,10 @@ TEST_F(GlobAsyncRefTest, GetSet) {
   ASSERT_EQ_U(static_cast<int>(garef), dash::myid().id);
   garef.flush();
   array.barrier();
+  garef.put(dash::myid());
+  ASSERT_EQ_U(static_cast<int>(garef), dash::myid().id);
+  garef.flush();
+  array.barrier();
   int left_neighbor = (dash::myid() + dash::size() - 1) % dash::size();
   ASSERT_EQ_U(left_neighbor, array.local[0]);
 }


### PR DESCRIPTION
Extends the interface of `dash::GlobAsyncRef` to match the interface of `dash::GlobRef`. Also fixes constness of `GlobRef` and adds checks for return values of DART functions. 

@fmoessbauer please review and let me know if any functionality is missing. 

See #357 