### PR TITLE
Fix IndexTypes in the typedefs for the BlockSpec_t and BlockSizeSpec_…

### DIFF
--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -85,9 +85,9 @@ private:
     MemoryLayout_t;
   typedef CartesianIndexSpace<NumDimensions, Arrangement, IndexType>
     LocalMemoryLayout_t;
-  typedef CartesianIndexSpace<NumDimensions, Arrangement, SizeType>
+  typedef CartesianIndexSpace<NumDimensions, Arrangement, IndexType>
     BlockSpec_t;
-  typedef CartesianIndexSpace<NumDimensions, Arrangement, SizeType>
+  typedef CartesianIndexSpace<NumDimensions, Arrangement, IndexType>
     BlockSizeSpec_t;
   typedef DistributionSpec<NumDimensions>
     DistributionSpec_t;


### PR DESCRIPTION
…t in TilePattern

Can be exercised by using the operator<< on these types.

Fixes #379.