### PR TITLE
Fix conditional jump on uninitialized data in `dart_exit`

### DIFF
--- a/dart-impl/base/src/internal/domain_locality.c
+++ b/dart-impl/base/src/internal/domain_locality.c
@@ -560,6 +560,7 @@ dart_ret_t dart__base__locality__domain__filter_subdomains(
         DART_ASSERT(subdomain_idx <= domain->num_domains);
         for (int sd = domain->num_domains; sd < subdomain_idx; sd++) {
           domain->children[sd] = malloc(sizeof(dart_domain_locality_t));
+          /* No dart__base__locality__domain__init(domain->children[sd])? */
         }
       } else {
         /* delete subdomains at rel. index > new number of subdomains:

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -135,18 +135,16 @@ dart_ret_t dart__base__locality__create(
   dart__base__locality__global_domain_[team] =
     team_global_domain;
 
+  DART_ASSERT_RETURNS(
+    dart__base__locality__domain__init(
+      team_global_domain),
+    DART_OK);
+
   /* Initialize the global domain as the root entry in the locality
    * hierarchy:
    */
   team_global_domain->scope          = DART_LOCALITY_SCOPE_GLOBAL;
-  team_global_domain->level          = 0;
-  team_global_domain->relative_index = 0;
   team_global_domain->team           = team;
-  team_global_domain->parent         = NULL;
-  team_global_domain->num_domains    = 0;
-  team_global_domain->children       = NULL;
-  team_global_domain->num_units      = 0;
-  team_global_domain->host[0]        = '\0';
   team_global_domain->domain_tag[0]  = '.';
   team_global_domain->domain_tag[1]  = '\0';
 


### PR DESCRIPTION
Fixes valgrind error in `dart_exit`:

```
==28232== Conditional jmp or move depends on uninitialised value(s)
==28232==    at 0x43595B: dart__base__locality__domain__destruct (domain_locality.c:131)
==28232==    by 0x4393B9: dart__base__locality__delete (locality.c:225)
==28232==    by 0x439186: dart__base__locality__finalize (locality.c:83)
==28232==    by 0x432BAE: dart__mpi__locality_finalize (dart_locality_priv.c:37)
==28232==    by 0x4322EA: dart_exit (dart_initialization.c:251)
==28232==    by 0x4176ED: dash::finalize() (Init.cc:92)
```