### PR TITLE
Unify `team()` getters regarding `const`.

### DIFF
--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -1127,7 +1127,7 @@ public:
    * \return  The instance of Team that this array has been instantiated
    *          with
    */
-  constexpr const Team & team() const noexcept
+  constexpr Team & team() const noexcept
   {
     return *m_team;
   }

--- a/dash/include/dash/List.h
+++ b/dash/include/dash/List.h
@@ -545,7 +545,7 @@ public:
    * \return  A reference to the Team containing the units associated with
    *          the container instance.
    */
-  constexpr const Team & team() const noexcept
+  constexpr Team & team() const noexcept
   {
     return *_team;
   }

--- a/dash/include/dash/Matrix.h
+++ b/dash/include/dash/Matrix.h
@@ -378,7 +378,7 @@ public:
    */
   void deallocate();
 
-  Team                      & team();
+  constexpr Team            & team()                const noexcept;
 
   constexpr size_type         size()                const noexcept;
   constexpr size_type         local_size()          const noexcept;

--- a/dash/include/dash/UnorderedMap.h
+++ b/dash/include/dash/UnorderedMap.h
@@ -232,7 +232,7 @@ public:
    * \return  A reference to the Team containing the units associated with
    *          the container instance.
    */
-  const Team & team() const noexcept;
+  constexpr Team & team() const noexcept;
 
   /**
    * Reference to instance of \c DashGlobalMemoryConcept used for underlying

--- a/dash/include/dash/list/ListRef.h
+++ b/dash/include/dash/list/ListRef.h
@@ -155,7 +155,7 @@ public:
                "dash::ListRef.front is not implemented");
   }
 
-  inline Team              & team();
+  inline Team              & team()             const noexcept;
 
   inline size_type           size()             const noexcept;
   inline size_type           local_size()       const noexcept;

--- a/dash/include/dash/map/UnorderedMap.h
+++ b/dash/include/dash/map/UnorderedMap.h
@@ -253,7 +253,7 @@ public:
   // Distributed container
   //////////////////////////////////////////////////////////////////////////
 
-  inline const Team & team() const noexcept
+  inline Team & team() const noexcept
   {
     if (_team != nullptr) {
       return *_team;

--- a/dash/include/dash/map/UnorderedMapLocalRef.h
+++ b/dash/include/dash/map/UnorderedMapLocalRef.h
@@ -108,7 +108,7 @@ public:
   // Distributed container
   //////////////////////////////////////////////////////////////////////////
 
-  inline const dash::Team & team() const noexcept
+  inline dash::Team & team() const noexcept
   {
     return _map->team();
   }

--- a/dash/include/dash/matrix/LocalMatrixRef.h
+++ b/dash/include/dash/matrix/LocalMatrixRef.h
@@ -181,7 +181,7 @@ public:
 
   inline    T                   & local_at(size_type pos);
 
-  constexpr const Team          & team()                const noexcept;
+  constexpr Team                & team()                const noexcept;
 
   constexpr size_type             size()                const noexcept;
   constexpr size_type             local_size()          const noexcept;

--- a/dash/include/dash/matrix/MatrixRef.h
+++ b/dash/include/dash/matrix/MatrixRef.h
@@ -164,7 +164,7 @@ public:
   MatrixRef<ElementT, NumDimensions, NumViewDim, PatternT>(
     const MatrixRef<T_, NumDimensions, NumViewDim, PatternT> & other);
 
-  constexpr const Team      & team()                const noexcept;
+  constexpr Team            & team()                const noexcept;
 
   constexpr size_type         size()                const noexcept;
   constexpr size_type         local_size()          const noexcept;

--- a/dash/include/dash/matrix/internal/Matrix-inl.h
+++ b/dash/include/dash/matrix/internal/Matrix-inl.h
@@ -264,8 +264,9 @@ void Matrix<T, NumDim, IndexT, PatternT>
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT>
-inline dash::Team & Matrix<T, NumDim, IndexT, PatternT>
-::team() {
+constexpr inline dash::Team & Matrix<T, NumDim, IndexT, PatternT>
+::team() const noexcept
+{
   return *_team;
 }
 

--- a/dash/include/dash/matrix/internal/MatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/MatrixRef-inl.h
@@ -49,7 +49,7 @@ MatrixRef<T, NumDim, CUR, PatternT>
 }
 
 template <typename T, dim_t NumDim, dim_t CUR, class PatternT>
-constexpr const Team &
+constexpr Team &
 MatrixRef<T, NumDim, CUR, PatternT>
 ::team() const noexcept
 {

--- a/dash/include/dash/util/TeamLocality.h
+++ b/dash/include/dash/util/TeamLocality.h
@@ -190,12 +190,7 @@ public:
     return _domain.num_cores();
   }
 
-  inline dash::Team & team()
-  {
-    return (nullptr == _team) ? dash::Team::Null() : *_team;
-  }
-
-  inline const dash::Team & team() const
+  inline dash::Team & team() const
   {
     return (nullptr == _team) ? dash::Team::Null() : *_team;
   }

--- a/dash/include/dash/util/UnitLocality.h
+++ b/dash/include/dash/util/UnitLocality.h
@@ -98,7 +98,7 @@ public:
     return *_unit_domain;
   }
 
-  inline const dash::Team & team()
+  inline const dash::Team & team() const
   {
     if (nullptr == _team) {
       return dash::Team::Null();


### PR DESCRIPTION
This does not tackle `constexpr`and `noexcept` consistently. And `UnitLocality.h` has a `const Team*` member and therefore also a `const Team&` argument in the constructor, thus can not have a `Team & team() const` member but only a `const Team & team() const` one.

See #385.