### PR TITLE
Feat 389 array move

### DIFF
--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -168,6 +168,12 @@ public:
     _viewspec(viewspec)
   { }
 
+  LocalArrayRef(const self_t &) = delete;
+  LocalArrayRef(self_t &&)      = default;
+
+  self_t & operator=(const self_t &) = delete;
+  self_t & operator=(self_t &&)      = default;
+
   /**
    * Pointer to initial local element in the array.
    */
@@ -245,9 +251,9 @@ public:
 
 private:
   /// Pointer to array instance referenced by this view.
-  const Array_t * const _array;
+  const Array_t * _array;
   /// The view's offset and extent within the referenced array.
-  ViewSpec_t            _viewspec;
+  ViewSpec_t      _viewspec;
 };
 
 #ifndef DOXYGEN
@@ -292,7 +298,7 @@ public:
   }
 
 private:
-  Array<T, IndexType, PatternType> * const _array;
+  Array<T, IndexType, PatternType> * _array;
 
 public:
   /**
@@ -302,6 +308,13 @@ public:
     Array<T, IndexType, PatternType> * const array)
   : _array(array) {
   }
+
+  AsyncArrayRef(const self_t &) = delete;
+  AsyncArrayRef(self_t &&)      = default;
+
+  self_t & operator=(const self_t &) = delete;
+  self_t & operator=(self_t &&)      = default;
+
 
   /**
    * Pointer to initial local element in the array.
@@ -700,6 +713,8 @@ private:
     DistributionSpec_t;
   typedef SizeSpec<1, size_type>
     SizeSpec_t;
+  typedef std::unique_ptr<glob_mem_type>
+    PtrGlobMemType_t;
 
 public:
   /// Local proxy object, allows use in range-based for loops.
@@ -715,7 +730,7 @@ private:
   /// Element distribution pattern
   PatternType          m_pattern;
   /// Global memory allocation and -access
-  glob_mem_type      * m_globmem   = nullptr;
+  PtrGlobMemType_t     m_globmem;
   /// Iterator to initial element in the array
   iterator             m_begin;
   /// Iterator to final element in the array
@@ -884,7 +899,14 @@ public:
    */
   Array(const self_t & other) = delete;
 
-  Array(self_t && other)      = delete;
+  /**
+   * Move construction is supported for the container with the following
+   * limitations:
+   *
+   * The pattern has to be movable or copyable
+   * The underlying memory does not have to be movable (it might).
+   */
+  Array(self_t && other)      = default;
 
   /**
    * Assignment operator is deleted to prevent unintentional copies of
@@ -906,7 +928,14 @@ public:
    */
   self_t & operator=(const self_t & rhs) = delete;
 
-  self_t & operator=(self_t && other)    = delete;
+  /**
+   * Move assignment is supported for the container with the following
+   * limitations:
+   *
+   * The pattern has to be movable or copyable
+   * The underlying memory does not have to be movable (it might).
+   */
+  self_t & operator=(self_t && other)    = default;
 
   /**
    * Destructor, deallocates array elements.
@@ -1297,8 +1326,7 @@ public:
     // Actual destruction of the array instance:
     DASH_LOG_TRACE_VAR("Array.deallocate()", m_globmem);
     if (m_globmem != nullptr) {
-      delete m_globmem;
-      m_globmem = nullptr;
+      m_globmem.reset();
     }
     m_size = 0;
     DASH_LOG_TRACE_VAR("Array.deallocate >", this);
@@ -1328,9 +1356,9 @@ public:
     // Allocate local memory of identical size on every unit:
     DASH_LOG_TRACE_VAR("Array._allocate", m_lcapacity);
     DASH_LOG_TRACE_VAR("Array._allocate", m_lsize);
-    m_globmem   = new glob_mem_type(m_lcapacity, *m_team);
+    m_globmem   = PtrGlobMemType_t(new glob_mem_type(m_lcapacity, *m_team));
     // Global iterators:
-    m_begin     = iterator(m_globmem, m_pattern);
+    m_begin     = iterator(m_globmem.get(), m_pattern);
     m_end       = iterator(m_begin) + m_size;
     // Local iterators:
     m_lbegin    = m_globmem->lbegin();
@@ -1378,9 +1406,9 @@ private:
     // Allocate local memory of identical size on every unit:
     DASH_LOG_TRACE_VAR("Array._allocate", m_lcapacity);
     DASH_LOG_TRACE_VAR("Array._allocate", m_lsize);
-    m_globmem   = new glob_mem_type(local_elements, *m_team);
+    m_globmem   = PtrGlobMemType_t(new glob_mem_type(local_elements, *m_team));
     // Global iterators:
-    m_begin     = iterator(m_globmem, pattern);
+    m_begin     = iterator(m_globmem.get(), pattern);
     m_end       = iterator(m_begin) + m_size;
     // Local iterators:
     m_lbegin    = m_globmem->lbegin();

--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -168,10 +168,10 @@ public:
     _viewspec(viewspec)
   { }
 
-  LocalArrayRef(const self_t &) = delete;
+  LocalArrayRef(const self_t &) = default;
   LocalArrayRef(self_t &&)      = default;
 
-  self_t & operator=(const self_t &) = delete;
+  self_t & operator=(const self_t &) = default;
   self_t & operator=(self_t &&)      = default;
 
   /**
@@ -309,10 +309,10 @@ public:
   : _array(array) {
   }
 
-  AsyncArrayRef(const self_t &) = delete;
+  AsyncArrayRef(const self_t &) = default;
   AsyncArrayRef(self_t &&)      = default;
 
-  self_t & operator=(const self_t &) = delete;
+  self_t & operator=(const self_t &) = default;
   self_t & operator=(self_t &&)      = default;
 
 

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -106,7 +106,7 @@ private:
   // Size of the local section at the current position of this pointer
   index_type          _lsize       = 0;
   // Unit id of last unit in referenced global memory space
-  dart_team_unit_t    _unit_end    = 0;
+  dart_team_unit_t    _unit_end{0};
 protected:
   /**
    * Constructor, specifies underlying global address.

--- a/dash/include/dash/memory/GlobStaticMem.h
+++ b/dash/include/dash/memory/GlobStaticMem.h
@@ -238,7 +238,10 @@ public:
   ~GlobStaticMem()
   {
     DASH_LOG_TRACE_VAR("GlobStaticMem.~GlobStaticMem()", _begptr);
-    _allocator.deallocate(_begptr);
+    // check if has been moved away
+    if(!DART_GPTR_ISNULL(_begptr)){
+      _allocator.deallocate(_begptr);
+    }
     DASH_LOG_TRACE("GlobStaticMem.~GlobStaticMem >");
   }
 
@@ -246,13 +249,64 @@ public:
    * Copy constructor.
    */
   GlobStaticMem(const self_t & other)
-    = default;
+    = delete;
 
   /**
-   * Assignment operator.
+   * Move constructor
+   *
+   * \TODO make move constructor defaultable by using RAII 
+   */
+  GlobStaticMem(self_t && other)
+  : _allocator(std::move(other._allocator)),
+    _begptr(other._begptr),
+    _team(other._team),
+    _teamid(other._teamid),
+    _nunits(other._nunits),
+    _myid(other._myid),
+    _nlelem(other._nlelem),
+    _lbegin(other._lbegin),
+    _lend(other._lend)
+  {
+    // avoid deallocation of underlying memory
+    // in the dead hull
+    other._begptr = DART_GPTR_NULL;
+    other._lbegin = nullptr;
+    other._lend   = nullptr;
+  }
+
+  /**
+   * Copy-assignment operator.
+   *
+   * \TODO make move constructor defaultable by using RAII 
    */
   self_t & operator=(const self_t & rhs)
-    = default;
+    = delete;
+
+  /**
+   * Move-assignment operator.
+   */
+  self_t & operator=(self_t && other) {
+    // deallocate old memory
+    if(!DART_GPTR_ISNULL(_begptr)){
+      _allocator.deallocate(_begptr);
+    }
+
+    _allocator = std::move(other._allocator);
+    _begptr = other._begptr;
+    _team = other._team;
+    _teamid = other._teamid;
+    _nunits = other._nunits;
+    _myid = other._myid;
+    _nlelem = other._nlelem;
+    _lbegin = other._lbegin;
+    _lend = other._lend;
+
+    // avoid deallocation of underlying memory
+    // in the dead hull
+    other._begptr = DART_GPTR_NULL;
+    other._lbegin = nullptr;
+    other._lend   = nullptr;
+  }
 
   /**
    * Equality comparison operator.

--- a/dash/include/dash/memory/GlobStaticMem.h
+++ b/dash/include/dash/memory/GlobStaticMem.h
@@ -307,6 +307,8 @@ public:
     other._begptr = DART_GPTR_NULL;
     other._lbegin = nullptr;
     other._lend   = nullptr;
+
+    return *this;
   }
 
   /**

--- a/dash/include/dash/memory/GlobStaticMem.h
+++ b/dash/include/dash/memory/GlobStaticMem.h
@@ -277,13 +277,14 @@ public:
   /**
    * Copy-assignment operator.
    *
-   * \TODO make move constructor defaultable by using RAII 
    */
   self_t & operator=(const self_t & rhs)
     = delete;
 
   /**
    * Move-assignment operator.
+   *
+   * \TODO make move constructor defaultable by using RAII 
    */
   self_t & operator=(self_t && other) {
     // deallocate old memory
@@ -292,14 +293,14 @@ public:
     }
 
     _allocator = std::move(other._allocator);
-    _begptr = other._begptr;
-    _team = other._team;
-    _teamid = other._teamid;
-    _nunits = other._nunits;
-    _myid = other._myid;
-    _nlelem = other._nlelem;
-    _lbegin = other._lbegin;
-    _lend = other._lend;
+    _begptr    = other._begptr;
+    _team      = other._team;
+    _teamid    = other._teamid;
+    _nunits    = other._nunits;
+    _myid      = other._myid;
+    _nlelem    = other._nlelem;
+    _lbegin    = other._lbegin;
+    _lend      = other._lend;
 
     // avoid deallocation of underlying memory
     // in the dead hull

--- a/dash/src/Init.cc
+++ b/dash/src/Init.cc
@@ -52,6 +52,7 @@ void dash::init(int * argc, char ** *argv)
   dash::_initialized = true;
 
   if (dash::util::Config::get<bool>("DASH_INIT_BREAKPOINT")) {
+    DASH_LOG_DEBUG("Process ID", getpid());
     if (dash::myid() == 0) {
       int blockvar = 1;
       dash::prevent_opt_elimination(blockvar);

--- a/dash/test/container/ArrayTest.cc
+++ b/dash/test/container/ArrayTest.cc
@@ -230,3 +230,44 @@ TEST_F(ArrayTest, TeamSplit)
   team_all.barrier();
 }
 
+TEST_F(ArrayTest, MoveSemantics){
+  using array_t = dash::Array<double>;
+  // move construction
+  {
+    array_t array_a(10);
+
+    *(array_a.lbegin()) = 5;
+    dash::barrier();
+
+    array_t array_b(std::move(array_a));
+    int value = *(array_b.lbegin());
+    ASSERT_EQ_U(value, 5);
+  }
+  dash::barrier();
+  //move assignment
+  {
+    array_t array_a(10);
+    {
+      array_t array_b(8);
+
+      *(array_a.lbegin()) = 1;
+      *(array_b.lbegin()) = 2;
+      array_a = std::move(array_b);
+      // leave scope of array_b
+    }
+    ASSERT_EQ_U(*(array_a.lbegin()), 2);
+  }
+  dash::barrier();
+  // swap
+  {
+    array_t array_a(10);
+    array_t array_b(8);
+
+    *(array_a.lbegin()) = 1;
+    *(array_b.lbegin()) = 2;
+
+    std::swap(array_a, array_b);
+    ASSERT_EQ_U(*(array_a.lbegin()), 2);
+    ASSERT_EQ_U(*(array_b.lbegin()), 1);
+  }
+}


### PR DESCRIPTION
This PR implements move semantic for `dash::GlobStaticMem` and `dash::Array`, as proposed in #389. The changes are implemented in a way that benefits from RAII. Hence, the move constructors for the containers can be defaulted in the future.