### PR TITLE
updated openmpi to 2.1.1. Temporary use only mpich and openmpi2 in CI…

### DIFF
--- a/dash/scripts/circleci/pull-docker.sh
+++ b/dash/scripts/circleci/pull-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MPIENVS=(mpich openmpi)
+MPIENVS=(mpich openmpi2)
 
 # build docker containers
 

--- a/dash/scripts/circleci/run-docker.sh
+++ b/dash/scripts/circleci/run-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MPIENVS=(mpich openmpi)
+MPIENVS=(mpich openmpi2)
 BUILD_CONFIG=$1
 COMPILER=$2
 MAKE_PROCS=4

--- a/dash/scripts/docker-testing/openmpi2/dockerfile
+++ b/dash/scripts/docker-testing/openmpi2/dockerfile
@@ -11,7 +11,8 @@ RUN           apt-get update -y    \
                   cmake            \
                   uuid-runtime     \
                   libhwloc-plugins \
-                  libhwloc-dev
+                  libhwloc-dev     \
+                  clang-3.8
 
 # Install PAPI from source
 WORKDIR       /tmp

--- a/dash/scripts/docker-testing/openmpi2/dockerfile
+++ b/dash/scripts/docker-testing/openmpi2/dockerfile
@@ -25,8 +25,8 @@ RUN           cd papi*/src/                     \
               && make                           \
               && make install
 
-# Openmpi 2.0
-ADD           https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz ompi.tgz
+# Openmpi 2.1
+ADD           https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.gz ompi.tgz
 RUN           tar -xf ompi.tgz
 RUN           cd openmpi*                         \
            && ./configure --prefix=/opt/openmpi   \

--- a/dash/scripts/docker-testing/openmpi2_vg/dockerfile
+++ b/dash/scripts/docker-testing/openmpi2_vg/dockerfile
@@ -29,8 +29,8 @@ RUN           cd valgrind-3*                        \
 ENV           VALGRIND_BASE=/opt/valgrind
 ENV           PATH=${PATH}:${VALGRIND_BASE}/bin
 
-# Openmpi 2.0
-ADD           https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz ompi.tgz
+# Openmpi 2.1
+ADD           https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.gz ompi.tgz
 RUN           tar -xf ompi.tgz
 RUN           cd openmpi*                                     \
               && ./configure --prefix=/opt/openmpi            \


### PR DESCRIPTION
… (instead of openmpi 1)

After merging this PR, the build settings on hub.docker.com have to be set to branch development again. Propably a re-run of the CI is necessary.