### PR TITLE
DART: construct correct sharedmem mapping table

### DIFF
--- a/dart-impl/mpi/src/dart_initialization.c
+++ b/dart-impl/mpi/src/dart_initialization.c
@@ -51,10 +51,6 @@ dart_ret_t do_init()
 
   dart_team_data_t *team_data = dart_adapt_teamlist_get(DART_TEAM_ALL);
 
-  /* Create a global translation table for all
-   * the collective global memory segments */
-  dart_segment_init(&team_data->segdata, DART_TEAM_ALL);
-
   dart_next_availteamid++;
 
   team_data->comm = DART_COMM_WORLD;

--- a/dart-impl/mpi/src/dart_team_private.c
+++ b/dart-impl/mpi/src/dart_team_private.c
@@ -260,7 +260,7 @@ dart_ret_t dart_allocate_shared_comm(dart_team_data_t *team_data)
 {
   int size;
 
-  MPI_Comm_size(DART_COMM_WORLD, &size);
+  MPI_Comm_size(team_data->comm, &size);
 
   MPI_Comm sharedmem_comm;
   MPI_Group sharedmem_group, group_all;
@@ -281,7 +281,7 @@ dart_ret_t dart_allocate_shared_comm(dart_team_data_t *team_data)
   // dart_sharedmem_size[index] * sizeof (int));
 
     MPI_Comm_group(sharedmem_comm, &sharedmem_group);
-    MPI_Comm_group(DART_COMM_WORLD, &group_all);
+    MPI_Comm_group(team_data->comm, &group_all);
 
     int * dart_unit_mapping  = malloc(
         team_data->sharedmem_nodesize * sizeof(int));


### PR DESCRIPTION
Use current team's communicator instead of DART_COMM_WORLD.

Thanks to @HuanZhou2 for the discovery. 