### PR TITLE
fixed argc and argv not being set in tests

### DIFF
--- a/dash/test/TestBase.h
+++ b/dash/test/TestBase.h
@@ -249,7 +249,7 @@ class TestBase : public ::testing::Test {
       ::testing::UnitTest::GetInstance()->current_test_info();
     LOG_MESSAGE("===> Running test case %s.%s ...",
                 test_info->test_case_name(), test_info->name());
-    dash::init(&TESTENV.argc, &TESTENV.argv);
+    dash::init(&TESTENV::argc, &TESTENV::argv);
     
     LOG_MESSAGE("-==- DASH initialized with %lu units", dash::size());
     dash::barrier();

--- a/dash/test/TestGlobals.h
+++ b/dash/test/TestGlobals.h
@@ -2,9 +2,10 @@
 #define DASH__TEST__TEST_GLOBALS_H_
 
 // store program arguments to pass to dash::init
-static struct testenv_t {
-  int     argc;
-  char ** argv;
-} TESTENV;
+class TESTENV {
+public:
+  static int     argc;
+  static char ** argv;
+};
 
 #endif // DASH__TEST__TEST_GLOBALS_H_

--- a/dash/test/main.cc
+++ b/dash/test/main.cc
@@ -15,14 +15,16 @@
 using ::testing::UnitTest;
 using ::testing::TestEventListeners;
 
+int     TESTENV::argc;
+char ** TESTENV::argv;
 
 int main(int argc, char * argv[])
 {
   char hostname[100];
   int team_myid = -1;
   int team_size = -1;
-  TESTENV.argc = argc;
-  TESTENV.argv = argv;
+  TESTENV::argc = argc;
+  TESTENV::argv = argv;
 
   gethostname(hostname, 100);
   std::string host(hostname);


### PR DESCRIPTION
The problems in PR #406 related to missing argc and argv are due to a erroneous declarations of the global variable `TESTENV`. Hence, each translation unit got it own global state.