### PR TITLE
Fixes in Matrix, Array, GlobRef

### DIFF
--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -765,6 +765,7 @@ public:
    * Sets the associated team to DART_TEAM_NULL for global array instances
    * that are declared before \c dash::Init().
    */
+  explicit
   Array(
     Team & team = dash::Team::Null())
   : local(this),
@@ -810,6 +811,7 @@ public:
   /**
    * Delegating constructor, specifies the array's global capacity.
    */
+  explicit
   Array(
     size_type   nelem,
     Team      & team = dash::Team::All())
@@ -864,6 +866,7 @@ public:
   /**
    * Constructor, specifies distribution pattern explicitly.
    */
+  explicit
   Array(
     const PatternType & pattern)
   : local(this),
@@ -1270,6 +1273,18 @@ public:
     bool ret = allocate(m_pattern);
     DASH_LOG_TRACE("Array.allocate(nlocal,ds,team) >");
     return ret;
+  }
+
+
+  /**
+   * Delayed allocation of global memory using the default blocked
+   * distribution spec.
+   */
+  bool allocate(
+    size_type   nelem,
+    Team      & team = dash::Team::All())
+  {
+    return allocate(nelem, dash::BLOCKED, team);
   }
 
   /**

--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -673,7 +673,9 @@ public:
   typedef GlobIter<      value_type, PatternType>                    pointer;
   typedef GlobIter<const value_type, PatternType>              const_pointer;
 
-  typedef dash::GlobStaticMem<value_type>                            glob_mem_type;
+  typedef dash::GlobStaticMem<value_type>                      glob_mem_type;
+
+  typedef DistributionSpec<1>                              distribution_spec;
 
 public:
   template<
@@ -709,8 +711,6 @@ public:
   }
 
 private:
-  typedef DistributionSpec<1>
-    DistributionSpec_t;
   typedef SizeSpec<1, size_type>
     SizeSpec_t;
   typedef std::unique_ptr<glob_mem_type>
@@ -773,7 +773,7 @@ public:
     m_team(&team),
     m_pattern(
       SizeSpec_t(0),
-      DistributionSpec_t(dash::BLOCKED),
+      distribution_spec(dash::BLOCKED),
       team),
     m_globmem(nullptr),
     m_size(0),
@@ -790,7 +790,7 @@ public:
    */
   Array(
     size_type                  nelem,
-    const DistributionSpec_t & distribution,
+    const distribution_spec  & distribution,
     Team                     & team = dash::Team::All())
   : local(this),
     async(this),
@@ -828,7 +828,7 @@ public:
   Array(
     size_type                           nelem,
     std::initializer_list<value_type>   local_elements,
-    const DistributionSpec_t          & distribution,
+    const distribution_spec           & distribution,
     Team                              & team = dash::Team::All())
   : local(this),
     async(this),

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -308,11 +308,25 @@ public:
     return *this;
   }
 
+  nonconst_value_type operator++(int) {
+    nonconst_value_type val = operator nonconst_value_type();
+    nonconst_value_type result = val++;
+    operator=(val);
+    return result;
+  }
+
   self_t & operator--() {
     nonconst_value_type val = operator nonconst_value_type();
     --val;
     operator=(val);
     return *this;
+  }
+
+  nonconst_value_type operator--(int) {
+    nonconst_value_type val = operator nonconst_value_type();
+    nonconst_value_type result = val--;
+    operator=(val);
+    return result;
   }
 
   self_t & operator*=(const_value_type& ref) {

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -308,27 +308,11 @@ public:
     return *this;
   }
 
-  self_t operator++(int) {
-    GlobRef<T> result = *this;
-    nonconst_value_type val = operator nonconst_value_type();
-    ++val;
-    operator=(val);
-    return result;
-  }
-
   self_t & operator--() {
     nonconst_value_type val = operator nonconst_value_type();
     --val;
     operator=(val);
     return *this;
-  }
-
-  self_t operator--(int) {
-    GlobRef<T> result = *this;
-    nonconst_value_type val = operator nonconst_value_type();
-    --val;
-    operator=(val);
-    return result;
   }
 
   self_t & operator*=(const_value_type& ref) {

--- a/dash/include/dash/List.h
+++ b/dash/include/dash/List.h
@@ -279,7 +279,7 @@ public:
    * Sets the associated team to DART_TEAM_NULL for global list instances
    * that are declared before \c dash::Init().
    */
-  List(
+  explicit List(
     Team & team = dash::Team::Null())
   : local(this),
     _team(&team),
@@ -293,7 +293,7 @@ public:
    * Constructor, creates a new constainer instance with the specified
    * initial global container capacity and associated units.
    */
-  List(
+  explicit List(
     size_type   nelem = 0,
     Team      & team  = dash::Team::All())
   : local(this),

--- a/dash/include/dash/Matrix.h
+++ b/dash/include/dash/Matrix.h
@@ -274,12 +274,14 @@ public:
    * Sets the associated team to DART_TEAM_NULL for global matrix instances
    * that are declared before \ref dash::Init().
    */
+  explicit
   Matrix(
     Team & team = dash::Team::Null());
 
   /**
    * Constructor, creates a new instance of Matrix.
    */
+  explicit
   Matrix(
     const SizeSpec_t         & ss,
     const DistributionSpec_t & ds  = DistributionSpec_t(),
@@ -289,12 +291,14 @@ public:
   /**
    * Constructor, creates a new instance of Matrix from a pattern instance.
    */
+  explicit
   Matrix(
     const PatternT & pat);
 
   /**
    * Constructor, creates a new instance of Matrix.
    */
+  explicit
   Matrix(
     /// Number of elements
     size_t nelem,
@@ -369,6 +373,18 @@ public:
   bool allocate(
     const PatternT & pattern
   );
+
+
+  /**
+   * Allocation and distribution of matrix elements as specified by given
+   * extents. See variadic constructor.
+   */
+  template<typename... Args>
+  bool
+  allocate(SizeType arg, Args... args)
+  {
+    return allocate(PatternT(arg, args... ));
+  }
 
   /**
    * Explicit deallocation of matrix elements, called implicitly in

--- a/dash/include/dash/Matrix.h
+++ b/dash/include/dash/Matrix.h
@@ -158,16 +158,6 @@ private:
     Pattern_t;
   typedef GlobStaticMem<ElementT, dash::allocator::SymmetricAllocator<ElementT>>
     GlobMem_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef SizeSpec<NumDimensions, typename PatternT::size_type>
-    SizeSpec_t;
-  typedef TeamSpec<NumDimensions, typename PatternT::index_type>
-    TeamSpec_t;
-  typedef std::array<typename PatternT::size_type, NumDimensions>
-    Extents_t;
-  typedef std::array<typename PatternT::index_type, NumDimensions>
-    Offsets_t;
 
 public:
   template<
@@ -204,6 +194,17 @@ public:
   typedef       ElementT *                                   local_pointer;
   typedef const ElementT *                             const_local_pointer;
 
+  typedef DistributionSpec<NumDimensions>                distribution_spec;
+  typedef SizeSpec<NumDimensions, typename PatternT::size_type>
+    size_spec;
+  typedef TeamSpec<NumDimensions, typename PatternT::index_type>
+    team_spec;
+  typedef std::array<typename PatternT::size_type, NumDimensions>
+    extents_type;
+  typedef std::array<typename PatternT::index_type, NumDimensions>
+    offsets_type;
+
+
 // Public types as required by dash container concept
 public:
   /// Type specifying the view on local matrix elements.
@@ -231,6 +232,9 @@ public:
   template <dim_t NumViewDim>
     using const_view_type =
           MatrixRef<const ElementT, NumDimensions, NumViewDim, PatternT>;
+
+// public types exposed in Matrix interface
+public:
 
 public:
   /// Local view proxy object.
@@ -283,10 +287,10 @@ public:
    */
   explicit
   Matrix(
-    const SizeSpec_t         & ss,
-    const DistributionSpec_t & ds  = DistributionSpec_t(),
-    Team                     & t   = dash::Team::All(),
-    const TeamSpec_t         & ts  = TeamSpec_t());
+    const size_spec         & ss,
+    const distribution_spec & ds  = distribution_spec(),
+    Team                    & t   = dash::Team::All(),
+    const team_spec         & ts  = team_spec());
 
   /**
    * Constructor, creates a new instance of Matrix from a pattern instance.
@@ -360,10 +364,10 @@ public:
    * \see  DashContainerConcept
    */
   bool allocate(
-    const SizeSpec_t         & sizespec,
-    const DistributionSpec_t & distribution,
-    const TeamSpec_t         & teamspec,
-    dash::Team               & team = dash::Team::All()
+    const size_spec         & sizespec,
+    const distribution_spec & distribution,
+    const team_spec         & teamspec,
+    dash::Team              & team = dash::Team::All()
   );
 
   /**
@@ -400,9 +404,9 @@ public:
   constexpr size_type         local_size()          const noexcept;
   constexpr size_type         local_capacity()      const noexcept;
   constexpr size_type         extent(dim_t dim)     const noexcept;
-  constexpr Extents_t         extents()             const noexcept;
+  constexpr extents_type      extents()             const noexcept;
   constexpr index_type        offset(dim_t dim)     const noexcept;
-  constexpr Offsets_t         offsets()             const noexcept;
+  constexpr offsets_type      offsets()             const noexcept;
   constexpr bool              empty()               const noexcept;
 
   /**

--- a/dash/include/dash/iterator/GlobViewIter.h
+++ b/dash/include/dash/iterator/GlobViewIter.h
@@ -1091,7 +1091,7 @@ std::ostream & operator<<(
           ElementType, Pattern, GlobStaticMem, Pointer, Reference> & it)
 {
   std::ostringstream ss;
-  dash::GlobPtr<ElementType, GlobStaticMem> ptr(it);
+  Pointer ptr(it.globmem(), it.dart_gptr());
   ss << "dash::GlobViewIter<" << typeid(ElementType).name() << ">("
      << "idx:"  << it._idx << ", "
      << "gptr:" << ptr << ")";

--- a/dash/include/dash/map/UnorderedMap.h
+++ b/dash/include/dash/map/UnorderedMap.h
@@ -209,6 +209,7 @@ public:
   local_type local;
 
 public:
+  explicit
   UnorderedMap(
     size_type   nelem = 0,
     Team      & team  = dash::Team::All())

--- a/dash/include/dash/matrix/internal/Matrix-inl.h
+++ b/dash/include/dash/matrix/internal/Matrix-inl.h
@@ -29,8 +29,8 @@ inline Matrix<T, NumDim, IndexT, PatternT>
   _lsize(0),
   _lcapacity(0),
   _pattern(
-    SizeSpec_t(),
-    DistributionSpec_t(),
+    size_spec(),
+    distribution_spec(),
     *_team),
   _glob_mem(nullptr),
   _lbegin(nullptr),
@@ -42,10 +42,10 @@ inline Matrix<T, NumDim, IndexT, PatternT>
 template <typename T, dim_t NumDim, typename IndexT, class PatternT>
 inline Matrix<T, NumDim, IndexT, PatternT>
 ::Matrix(
-  const SizeSpec_t & ss,
-  const DistributionSpec_t & ds,
+  const size_spec & ss,
+  const distribution_spec & ds,
   Team & t,
-  const TeamSpec_t & ts)
+  const team_spec & ts)
 : _team(&t),
   _size(0),
   _lsize(0),

--- a/dash/test/container/MatrixTest.cc
+++ b/dash/test/container/MatrixTest.cc
@@ -964,6 +964,20 @@ TEST_F(MatrixTest, DelayedAlloc)
       }
     }
   }
+
+
+  // re-allocate to test variadic allocate
+  mx.deallocate();
+
+  mx.allocate(
+    extent_i,
+    extent_j,
+    extent_k,
+    num_units_i < 2 ? dash::NONE : dash::TILE(tilesize_i),
+    num_units_j < 2 ? dash::NONE : dash::TILE(tilesize_j),
+    num_units_k < 2 ? dash::NONE : dash::TILE(tilesize_k),
+    teamspec
+  );
 }
 
 TEST_F(MatrixTest, PatternScope)

--- a/dash/test/memory/GlobStaticMemTest.cc
+++ b/dash/test/memory/GlobStaticMemTest.cc
@@ -2,8 +2,6 @@
 #include "GlobStaticMemTest.h"
 
 #include <dash/memory/GlobStaticMem.h>
-#include <dash/GlobRef.h>
-#include <dash/GlobPtr.h>
 
 
 TEST_F(GlobStaticMemTest, ConstructorInitializerList)

--- a/dash/test/memory/LocalAllocatorTest.cc
+++ b/dash/test/memory/LocalAllocatorTest.cc
@@ -3,7 +3,6 @@
 
 #include <dash/allocator/LocalAllocator.h>
 #include <dash/GlobPtr.h>
-#include <dash/GlobRef.h>
 #include <dash/Pattern.h>
 
 TEST_F(LocalAllocatorTest, Constructor)

--- a/dash/test/memory/SymmetricAllocatorTest.cc
+++ b/dash/test/memory/SymmetricAllocatorTest.cc
@@ -3,7 +3,6 @@
 
 #include <dash/allocator/SymmetricAllocator.h>
 #include <dash/GlobPtr.h>
-#include <dash/GlobRef.h>
 #include <dash/Pattern.h>
 
 TEST_F(SymmetricAllocatorTest, Constructor)

--- a/dash/test/types/GlobRefTest.cc
+++ b/dash/test/types/GlobRefTest.cc
@@ -42,4 +42,16 @@ TEST_F(GlobRefTest, ArithmeticOps)
 
   gref -= 1;
   ASSERT_EQ_U(gref, 1);
+
+  // postfix increment
+  value_t prev = gref++;
+  ASSERT_EQ_U(prev, 1);
+  ASSERT_EQ_U(gref, 2);
+
+
+  // postfix increment
+  prev = gref--;
+  ASSERT_EQ_U(prev, 2);
+  ASSERT_EQ_U(gref, 1);
+
 }

--- a/dash/test/types/GlobRefTest.cc
+++ b/dash/test/types/GlobRefTest.cc
@@ -1,0 +1,45 @@
+
+#include "../TestBase.h"
+#include "../TestLogHelpers.h"
+#include "GlobRefTest.h"
+
+#include <dash/Array.h>
+#include <dash/algorithm/Fill.h>
+#include <dash/algorithm/Copy.h>
+
+
+TEST_F(GlobRefTest, ArithmeticOps)
+{
+  using value_t = int;
+  dash::Array<value_t> arr(dash::size());
+  int neighbor = (dash::myid() + 1) % dash::size();
+  dash::GlobRef<value_t> gref = arr[neighbor];
+
+  // assignment
+  gref = 0;
+  ASSERT_EQ_U(gref, 0);
+
+  // prefix increment
+  ++gref;
+  ASSERT_EQ_U(gref, 1);
+
+  ++(++gref);
+  ASSERT_EQ_U(gref, 3);
+
+  // prefix decrement
+  --(--gref);
+  ASSERT_EQ_U(gref, 1);
+
+  // unary operations
+  gref *= 2;
+  ASSERT_EQ_U(gref, 2);
+
+  gref /= 2;
+  ASSERT_EQ_U(gref, 1);
+
+  gref += 1;
+  ASSERT_EQ_U(gref, 2);
+
+  gref -= 1;
+  ASSERT_EQ_U(gref, 1);
+}

--- a/dash/test/types/GlobRefTest.h
+++ b/dash/test/types/GlobRefTest.h
@@ -1,0 +1,24 @@
+#ifndef DASH__TEST__GLOBREF_TEST_H_
+#define DASH__TEST__GLOBREF_TEST_H_
+
+#include <gtest/gtest.h>
+
+#include "../TestBase.h"
+
+
+/**
+ * Test fixture for \c dash::GlobRef.
+ */
+class GlobRefTest : public dash::test::TestBase {
+protected:
+  size_t _dash_id    = 0;
+  size_t _dash_size  = 0;
+
+  virtual void SetUp() {
+    dash::test::TestBase::SetUp();
+    _dash_id   = dash::myid();
+    _dash_size = dash::size();
+  }
+};
+
+#endif // DASH__TEST__GLOBREF_TEST_H_


### PR DESCRIPTION
This PR fixes some issues I came across recently, some of which are documented in #412. 

- Fix postfix increment/decrement operators in `GlobRef` to return the value type and keep postfix semantics
- Add test case for GlobRef arithmetic operations
- Make publicly exposed types in Matrix and Array public
- Fix `operator<<` on `GlobViewIter`
- Add a variadic version of `allocate()` to Matrix and Array to provide a similar interface as the constructors.