### PR TITLE
Fixes to [Local]MatrixRef

### DIFF
--- a/dash/include/dash/matrix/LocalMatrixRef.h
+++ b/dash/include/dash/matrix/LocalMatrixRef.h
@@ -268,7 +268,7 @@ public:
 
   template<dim_t __NumViewDim = CUR-1>
   typename std::enable_if<(__NumViewDim == 0), const T&>::type
-  constexpr operator[](size_type n) const;
+  operator[](size_type n) const;
 
   LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
     col(size_type n);

--- a/dash/include/dash/matrix/LocalMatrixRef.h
+++ b/dash/include/dash/matrix/LocalMatrixRef.h
@@ -149,7 +149,7 @@ public:
   template <class T_>
   LocalMatrixRef<T, NumDimensions, CUR, PatternT>(
     const LocalMatrixRef<T_, NumDimensions, CUR+1, PatternT> & previous,
-    index_type coord);
+    size_type coord);
 
   /**
    * Constructor, creates a local view reference to a Matrix view.
@@ -251,14 +251,14 @@ public:
    * in global element range.
    */
   LocalMatrixRef<T, NumDimensions, CUR-1, PatternT>
-    operator[](index_type n);
+    operator[](size_type n);
 
   /**
    * Subscript operator, access element at given offset in
    * global element range.
    */
   constexpr LocalMatrixRef<const T, NumDimensions, CUR-1, PatternT>
-    operator[](index_type n) const;
+    operator[](size_type n) const;
 
   LocalMatrixRef<T, NumDimensions, NumDimensions-1, PatternT>
     col(size_type n);
@@ -277,7 +277,7 @@ public:
   template<dim_t NumSubDimensions>
   LocalMatrixRef<const T, NumDimensions, NumDimensions-1, PatternT>
     sub(size_type n) const;
-  
+
   template<dim_t SubDimension>
   LocalMatrixRef<T, NumDimensions, NumDimensions, PatternT>
     sub(size_type n,
@@ -303,7 +303,7 @@ public:
     size_type offset,
     /// Number of rows in the range
     size_type range);
-  
+
   constexpr LocalMatrixRef<const T, NumDimensions, NumDimensions, PatternT>
   rows(
     /// Offset of first row in range
@@ -326,7 +326,7 @@ public:
     size_type offset,
     /// Number of columns in the range
     size_type extent);
-  
+
   constexpr LocalMatrixRef<const T, NumDimensions, NumDimensions, PatternT>
   cols(
     /// Offset of first column in range
@@ -407,7 +407,7 @@ class LocalMatrixRef<T, NumDimensions, 0, PatternT>
     const LocalMatrixRef<T_, NumDimensions, 1, PatternT> & previous,
     index_type coord);
 
-  inline T * local_at(index_type pos) const;
+  inline T * local_at(size_type pos) const;
 
   inline bool is_local() const {
     return true;

--- a/dash/include/dash/matrix/MatrixRef.h
+++ b/dash/include/dash/matrix/MatrixRef.h
@@ -211,7 +211,7 @@ public:
   template<dim_t __NumViewDim = NumViewDim-1>
   typename std::enable_if<(__NumViewDim != 0), 
     MatrixRef<ElementT, NumDimensions, __NumViewDim, PatternT>>::type
-    operator[](index_type n);
+    operator[](size_type n);
 
   /**
    * Subscript operator, returns a submatrix reference at given offset
@@ -220,7 +220,7 @@ public:
   template<dim_t __NumViewDim = NumViewDim-1>
   typename std::enable_if<(__NumViewDim != 0), 
     MatrixRef<const ElementT, NumDimensions, __NumViewDim, PatternT>>::type
-  constexpr operator[](index_type n) const;
+  constexpr operator[](size_type n) const;
     
   /**
    * Subscript operator, returns a \ref dash::GlobRef at given offset
@@ -228,7 +228,7 @@ public:
    */
   template<dim_t __NumViewDim = NumViewDim-1>
   typename std::enable_if<(__NumViewDim == 0), reference>::type
-  operator[](index_type n);
+  operator[](size_type n);
   
   /**
    * Subscript operator, returns a \ref dash::GlobRef at given offset
@@ -236,7 +236,7 @@ public:
    */
   template<dim_t __NumViewDim = NumViewDim-1>
   typename std::enable_if<(__NumViewDim == 0), const_reference>::type
-  operator[](index_type n) const;
+  operator[](size_type n) const;
 
   template<dim_t NumSubDimensions>
   MatrixRef<const ElementT, NumDimensions, NumDimensions-1, PatternT>

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -12,7 +12,7 @@ template <class T_>
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::LocalMatrixRef(
   const LocalMatrixRef<T_, NumDim, CUR+1, PatternT> & previous,
-  index_type coord)
+  size_type coord)
   : _refview(previous._refview)
 {
   DASH_LOG_TRACE_VAR("LocalMatrixRef.(prev)", CUR);
@@ -349,7 +349,7 @@ template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 LocalMatrixRef<T, NumDim, CUR-1, PatternT>
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::operator[](
-  index_type pos)
+  size_type pos)
 {
   DASH_LOG_TRACE("LocalMatrixRef.[]=()",
                  "curdim:",   CUR,
@@ -362,7 +362,7 @@ template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 constexpr LocalMatrixRef<const T, NumDim, CUR-1, PatternT>
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::operator[](
-  index_type pos) const
+  size_type pos) const
 {
   return LocalMatrixRef<const T, NumDim, CUR-1, PatternT>(*this, pos);
 }
@@ -600,9 +600,9 @@ template <typename T, dim_t NumDim, class PatternT>
 inline T *
 LocalMatrixRef<T, NumDim, 0, PatternT>
 ::local_at(
-  index_type pos) const
+  size_type pos) const
 {
-  if (!(static_cast<size_type>(pos) < _refview._mat->size())) {
+  if (!(pos < _refview._mat->size())) {
     DASH_THROW(
       dash::exception::OutOfRange,
       "Position for LocalMatrixRef<0>.local_at out of range");

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -75,8 +75,8 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
   //                        block_view.extent(d));
   //
   DASH_LOG_TRACE("LocalMatrixRef.block()", block_lcoords);
-  auto pattern      = _refview._mat->_pattern;
-  auto block_lindex = pattern.blockspec().at(block_lcoords);
+  const auto& pattern = _refview._mat->_pattern;
+  auto block_lindex   = pattern.blockspec().at(block_lcoords);
   DASH_LOG_TRACE("LocalMatrixRef.block()", block_lindex);
   // Global view of local block:
   auto l_block_g_view = pattern.local_block(block_lindex);
@@ -109,7 +109,7 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
   //                        block_view.extent(d));
   //
   DASH_LOG_TRACE("LocalMatrixRef.block()", block_lindex);
-  auto pattern        = _refview._mat->_pattern;
+  const auto& pattern = _refview._mat->_pattern;
   // Global view of local block:
   auto l_block_g_view = pattern.local_block(block_lindex);
   // Local view of local block:
@@ -417,8 +417,8 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
   size_type pos) const
 {
   auto  l_coords   = _refview._coord;
-  auto& l_viewspec = _refview._l_viewspec;
-  auto& pattern    = _refview._mat->_pattern;
+  const auto& l_viewspec = _refview._l_viewspec;
+  const auto& pattern    = _refview._mat->_pattern;
   DASH_LOG_TRACE("LocalMatrixRef<0>.local()",
                  "coords:",         l_coords,
                  "local viewspec:", l_viewspec.extents());

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -325,18 +325,18 @@ inline T & LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::at(
   Args... args)
 {
-  if(sizeof...(Args) != (NumDim - _refview._dim)) {
-    DASH_THROW(
-      dash::exception::InvalidArgument,
-      "LocalMatrixRef.at(): Invalid number of arguments " <<
-      "expected " << (NumDim - _refview._dim) << " " <<
-      "got " << sizeof...(Args));
-  }
-  std::array<index_type, NumDim> coord = {
-    static_cast<index_type>(args)...
+  static_assert(sizeof...(Args) == CUR,
+      "Invalid number of arguments in variadic access method!");
+
+        auto  l_coords   = _refview._coord;
+  const auto& l_viewspec = _refview._l_viewspec;
+  const auto& pattern    = _refview._mat->_pattern;
+  std::array<size_type, CUR> coord = {
+    static_cast<size_type>(args)...
   };
-  for(auto i = _refview._dim; i < NumDim; ++i) {
-    _refview._coord[i] = coord[i-_refview._dim];
+
+  for(auto i = 0; i < CUR; ++i) {
+    l_coords[NumDim - CUR + i] = coord[i];
   }
   DASH_LOG_TRACE("LocalMatrixRef.at()",
                  "ndim:",     NumDim,
@@ -344,9 +344,9 @@ inline T & LocalMatrixRef<T, NumDim, CUR, PatternT>
                  "l_coords:",   _refview._coord,
                  "l_viewspec:", _refview._l_viewspec);
   return local_at(
-           _refview._mat->_pattern.local_at(
-             _refview._coord,
-             _refview._l_viewspec));
+           pattern.local_at(
+             l_coords,
+             l_viewspec));
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
@@ -381,9 +381,9 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::operator[](
   size_type pos)
 {
-  auto  l_coords   = _refview._coord;
-  auto& l_viewspec = _refview._l_viewspec;
-  auto& pattern    = _refview._mat->_pattern;
+        auto  l_coords   = _refview._coord;
+  const auto& l_viewspec = _refview._l_viewspec;
+  const auto& pattern    = _refview._mat->_pattern;
   DASH_LOG_TRACE("LocalMatrixRef<0>.local()",
                  "coords:",         l_coords,
                  "local viewspec:", l_viewspec.extents());

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -412,7 +412,6 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 template<dim_t __NumViewDim>
 typename std::enable_if<(__NumViewDim == 0), const T&>::type
-constexpr
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::operator[](
   size_type pos) const

--- a/dash/include/dash/matrix/internal/MatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/MatrixRef-inl.h
@@ -290,7 +290,7 @@ typename std::enable_if<(__NumViewDim != 0),
   MatrixRef<T, NumDim, __NumViewDim, PatternT>>::type
 MatrixRef<T, NumDim, CUR, PatternT>
 ::operator[](
-  index_type pos)
+  size_type pos)
 {
   return MatrixRef<T, NumDim, __NumViewDim, PatternT>(*this, pos);
 }
@@ -300,7 +300,7 @@ template<dim_t __NumViewDim>
 typename std::enable_if<(__NumViewDim != 0), 
   MatrixRef<const T, NumDim, __NumViewDim, PatternT>>::type
 constexpr MatrixRef<T, NumDim, CUR, PatternT>
-::operator[](index_type pos) const {
+::operator[](size_type pos) const {
   return MatrixRef<const T, NumDim, __NumViewDim, PatternT>(*this, pos);
 }
 
@@ -308,10 +308,10 @@ template <typename T, dim_t NumDim, dim_t CUR, class PatternT>
 template<dim_t __NumViewDim>
 typename std::enable_if<(__NumViewDim == 0), GlobRef<T> >::type
 MatrixRef<T, NumDim, CUR, PatternT>
-::operator[](index_type pos)
+::operator[](size_type pos)
 {
   auto coords = _refview._coord;
-  coords[0] = pos;
+  coords[NumDim - 1] = pos;
   return _refview.global_reference(coords);
 }
 
@@ -319,10 +319,10 @@ template <typename T, dim_t NumDim, dim_t CUR, class PatternT>
 template<dim_t __NumViewDim>
 typename std::enable_if<(__NumViewDim == 0), GlobRef<const T> >::type
 MatrixRef<T, NumDim, CUR, PatternT>
-::operator[](index_type pos) const
+::operator[](size_type pos) const
 {
   auto coords = _refview._coord;
-  coords[0] = pos;
+  coords[NumDim - 1] = pos;
   return _refview.global_reference(coords);
 }
  

--- a/dash/include/dash/matrix/internal/MatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/MatrixRef-inl.h
@@ -311,7 +311,7 @@ MatrixRef<T, NumDim, CUR, PatternT>
 ::operator[](size_type pos)
 {
   auto coords = _refview._coord;
-  coords[NumDim - 1] = pos;
+  coords[0] = pos;
   return _refview.global_reference(coords);
 }
 
@@ -325,7 +325,7 @@ MatrixRef<T, NumDim, CUR, PatternT>
   coords[NumDim - 1] = pos;
   return _refview.global_reference(coords);
 }
- 
+
 template <typename T, dim_t NumDim, dim_t CUR, class PatternT>
 template <dim_t SubDimension>
 MatrixRef<const T, NumDim, NumDim-1, PatternT>

--- a/dash/test/container/MatrixTest.cc
+++ b/dash/test/container/MatrixTest.cc
@@ -1460,6 +1460,48 @@ TEST_F(MatrixTest, ConstMatrixRefs)
   EXPECT_EQ_U(global_range_sum, global_elems_sum);
 }
 
+
+TEST_F(MatrixTest, LocalMatrixRefs)
+{
+  using value_t = unsigned int;
+  using uint    = unsigned int;
+
+  uint myid = static_cast<uint>(dash::Team::GlobalUnitID().id);
+
+  const uint nelts = 40;
+
+  dash::NArray<value_t, 2> mat(nelts, nelts);
+
+  for (int i = 0; i < mat.local.extent(0); ++i) {
+    auto lref = mat.local[i];
+    for (int j = 0; j < mat.local.extent(1); ++j) {
+      lref[j] = i*1000 + j;
+    }
+  }
+
+  // full operator(...)
+  for (int i = 0; i < mat.local.extent(0); ++i) {
+    for (int j = 0; j < mat.local.extent(1); ++j) {
+      ASSERT_EQ_U(mat.local(i, j), i*1000 + j);
+    }
+  }
+
+  // partial operator(...)
+  for (int i = 0; i < mat.local.extent(0); ++i) {
+    auto lref = mat.local[i];
+    for (int j = 0; j < mat.local.extent(1); ++j) {
+      ASSERT_EQ_U(lref(j), i*1000 + j);
+    }
+  }
+
+  // lbegin, lend
+  int cnt = 0;
+  for (auto i = mat.local.lbegin(); i != mat.local.lend(); ++i) {
+      ASSERT_EQ_U(*i, (cnt / nelts)*1000 + (cnt % nelts));
+      ++cnt;
+  }
+}
+
 TEST_F(MatrixTest, SubViewMatrix3Dim)
 {
   int dim_0_ext  = dash::size();


### PR DESCRIPTION
- Use `size_type` in `operator[]` interface (still converted to `index_type` in the back though)
- `LocalMatrixRef`: directly return `T&` on lowest level in `operator[]` (similar to `MatrixRef`)
- Some minor improvements.