### PR TITLE
[WIP]Fix MatrixRef::lbegin/lend

### DIFF
--- a/build.nasty.sh
+++ b/build.nasty.sh
@@ -61,11 +61,11 @@ fi
 # Configure with default release build settings:
 mkdir -p $BUILD_DIR
 rm -Rf $BUILD_DIR/*
-(cd $BUILD_DIR && cmake -DCMAKE_BUILD_TYPE=Release \
+(cd $BUILD_DIR && cmake -DCMAKE_BUILD_TYPE=Debug \
                         -DENVIRONMENT_TYPE=default \
                         -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0-nasty \
                         -DDART_IMPLEMENTATIONS=mpi \
-                        -DENABLE_THREADSUPPORT=ON \
+                        -DENABLE_THREADSUPPORT=OFF \
                         -DENABLE_DEV_COMPILER_WARNINGS=OFF \
                         -DENABLE_EXT_COMPILER_WARNINGS=OFF \
                         -DENABLE_LT_OPTIMIZATION=OFF \
@@ -91,6 +91,7 @@ rm -Rf $BUILD_DIR/*
                         -DENABLE_HDF5=ON \
                         \
                         -DENABLE_NASTYMPI=ON \
+                        -DNASTYMPI_LIBRARY_PATH=/home/joseph/src/nasty-MPI/ \
                         \
                         -DBUILD_EXAMPLES=OFF \
                         -DBUILD_TESTS=ON \

--- a/dash/include/dash/matrix/LocalMatrixRef.h
+++ b/dash/include/dash/matrix/LocalMatrixRef.h
@@ -160,6 +160,16 @@ public:
   );
 
   /**
+   * Constructor, creates a local view reference to a Matrix view at the
+   * specified global coordinates.
+   */
+  template <class T_>
+  LocalMatrixRef<T, NumDimensions, CUR, PatternT>(
+    Matrix<T_, NumDimensions, index_type, PatternT> * mat,
+    std::array<index_type, NumDimensions> global_coords
+  );
+
+  /**
    * View at local block at given local block coordinates.
    */
   LocalMatrixRef<T, NumDimensions, CUR, PatternT> block(

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -289,7 +289,7 @@ inline T *
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::lend() noexcept
 {
-  return end().local();
+  return begin().local() + size();
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
@@ -297,7 +297,7 @@ constexpr const T *
 LocalMatrixRef<T, NumDim, CUR, PatternT>
 ::lend() const noexcept
 {
-  return end().local();
+  return begin().local() + size();
 }
 
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>

--- a/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/LocalMatrixRef-inl.h
@@ -40,6 +40,21 @@ LocalMatrixRef<T, NumDim, CUR, PatternT>
   DASH_LOG_TRACE_VAR("LocalMatrixRef(mat) >", _refview._viewspec);
 }
 
+template <typename T, dim_t NumDim, dim_t CUR, class PatternT>
+template <class T_>
+LocalMatrixRef<T, NumDim, CUR, PatternT>
+::LocalMatrixRef(
+  Matrix<T_, NumDim, index_type, PatternT> * mat,
+  std::array<index_type, NumDim> global_coords)
+  : _refview(mat->_ref._refview)
+{
+  auto local_extents = mat->_pattern.local_extents();
+  DASH_LOG_TRACE_VAR("LocalMatrixRef(mat, gcoords)", local_extents);
+  auto local_offsets = mat->_pattern.global(global_coords);
+  _refview._viewspec = ViewSpec_t(local_offsets, local_extents);
+  DASH_LOG_TRACE_VAR("LocalMatrixRef(mat, gcoords) >", _refview._viewspec);
+}
+
 #if 0
 template<typename T, dim_t NumDim, dim_t CUR, class PatternT>
 LocalMatrixRef<T, NumDim, CUR, PatternT>

--- a/dash/include/dash/matrix/internal/MatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/MatrixRef-inl.h
@@ -251,7 +251,7 @@ typename MatrixRef<T, NumDim, CUR, PatternT>::local_type
 MatrixRef<T, NumDim, CUR, PatternT>
 ::sub_local() noexcept
 {
-  return local_type(this);
+  return local_type(this->_refview._mat, _refview._coord);
 }
 
 template <typename T, dim_t NumDim, dim_t CUR, class PatternT>
@@ -266,7 +266,7 @@ MatrixRef<T, NumDim, CUR, PatternT>
   //   _mat->local.view(_refview)
   //
   // ... as order of projections (slice + local vs. local + slice) matters.
-  return sub_local().begin();
+  return sub_local().lbegin();
 }
 
 template <typename T, dim_t NumDim, dim_t CUR, class PatternT>
@@ -281,7 +281,7 @@ MatrixRef<T, NumDim, CUR, PatternT>
   //   _mat->local.view(_refview)
   //
   // ... as order of projections (slice + local vs. local + slice) matters.
-  return sub_local().end();
+  return sub_local().lend();
 }
 
 template <typename T, dim_t NumDim, dim_t CUR, class PatternT>

--- a/dash/include/dash/matrix/internal/MatrixRef-inl.h
+++ b/dash/include/dash/matrix/internal/MatrixRef-inl.h
@@ -251,7 +251,7 @@ typename MatrixRef<T, NumDim, CUR, PatternT>::local_type
 MatrixRef<T, NumDim, CUR, PatternT>
 ::sub_local() noexcept
 {
-  return local_type(this->_refview._mat, _refview._coord);
+  return local_type(this->_refview._mat, _refview._viewspec.offsets());
 }
 
 template <typename T, dim_t NumDim, dim_t CUR, class PatternT>

--- a/dash/test/container/MatrixTest.cc
+++ b/dash/test/container/MatrixTest.cc
@@ -1616,3 +1616,29 @@ TEST_F(MatrixTest, MoveSemantics){
     ASSERT_EQ_U(*(matrix_b.lbegin()), 1);
   }
 }
+
+
+TEST_F(MatrixTest, MatrixRefLbegin){
+  using matrix_t = dash::Matrix<int, 2>;
+  size_t nelem = dash::size() * 10;
+  size_t tilesize = 5;
+  matrix_t matrix(nelem, nelem, dash::TILE(tilesize), dash::TILE(tilesize));
+  auto& pattern = matrix.pattern();
+  dash::fill(matrix.begin(), matrix.end(), -1);
+
+  auto lbs = pattern.local_blockspec();
+
+  // fill our blocks with our ID
+  for (size_t i = 0; i < lbs.size(); ++i) {
+    auto coords = lbs.coords(i);
+    auto block  = matrix.block(coords);
+    for (auto bliter = block.lbegin(); bliter != block.lend(); ++bliter) {
+      *bliter = dash::myid();
+    }
+  }
+
+  // check that all our elements are correctly set
+  for (auto iter = matrix.lbegin(); iter != matrix.lend(); ++iter) {
+    ASSERT_EQ_U(*iter, dash::myid());
+  }
+}


### PR DESCRIPTION
This PR fixes two issues with `MatrixRef` `lbegin`/`lend`: 

1. Fixed compiler error 
2. Fixed `lend()` in `LocalMatrixRef` (and thus `MatrixRef`) to not return a `nullptr` but a pointer past the end of the range (`GlobViewIter::local()` returns `nullptr` if pointing beyond the current unit)