### PR TITLE
Chunk up puts/gets to cover large transfers

### DIFF
--- a/dart-impl/mpi/include/dash/dart/mpi/dart_communication_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_communication_priv.h
@@ -21,9 +21,10 @@ extern int dart__mpi__datatype_sizes[DART_TYPE_COUNT];
 /** DART handle type for non-blocking one-sided operations. */
 struct dart_handle_struct
 {
-  MPI_Request request;
+  MPI_Request reqs[2];   // a large transfer might consist of two operations
   MPI_Win     win;
   dart_unit_t dest;
+  uint8_t     num_reqs;
   bool        needs_flush;
 };
 

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_communication_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_communication_priv.h
@@ -15,7 +15,7 @@
 #include <dash/dart/if/dart_communication.h>
 
 DART_INTERNAL
-int dart__mpi__datatype_sizes[DART_TYPE_COUNT];
+extern int dart__mpi__datatype_sizes[DART_TYPE_COUNT];
 
 /** DART handle type for non-blocking one-sided operations. */
 struct dart_handle_struct
@@ -27,6 +27,9 @@ struct dart_handle_struct
 
 dart_ret_t
 dart__mpi__datatype_init() DART_INTERNAL;
+
+dart_ret_t
+dart__mpi__datatype_fini() DART_INTERNAL;
 
 static inline MPI_Op dart__mpi__op(dart_operation_t dart_op) {
   switch (dart_op) {

--- a/dart-impl/mpi/src/dart_communication.c
+++ b/dart-impl/mpi/src/dart_communication.c
@@ -49,11 +49,6 @@
 int dart__mpi__datatype_sizes[DART_TYPE_COUNT];
 static MPI_Datatype dart__mpi__max_chunk_datatype[DART_TYPE_COUNT];
 
-static inline size_t minsize(size_t a, size_t b)
-{
-  return (a < b) ? a : b;
-}
-
 dart_ret_t
 dart__mpi__datatype_init()
 {

--- a/dart-impl/mpi/src/dart_communication.c
+++ b/dart-impl/mpi/src/dart_communication.c
@@ -268,7 +268,7 @@ dart_ret_t dart_put(
 
   // chunk up the put
   const size_t chunk_size = INT_MAX;
-        char * src_ptr    = (char*) src;
+  const char * src_ptr    = (const char*) src;
         size_t copied     = 0;
 
   while (copied < nelem) {
@@ -809,7 +809,7 @@ dart_ret_t dart_put_blocking(
     DART_LOG_DEBUG("dart_put_blocking:  nelem:%zu "
                    "target (coll.): win:%p unit:%d offset:%lu "
                    "<- source: %p",
-                   nelem, win, team_unit_id.id,
+                   nelem, (void*)win, team_unit_id.id,
                    offset, src);
 
   } else {
@@ -827,7 +827,7 @@ dart_ret_t dart_put_blocking(
     DART_LOG_DEBUG("dart_put_blocking:  nelem:%zu "
                    "target (local): win:%p unit:%d offset:%lu "
                    "<- source: %p",
-                   nelem, win, team_unit_id.id,
+                   nelem, (void*)win, team_unit_id.id,
                    offset, src);
   }
 
@@ -836,7 +836,7 @@ dart_ret_t dart_put_blocking(
    */
   // chunk up the put
   const size_t   chunk_size = INT_MAX;
-        char   * src_ptr    = (char*) src;
+  const char   * src_ptr    = (const char*) src;
         size_t   copied     = 0;
 
   while (copied < nelem) {
@@ -939,7 +939,7 @@ dart_ret_t dart_get_blocking(
     DART_LOG_DEBUG("dart_get_blocking:  nelem:%zu "
                    "source (coll.): win:%p unit:%d offset:%lu "
                    "-> dest: %p",
-                   nelem, win, team_unit_id.id,
+                   nelem, (void*)win, team_unit_id.id,
                    offset, dest);
 
   } else {
@@ -958,7 +958,7 @@ dart_ret_t dart_get_blocking(
     DART_LOG_DEBUG("dart_get_blocking:  nelem:%zu "
                    "source (local): win:%p unit:%d offset:%lu "
                    "-> dest: %p",
-                   nelem, win, team_unit_id.id,
+                   nelem, (void*)win, team_unit_id.id,
                    offset, dest);
   }
 

--- a/dart-impl/mpi/src/dart_communication.c
+++ b/dart-impl/mpi/src/dart_communication.c
@@ -183,7 +183,7 @@ dart_ret_t dart_get(
 
   while (copied < nelem) {
     int to_copy = minsize(chunk_size, nelem - copied);
-    DART_LOG_TRACE("dart_get:  MPI_Get (chunk %d, size %d)", chunk, to_copy);
+    DART_LOG_TRACE("dart_get:  MPI_Get (dest %p, size %d)", dest_ptr, to_copy);
     if (MPI_Get(dest_ptr,
                 to_copy,
                 mpi_dtype,
@@ -273,7 +273,7 @@ dart_ret_t dart_put(
 
   while (copied < nelem) {
     int to_copy = minsize(chunk_size, nelem - copied);
-    DART_LOG_TRACE("dart_get:  MPI_Put (chunk %d, size %d)", chunk, to_copy);
+    DART_LOG_TRACE("dart_get:  MPI_Put (src %p, size %d)", src_ptr, to_copy);
     if (MPI_Put(src_ptr,
                 to_copy,
                 mpi_dtype,
@@ -841,7 +841,7 @@ dart_ret_t dart_put_blocking(
 
   while (copied < nelem) {
     int to_copy = minsize(chunk_size, nelem - copied);
-    DART_LOG_TRACE("dart_get:  MPI_Put (chunk %d, size %d)", chunk, to_copy);
+    DART_LOG_TRACE("dart_get:  MPI_Put (src %p, size %d)", src_ptr, to_copy);
     if (MPI_Put(src_ptr,
                 to_copy,
                 mpi_dtype,

--- a/dart-impl/mpi/src/dart_initialization.c
+++ b/dart-impl/mpi/src/dart_initialization.c
@@ -292,6 +292,8 @@ dart_ret_t dart_exit()
 
   MPI_Comm_free(&dart_comm_world);
 
+  dart__mpi__datatype_fini();
+
   if (_init_by_dart) {
     DART_LOG_DEBUG("%2d: dart_exit: MPI_Finalize", unitid.id);
     MPI_Finalize();


### PR DESCRIPTION
Chunk up puts/gets in `dart_put`, `dart_put_blocking`, `dart_get`, and `dart_get_blocking`.

This change is required because MPI does not expect users to copy more than 2GB of data.

This PR is incomplete as `dart_put_handle` and `dart_get_handle` are not covered. There is a host of changes to the way handles are handled in DART waiting for review in #419 so this would only create unnecessary conflicts. I will adjust them accordingly as soon as #419 is merged.

This PR does not include a test case because such large allocations won't work on small systems and thus render the test suite unusable.

@BenjaProg Your test case should be covered, IIRC the problem for you was in `dart_get_blocking`. Please test whether this works now.

Related to #432.