### PR TITLE
updated libs in docker-ci containers, added openmpi3 container

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Docker Containers
 -----------------
 
 [![](https://images.microbadger.com/badges/version/dashproject/dash:mpich.svg)](https://microbadger.com/images/dashproject/dash:mpich "DASH Docker Container (MPICH backend)")
-[![](https://images.microbadger.com/badges/version/dashproject/dash:openmpi.svg)](https://microbadger.com/images/dashproject/dash:openmpi "DASH Docker Container (OpenMPI backend)")
+[![](https://images.microbadger.com/badges/version/dashproject/dash:openmpi2.svg)](https://microbadger.com/images/dashproject/dash:openmpi2 "DASH Docker Container (OpenMPI 2.x backend)")
+[![](https://images.microbadger.com/badges/version/dashproject/dash:openmpi3.svg)](https://microbadger.com/images/dashproject/dash:openmpi3 "DASH Docker Container (OpenMPI 3.x backend)")
 
 For pre-build Docker container images, see the
 [DASH project on Docker Hub](https://hub.docker.com/r/dashproject).

--- a/dash/scripts/docker-testing/mpich/dockerfile
+++ b/dash/scripts/docker-testing/mpich/dockerfile
@@ -18,10 +18,9 @@ WORKDIR       /tmp
 ENV           CC=gcc
 ENV           CXX=g++
 
-# Install PAPI from source
-# Compiler error when compiling with -pedantic for papi > 5.4.1
-# ADD         http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz papi.tgz
-ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.1.tar.gz papi.tgz
+# Compiler error when compiling with -pedantic for papi >= 5.5
+ ADD         http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz papi.tgz
+#ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.3.tar.gz papi.tgz
 RUN           tar -xf papi.tgz
 RUN           cd papi*/src/                     \
               && ./configure --prefix=/opt/papi \
@@ -41,7 +40,7 @@ RUN           cd mpich*                           \
 ENV           PATH=${PATH}:/opt/mpich/bin
 
 # PHDF5 1.10
-ADD           https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz phdf5.tgz
+ADD           https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz phdf5.tgz
 RUN           tar -xf phdf5.tgz
 RUN           cd hdf5*                        \
            && CC=/opt/mpich/bin/mpicc         \

--- a/dash/scripts/docker-testing/openmpi/dockerfile
+++ b/dash/scripts/docker-testing/openmpi/dockerfile
@@ -18,19 +18,18 @@ WORKDIR       /tmp
 ENV           CC=gcc
 ENV           CXX=g++
 
-# Install PAPI from source
-# Compiler error when compiling with -pedantic for papi > 5.4.1
-# ADD         http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz papi.tgz
-ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.1.tar.gz papi.tgz
+# Compiler error when compiling with -pedantic for papi >= 5.5
+ ADD         http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz papi.tgz
+#ADD           http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.3.tar.gz papi.tgz
 RUN           tar -xf papi.tgz
-RUN           cd papi*/src/                  \
-           && ./configure --prefix=/opt/papi \
-           && make                           \
-           && make install
+RUN           cd papi*/src/                     \
+              && ./configure --prefix=/opt/papi \
+              && make                           \
+              && make install
 ENV           PAPI_BASE=/opt/papi
 
 # Openmpi 1.10.5
-ADD           https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.5.tar.gz ompi.tgz
+ADD           https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.7.tar.gz ompi.tgz
 RUN           tar -xf ompi.tgz
 RUN           cd openmpi*                         \
            && ./configure --prefix=/opt/openmpi  \
@@ -41,7 +40,7 @@ ENV           PATH=${PATH}:/opt/openmpi/bin
 ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/openmpi/lib
 
 # PHDF5 1.10
-ADD           https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz phdf5.tgz
+ADD           https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz phdf5.tgz
 RUN           tar -xf phdf5.tgz
 RUN           cd hdf5*                        \
            && CC=/opt/openmpi/bin/mpicc       \

--- a/dash/scripts/docker-testing/openmpi3/dockerfile
+++ b/dash/scripts/docker-testing/openmpi3/dockerfile
@@ -26,8 +26,8 @@ RUN           cd papi*/src/                     \
               && make                           \
               && make install
 
-# Openmpi 2.1
-ADD           https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.2.tar.gz ompi.tgz
+# Openmpi 3.0
+ADD           https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.0.tar.gz ompi.tgz
 RUN           tar -xf ompi.tgz
 RUN           cd openmpi*                         \
            && ./configure --prefix=/opt/openmpi   \


### PR DESCRIPTION
This PR updates the libraries used in out docker-ci containers. A new container using OpenMPI 3.0.0 is added as well. This container is currently not used in CI but can be used for testing against OpenMPI 3.

**Note:** Compiling with PAPI and `-pedantic` will raise an error as there is still an unresolved issue regarding `noexcept` specifier. If necessary, switch back to PAPI 5.4.x.

## ci:openmpi (now deprecated)
- Papi: 5.4.1 -> 5.5.1
- OpenMPI: 1.10.5 -> 1.10.7
- HDF5: 1.10.0 -> 1.10.1

## ci:openmpi2

- Papi: 5.4.1 -> 5.5.1
- OpenMPI: 2.1.1 -> 2.1.2
- HDF5: 1.10.0 -> 1.10.1

## ci:openmpi3 (experimental)

- Papi: 5.5.1
- OpenMPI: 3.0.0
- HDF5: 1.10.1

## ci:mpich

- Papi: 5.4.1 -> 5.5.1
- mpich: 3.2
- HDF5: 1.10.0 -> 1.10.1