### PR TITLE
fixed pattern in MatrixTest.DelayedAlloc ...

### DIFF
--- a/dash/test/container/MatrixTest.cc
+++ b/dash/test/container/MatrixTest.cc
@@ -865,9 +865,9 @@ TEST_F(MatrixTest, DelayedAlloc)
         extent_j,
         extent_k),
       dash::DistributionSpec<3>(
-        num_units_i < 2 ? dash::NONE : dash::TILE(tilesize_i),
-        num_units_j < 2 ? dash::NONE : dash::TILE(tilesize_j),
-        num_units_k < 2 ? dash::NONE : dash::TILE(tilesize_k)),
+        dash::TILE(tilesize_i),
+        dash::TILE(tilesize_j),
+        dash::TILE(tilesize_k)),
       teamspec
   );
 
@@ -973,9 +973,9 @@ TEST_F(MatrixTest, DelayedAlloc)
     extent_i,
     extent_j,
     extent_k,
-    num_units_i < 2 ? dash::NONE : dash::TILE(tilesize_i),
-    num_units_j < 2 ? dash::NONE : dash::TILE(tilesize_j),
-    num_units_k < 2 ? dash::NONE : dash::TILE(tilesize_k),
+    dash::TILE(tilesize_i),
+    dash::TILE(tilesize_j),
+    dash::TILE(tilesize_k),
     teamspec
   );
 }


### PR DESCRIPTION
… to be valid for any number of units. Before this change, the test failed if run with 4 units.