### PR TITLE
Hotfix: fix macro used to check call to MPI_Wait

### DIFF
--- a/dart-impl/mpi/src/dart_communication.c
+++ b/dart-impl/mpi/src/dart_communication.c
@@ -1194,8 +1194,8 @@ dart_ret_t dart_wait(
                    (unsigned long)handle->win);
     if (handle->num_reqs > 0) {
       DART_LOG_DEBUG("dart_wait:     -- MPI_Wait");
-      DART_LOG_DEBUG(
-        MPI_Waitall(handle->num_reqs, handle->reqs, MPI_STATUS_IGNORE),
+      CHECK_MPI_RET(
+        MPI_Waitall(handle->num_reqs, handle->reqs, MPI_STATUSES_IGNORE),
         "MPI_Waitall");
 
       if (handle->needs_flush) {


### PR DESCRIPTION
AFAICS nothing in DASH actually uses `dart_wait` so the impact of this bug was limited.