### PR TITLE
Fix comparison for GlobRef and the like

### DIFF
--- a/dash/include/dash/GlobAsyncRef.h
+++ b/dash/include/dash/GlobAsyncRef.h
@@ -45,9 +45,11 @@ class GlobAsyncRef
     typename ElementT >
   friend class GlobAsyncRef;
 
-private:
+public:
   typedef GlobAsyncRef<T>
     self_t;
+
+  typedef T value_type;
 
   typedef typename std::remove_const<T>::type
     nonconst_value_type;
@@ -278,6 +280,15 @@ public:
   dart_gptr_t dart_gptr() const {
     return this->_gptr;
   }
+
+  /**
+   * Disallow implicit comparison with other global references.
+   */
+  template <class ValueT>
+  bool operator==(const GlobAsyncRef<ValueT> & other) = delete;
+
+  template <class ValueT>
+  bool operator!=(const GlobAsyncRef<ValueT> & other) = delete;
 
   /**
    * Flush all pending asynchronous operations on this asynchronous reference.

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -177,6 +177,17 @@ public:
     return t;
   }
 
+  template <class GlobRefT, typename ValueT = typename GlobRefT::value_type>
+  bool operator==(const GlobRefT & other) {
+    ValueT val = other.get();
+    return operator==(val);
+  }
+
+  template <class GlobRefT>
+  bool operator!=(const GlobRefT & other) {
+    return !(*this == other);
+  }
+
   constexpr bool operator==(const_value_type & value) const
   {
     return static_cast<T>(*this) == value;

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -177,23 +177,25 @@ public:
     return t;
   }
 
-  template <class GlobRefT, typename ValueT = typename GlobRefT::value_type>
-  bool operator==(const GlobRefT & other) {
+  template <typename ValueT>
+  bool operator==(const GlobRef<ValueT> & other) const {
     ValueT val = other.get();
     return operator==(val);
   }
 
-  template <class GlobRefT>
-  bool operator!=(const GlobRefT & other) {
+  template <typename ValueT>
+  bool operator!=(const GlobRef<ValueT> & other) const {
     return !(*this == other);
   }
 
-  constexpr bool operator==(const_value_type & value) const
+  template<typename ValueT>
+  constexpr bool operator==(const ValueT& value) const
   {
     return static_cast<T>(*this) == value;
   }
 
-  constexpr bool operator!=(const_value_type & value) const
+  template<typename ValueT>
+  constexpr bool operator!=(const ValueT& value) const
   {
     return !(*this == value);
   }

--- a/dash/include/dash/atomic/GlobAtomicRef.h
+++ b/dash/include/dash/atomic/GlobAtomicRef.h
@@ -16,7 +16,7 @@ template<typename T>
 class Shared;
 
 /**
- * Specialization for atomic values. All atomic operations are 
+ * Specialization for atomic values. All atomic operations are
  * \c const as the \c GlobRef does not own the atomic values.
  */
 template<typename T>
@@ -101,19 +101,6 @@ public:
   { }
 
   self_t & operator=(const self_t & other) = delete;
-
-  inline bool operator==(const self_t & other) const noexcept
-  {
-    return _gptr == other._gptr;
-  }
-
-  inline bool operator!=(const self_t & other) const noexcept
-  {
-    return !(*this == other);
-  }
-
-  inline bool operator==(const T & value) const = delete;
-  inline bool operator!=(const T & value) const = delete;
 
   operator T() const {
     return load();
@@ -256,9 +243,9 @@ public:
   /**
    * Atomically compares the value with the value of expected and if thosei
    * are bitwise-equal, replaces the former with desired.
-   * 
+   *
    * \return  True if value is exchanged
-   * 
+   *
    * \see \c dash::atomic::compare_exchange
    */
   bool compare_exchange(const T & expected, const T & desired) const {

--- a/dash/test/container/ArrayTest.cc
+++ b/dash/test/container/ArrayTest.cc
@@ -284,6 +284,7 @@ TEST_F(ArrayTest, ElementCompare){
   array_t arr(dash::size());
 
   dash::fill(arr.begin(), arr.end(), 0);
+  arr.barrier();
 
   ASSERT_EQ_U(arr[0], arr[1]);
 

--- a/dash/test/container/ArrayTest.cc
+++ b/dash/test/container/ArrayTest.cc
@@ -273,7 +273,6 @@ TEST_F(ArrayTest, MoveSemantics){
   }
 }
 
-
 TEST_F(ArrayTest, ElementCompare){
   using value_t = int;
   using array_t = dash::Array<value_t>;
@@ -287,4 +286,16 @@ TEST_F(ArrayTest, ElementCompare){
   dash::fill(arr.begin(), arr.end(), 0);
 
   ASSERT_EQ_U(arr[0], arr[1]);
+
+  ASSERT_EQ_U(0, arr[dash::myid()]);
+  ASSERT_EQ_U(arr[dash::myid()], 0);
+  ASSERT_EQ_U(arr[dash::myid()], 0UL);
+
+  dash::barrier();
+  arr[dash::myid()] = dash::myid();
+  ASSERT_EQ_U(dash::myid(), arr[dash::myid()]);
+  dash::barrier();
+  if (dash::myid() > 0) {
+    ASSERT_NE_U(arr[0], arr[dash::myid()]);
+  }
 }

--- a/dash/test/types/AtomicTest.cc
+++ b/dash/test/types/AtomicTest.cc
@@ -517,6 +517,7 @@ TEST_F(AtomicTest, ElementCompare){
 
   array_t array(dash::size());
   dash::fill(array.begin(), array.end(), 0);
+  dash::barrier();
 
   ASSERT_EQ_U(0, array[dash::myid()]);
   ASSERT_EQ_U(0UL, array[dash::myid()]);


### PR DESCRIPTION
#450 seems to have broken the build (although CI and local tests succeeded, strange).

As they say: you break it, you own it. This PR should fix comparison and also allow comparison with non-matching types without GCC giving a warning, e.g., `GlobRef<int>` and `unsigned long`. 