### PR TITLE
Compatibility for libc++

### DIFF
--- a/dash/include/dash/Pair.h
+++ b/dash/include/dash/Pair.h
@@ -195,17 +195,38 @@ namespace dash {
     x.swap(y);
   }
 
+  namespace internal {
+    /**
+     * Duplicated here to not rely on an STL implementation
+     */
+    template <class T>
+    struct strip
+    {
+      typedef T type;
+    };
+    template <class T>
+    struct strip<std::reference_wrapper<T>>
+    {
+        typedef T& type;
+    };
+    template <class T>
+    struct decay_and_strip
+    {
+        typedef typename strip<typename std::decay<T>::type>::type type;
+    };
+  } // namespace internal
+
   /**
    * Convennience wrapper to create a Pair object.
    */
   template<class T1, class T2>
-  constexpr Pair<typename std::__decay_and_strip<T1>::__type,
-                 typename std::__decay_and_strip<T2>::__type>
+  constexpr Pair<typename internal::decay_and_strip<T1>::type,
+                 typename internal::decay_and_strip<T2>::type>
   make_pair(T1&& x, T2&& y)
   {
-    typedef typename std::__decay_and_strip<T1>::__type ds_type1;
-    typedef typename std::__decay_and_strip<T2>::__type ds_type2;
-    typedef Pair<ds_type1, ds_type2>                    pair_type;
+    typedef typename internal::decay_and_strip<T1>::type ds_type1;
+    typedef typename internal::decay_and_strip<T2>::type ds_type2;
+    typedef Pair<ds_type1, ds_type2>                     pair_type;
     return pair_type(std::forward<T1>(x), std::forward<T2>(y));
   }
 

--- a/dash/test/view/ViewTest.cc
+++ b/dash/test/view/ViewTest.cc
@@ -834,9 +834,7 @@ TEST_F(ViewTest, ArrayBlockCyclicPatternSubLocalBlocks)
                   l_block.size());
       EXPECT_EQ_U(l_block_index.size(), l_block.size());
 
-      l_blocks_sub_values.insert(l_blocks_sub_values.end(),
-                                 l_block.begin(),
-                                 l_block.end());
+      std::move(l_block.begin(), l_block.end(), std::back_inserter(l_blocks_sub_values));
       ++l_b_idx;
       l_idx += l_block.size();
     }
@@ -1255,9 +1253,7 @@ TEST_F(ViewTest, BlocksView1Dim)
       DASH_LOG_DEBUG("ViewTest.BlocksView1Dim", "----",
                      range_str(block));
 
-      gview_blocks_values.insert(gview_blocks_values.end(),
-                                 block.begin(),
-                                 block.end());
+      std::move(block.begin(), block.end(), std::back_inserter(gview_blocks_values));
       b_idx++;
     }
     EXPECT_EQ_U(gview_isect.size(),


### PR DESCRIPTION
Two small changes are necessary to make dash compatible with [libc++](https://libcxx.llvm.org/). They're both because of libc++'s different internals.