### PR TITLE
Introducing DASH Iterator Traits

### DIFF
--- a/dash/examples/bench.04.histo-tf/main.cpp
+++ b/dash/examples/bench.04.histo-tf/main.cpp
@@ -19,10 +19,10 @@ typedef dash::util::Timer<
 //   https://www.nas.nasa.gov/assets/pdf/techreports/1994/rnr-94-007.pdf
 
 // NOTE:
-//   In the NBP reference implementation, keys are first sorted to buckets 
+//   In the NBP reference implementation, keys are first sorted to buckets
 //   to determine their coarse distribution.
 //   For example, for key range (0, 2^23) and buckset size s_b = 2^10, a
-//   histogram with n_b = 2^(23-10) = 2^13 bins of size 2^10 = 1024 is 
+//   histogram with n_b = 2^(23-10) = 2^13 bins of size 2^10 = 1024 is
 //   created so that bucket[b] holds the number of keys with values
 //   between (b * s_b) and ((b+1) * s_b).
 
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
 
   if (dash::myid() != 0) {
     // Add local histogram values to result histogram at unit 0:
-    dash::transform<int>(key_histo.lbegin(), // A begin
+    dash::transform(key_histo.lbegin(), // A begin
                          key_histo.lend(),   // A end
                          key_histo.begin(),  // B
                          key_histo.begin(),  // C = plus(A,B)

--- a/dash/examples/ex.05.min_element/main.cpp
+++ b/dash/examples/ex.05.min_element/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char * argv[])
   // the following shows the usage of min_element with a composite
   // datatype (test_t). We're passing a comparator function as a
   // lambda expression
-  auto min = dash::min_element<test_t>(
+  auto min = dash::min_element(
                arr2.begin(),
                arr2.end(),
                [](const test_t & t1, const test_t & t2) -> bool {

--- a/dash/include/dash/Iterator.h
+++ b/dash/include/dash/Iterator.h
@@ -3,6 +3,7 @@
 
 #include <dash/Types.h>
 #include <dash/Dimensional.h>
+#include <dash/iterator/IteratorTraits.h>
 #include <dash/iterator/GlobIter.h>
 #include <dash/iterator/GlobViewIter.h>
 
@@ -48,15 +49,6 @@
 
 namespace dash {
 
-namespace detail {
-  DASH__META__DEFINE_TRAIT__HAS_TYPE(value_type)
-  DASH__META__DEFINE_TRAIT__HAS_TYPE(iterator)
-  DASH__META__DEFINE_TRAIT__HAS_TYPE(const_iterator)
-  DASH__META__DEFINE_TRAIT__HAS_TYPE(reference)
-  DASH__META__DEFINE_TRAIT__HAS_TYPE(const_reference)
-  DASH__META__DEFINE_TRAIT__HAS_TYPE(pointer)
-  DASH__META__DEFINE_TRAIT__HAS_TYPE(const_pointer)
-}
 
 /**
  *

--- a/dash/include/dash/algorithm/Accumulate.h
+++ b/dash/include/dash/algorithm/Accumulate.h
@@ -33,7 +33,7 @@ ValueType accumulate(
   GlobInputIt     in_last,
   ValueType       init)
 {
-  typedef typename GlobInputIt::index_type index_t;
+  typedef typename dash::iterator_traits<GlobInputIt>::index_type index_t;
 
   auto & team      = in_first.team();
   auto myid        = team.myid();
@@ -83,7 +83,7 @@ ValueType accumulate(
   ValueType       init,
   BinaryOperation binary_op = dash::plus<ValueType>())
 {
-  typedef typename GlobInputIt::index_type index_t;
+  typedef typename dash::iterator_traits<GlobInputIt>::index_type index_t;
 
   auto & team      = in_first.team();
   auto myid        = team.myid();

--- a/dash/include/dash/algorithm/Equal.h
+++ b/dash/include/dash/algorithm/Equal.h
@@ -15,23 +15,25 @@ namespace dash {
  *
  * \ingroup     DashAlgorithms
  */
-template <
-  typename ElementType,
-  class    PatternType >
+template <typename GlobIter>
 bool equal(
-  /// Iterator to the initial position in the sequence
-  GlobIter<ElementType, PatternType>   first_1,
-  /// Iterator to the final position in the sequence
-  GlobIter<ElementType, PatternType>   last_1,
-  GlobIter<ElementType, PatternType>   first_2)
+    /// Iterator to the initial position in the sequence
+    GlobIter first_1,
+    /// Iterator to the final position in the sequence
+    GlobIter last_1,
+    GlobIter first_2)
 {
-  auto & team        = first_1.team();
-  auto myid          = team.myid();
+  static_assert(
+      dash::iterator_traits<GlobIter>::is_global_iterator::value,
+      "invalid iterator: Need to be a global iterator");
+
+  auto& team = first_1.team();
+  auto  myid = team.myid();
   // Global iterators to local range:
-  auto index_range   = dash::local_range(first_1, last_1);
-  auto l_first_1     = index_range.begin;
-  auto l_last_1      = index_range.end;
-  auto l_result      = std::equal(l_first_1, l_last_1, first_2);
+  auto index_range = dash::local_range(first_1, last_1);
+  auto l_first_1   = index_range.begin;
+  auto l_last_1    = index_range.end;
+  auto l_result    = std::equal(l_first_1, l_last_1, first_2);
 
   dash::Array<bool> l_results(team.size(), team);
 
@@ -57,18 +59,19 @@ bool equal(
  *
  * \ingroup     DashAlgorithms
  */
-template <
-  typename ElementType,
-  class    PatternType,
-  class    BinaryPredicate >
+template <typename GlobIter, class BinaryPredicate>
 bool equal(
-  /// Iterator to the initial position in the sequence
-  GlobIter<ElementType, PatternType>   first_1,
-  /// Iterator to the final position in the sequence
-  GlobIter<ElementType, PatternType>   last_1,
-  GlobIter<ElementType, PatternType>   first_2,
-  BinaryPredicate                      pred)
+    /// Iterator to the initial position in the sequence
+    GlobIter        first_1,
+    /// Iterator to the final position in the sequence
+    GlobIter        last_1,
+    GlobIter        first_2,
+    BinaryPredicate pred)
 {
+  static_assert(
+      dash::iterator_traits<GlobIter>::is_global_iterator::value,
+      "invalid iterator: Need to be a global iterator");
+
   auto & team        = first_1.team();
   auto myid          = team.myid();
   // Global iterators to local range:

--- a/dash/include/dash/algorithm/Find.h
+++ b/dash/include/dash/algorithm/Find.h
@@ -24,7 +24,7 @@ GlobIter find(
   GlobIter   first,
   /// Iterator to the final position in the sequence
   GlobIter   last,
-  /// Value which will be assigned to the elements in range [first, last)
+  /// Value which is searched for using operator==
   const ElementType                  & value)
 {
 

--- a/dash/include/dash/algorithm/Find.h
+++ b/dash/include/dash/algorithm/Find.h
@@ -17,17 +17,24 @@ namespace dash {
  * \ingroup     DashAlgorithms
  */
 template<
-  typename ElementType,
-  class    PatternType>
-GlobIter<ElementType, PatternType> find(
+  typename GlobIter,
+  typename ElementType>
+GlobIter find(
   /// Iterator to the initial position in the sequence
-  GlobIter<ElementType, PatternType>   first,
+  GlobIter   first,
   /// Iterator to the final position in the sequence
-  GlobIter<ElementType, PatternType>   last,
+  GlobIter   last,
   /// Value which will be assigned to the elements in range [first, last)
   const ElementType                  & value)
 {
-  using p_index_t = typename PatternType::index_type;
+
+  using iterator_traits = dash::iterator_traits<GlobIter>;
+
+  using p_index_t = typename iterator_traits::index_type;
+
+  static_assert(
+      std::is_same<typename iterator_traits::value_type, ElementType>::value,
+      "element types do not match");
 
   if(first >= last) {
     return last;
@@ -95,29 +102,28 @@ GlobIter<ElementType, PatternType> find(
  *
  * \ingroup     DashAlgorithms
  */
-template<
-  typename ElementType,
-  class    PatternType,
-  class    UnaryPredicate >
-GlobIter<ElementType, PatternType> find_if(
-  /// Iterator to the initial position in the sequence
-  GlobIter<ElementType, PatternType>   first,
-  /// Iterator to the final position in the sequence
-  GlobIter<ElementType, PatternType>   last,
-  /// Predicate which will be applied to the elements in range [first, last)
-  UnaryPredicate                       predicate)
+template <typename GlobIter, typename UnaryPredicate>
+GlobIter find_if(
+    /// Iterator to the initial position in the sequence
+    GlobIter first,
+    /// Iterator to the final position in the sequence
+    GlobIter last,
+    /// Predicate which will be applied to the elements in range [first, last)
+    UnaryPredicate predicate)
 {
-  typedef typename PatternType::index_type index_t;
+  using iterator_traits = dash::iterator_traits<GlobIter>;
 
-  auto & team        = first.pattern().team();
-  auto myid          = team.myid();
+  using index_t = typename iterator_traits::index_type;
+
+  auto& team = first.pattern().team();
+  auto  myid = team.myid();
   /// Global iterators to local range:
-  auto index_range   = dash::local_range(first, last);
-  auto l_first       = index_range.begin;
-  auto l_last        = index_range.end;
+  auto index_range = dash::local_range(first, last);
+  auto l_first     = index_range.begin;
+  auto l_last      = index_range.end;
 
-  auto l_result      = std::find_if(l_first, l_last, predicate);
-  auto l_offset      = std::distance(l_first, l_result);
+  auto l_result = std::find_if(l_first, l_last, predicate);
+  auto l_offset = std::distance(l_first, l_result);
   if (l_result == l_last) {
     l_offset = -1;
   }
@@ -133,11 +139,8 @@ GlobIter<ElementType, PatternType> find_if(
 
   for (auto u = 0; u < team.size(); u++) {
     if (l_results[u] >= 0) {
-      auto g_offset = first.pattern()
-                           .global_index(
-                              u,
-                              { l_results[u] });
-      result = first + g_offset - first.pos();
+      auto g_offset = first.pattern().global_index(u, {l_results[u]});
+      result        = first + g_offset - first.pos();
       break;
     }
   }
@@ -156,17 +159,16 @@ GlobIter<ElementType, PatternType> find_if(
  *
  * \ingroup     DashAlgorithms
  */
-template<
-  typename ElementType,
-  class    PatternType,
-	class    UnaryPredicate>
-GlobIter<ElementType, PatternType> find_if_not(
-  /// Iterator to the initial position in the sequence
-  GlobIter<ElementType, PatternType>   first,
-  /// Iterator to the final position in the sequence
-  GlobIter<ElementType, PatternType>   last,
-  /// Predicate which will be applied to the elements in range [first, last)
-	UnaryPredicate                       predicate)
+template <
+    typename GlobIter,
+    class UnaryPredicate>
+GlobIter find_if_not(
+    /// Iterator to the initial position in the sequence
+    GlobIter first,
+    /// Iterator to the final position in the sequence
+    GlobIter last,
+    /// Predicate which will be applied to the elements in range [first, last)
+    UnaryPredicate predicate)
 {
   return find_if(first, last, std::not1(predicate));
 }

--- a/dash/include/dash/algorithm/Find.h
+++ b/dash/include/dash/algorithm/Find.h
@@ -28,6 +28,7 @@ GlobIter find(
   const ElementType & value)
 {
 
+  //use iterator traits
   using iterator_traits = dash::iterator_traits<GlobIter>;
 
   using p_index_t = typename iterator_traits::index_type;

--- a/dash/include/dash/algorithm/Find.h
+++ b/dash/include/dash/algorithm/Find.h
@@ -25,16 +25,12 @@ GlobIter find(
   /// Iterator to the final position in the sequence
   GlobIter   last,
   /// Value which is searched for using operator==
-  const ElementType                  & value)
+  const ElementType & value)
 {
 
   using iterator_traits = dash::iterator_traits<GlobIter>;
 
   using p_index_t = typename iterator_traits::index_type;
-
-  static_assert(
-      std::is_same<typename iterator_traits::value_type, ElementType>::value,
-      "element types do not match");
 
   if(first >= last) {
     return last;

--- a/dash/include/dash/algorithm/Find.h
+++ b/dash/include/dash/algorithm/Find.h
@@ -123,10 +123,7 @@ GlobIter find_if(
   auto l_last      = index_range.end;
 
   auto l_result = std::find_if(l_first, l_last, predicate);
-  auto l_offset = std::distance(l_first, l_result);
-  if (l_result == l_last) {
-    l_offset = -1;
-  }
+  auto l_offset = l_result == l_last ? -1 : std::distance(l_first, l_result);
 
   dash::Array<index_t> l_results(team.size(), team);
 

--- a/dash/include/dash/algorithm/ForEach.h
+++ b/dash/include/dash/algorithm/ForEach.h
@@ -28,17 +28,14 @@ namespace dash {
  *
  * \ingroup     DashAlgorithms
  */
-template <
-  typename ElementType,
-  class    PatternType,
-  class    UnaryFunction >
+template <typename GlobInputIt, class UnaryFunction>
 void for_each(
-  /// Iterator to the initial position in the sequence
-  const GlobIter<ElementType, PatternType> & first,
-  /// Iterator to the final position in the sequence
-  const GlobIter<ElementType, PatternType> & last,
-  /// Function to invoke on every index in the range
-  UnaryFunction                              func)
+    /// Iterator to the initial position in the sequence
+    const GlobInputIt& first,
+    /// Iterator to the final position in the sequence
+    const GlobInputIt& last,
+    /// Function to invoke on every index in the range
+    UnaryFunction func)
 {
   /// Global iterators to local index range:
   auto index_range  = dash::local_index_range(first, last);
@@ -75,17 +72,14 @@ void for_each(
  *
  * \ingroup     DashAlgorithms
  */
-template <
-  typename ElementType,
-  class    PatternType,
-  class    UnaryFunctionWithIndex >
+template <typename GlobInputIt, class UnaryFunctionWithIndex>
 void for_each_with_index(
-  /// Iterator to the initial position in the sequence
-  const GlobIter<ElementType, PatternType> & first,
-  /// Iterator to the final position in the sequence
-  const GlobIter<ElementType, PatternType> & last,
-  /// Function to invoke on every index in the range
-  UnaryFunctionWithIndex                     func)
+    /// Iterator to the initial position in the sequence
+    const GlobInputIt& first,
+    /// Iterator to the final position in the sequence
+    const GlobInputIt& last,
+    /// Function to invoke on every index in the range
+    UnaryFunctionWithIndex func)
 {
   /// Global iterators to local index range:
   auto index_range  = dash::local_index_range(first, last);

--- a/dash/include/dash/algorithm/ForEach.h
+++ b/dash/include/dash/algorithm/ForEach.h
@@ -37,6 +37,10 @@ void for_each(
     /// Function to invoke on every index in the range
     UnaryFunction func)
 {
+  using iterator_traits = dash::iterator_traits<GlobInputIt>;
+  static_assert(
+      iterator_traits::is_global_iterator::value,
+      "must be a global iterator");
   /// Global iterators to local index range:
   auto index_range  = dash::local_index_range(first, last);
   auto lbegin_index = index_range.begin;
@@ -81,6 +85,11 @@ void for_each_with_index(
     /// Function to invoke on every index in the range
     UnaryFunctionWithIndex func)
 {
+  using iterator_traits = dash::iterator_traits<GlobInputIt>;
+  static_assert(
+      iterator_traits::is_global_iterator::value,
+      "must be a global iterator");
+
   /// Global iterators to local index range:
   auto index_range  = dash::local_index_range(first, last);
   auto lbegin_index = index_range.begin;

--- a/dash/include/dash/algorithm/Generate.h
+++ b/dash/include/dash/algorithm/Generate.h
@@ -1,14 +1,13 @@
 #ifndef DASH__ALGORITHM__GENERATE_H__
 #define DASH__ALGORITHM__GENERATE_H__
 
-#include <dash/iterator/GlobIter.h>
 #include <dash/algorithm/LocalRange.h>
 #include <dash/algorithm/Operation.h>
+#include <dash/iterator/GlobIter.h>
 
 #include <dash/dart/if/dart_communication.h>
 
 #include <algorithm>
-
 
 namespace dash {
 
@@ -29,17 +28,19 @@ namespace dash {
  *
  * \ingroup     DashAlgorithms
  */
-template <
-    typename ElementType,
-    class    PatternType,
-    class    UnaryFunction >
-void generate (
-  /// Iterator to the initial position in the sequence
-  GlobIter<ElementType, PatternType> first,
-  /// Iterator to the final position in the sequence
-  GlobIter<ElementType, PatternType> last,
-  /// Generator function
-  UnaryFunction                      gen) {
+template <typename GlobInputIt, class UnaryFunction>
+void generate(
+    /// Iterator to the initial position in the sequence
+    GlobInputIt first,
+    /// Iterator to the final position in the sequence
+    GlobInputIt last,
+    /// Generator function
+    UnaryFunction gen)
+{
+  using iterator_traits = dash::iterator_traits<GlobInputIt>;
+  static_assert(
+      iterator_traits::is_global_iterator::value,
+      "must be a global iterator");
   /// Global iterators to local range:
   auto lrange = dash::local_range(first, last);
   auto lfirst = lrange.begin;
@@ -66,17 +67,19 @@ void generate (
  *
  * \ingroup     DashAlgorithms
  */
-template <
-    typename ElementType,
-    class    PatternType,
-    class    UnaryFunction >
+template <typename GlobInputIt, class UnaryFunction>
 void generate_with_index(
-  /// Iterator to the initial position in the sequence
-  GlobIter<ElementType, PatternType> first,
-  /// Iterator to the final position in the sequence
-  GlobIter<ElementType, PatternType> last,
-  /// Generator function
-  UnaryFunction                      gen) {
+    /// Iterator to the initial position in the sequence
+    GlobInputIt first,
+    /// Iterator to the final position in the sequence
+    GlobInputIt last,
+    /// Generator function
+    UnaryFunction gen)
+{
+  using iterator_traits = dash::iterator_traits<GlobInputIt>;
+  static_assert(
+      iterator_traits::is_global_iterator::value,
+      "must be a global iterator");
   /// Global iterators to local index range:
   auto index_range  = dash::local_index_range(first, last);
   auto lbegin_index = index_range.begin;
@@ -84,19 +87,17 @@ void generate_with_index(
 
   if (lbegin_index != lend_index) {
     // Pattern from global begin iterator:
-    auto & pattern    = first.pattern();
-    auto first_offset = first.pos();
+    auto& pattern      = first.pattern();
+    auto  first_offset = first.pos();
     // Iterate local index range:
-    for (auto lindex = lbegin_index;
-         lindex != lend_index;
-         ++lindex) {
+    for (auto lindex = lbegin_index; lindex != lend_index; ++lindex) {
       auto gindex     = pattern.global(lindex);
       auto element_it = first + (gindex - first_offset);
-      *element_it = gen(gindex);
+      *element_it     = gen(gindex);
     }
   }
 }
 
-} // namespace dash
+}  // namespace dash
 
-#endif // DASH__ALGORITHM__GENERATE_H__
+#endif  // DASH__ALGORITHM__GENERATE_H__

--- a/dash/include/dash/algorithm/MinMax.h
+++ b/dash/include/dash/algorithm/MinMax.h
@@ -148,22 +148,23 @@ const ElementType * min_element(
  * \ingroup     DashAlgorithms
  */
 template <
-  class ElementType,
-  class PatternType,
-  class Compare = std::less<const ElementType &> >
-GlobIter<ElementType, PatternType> min_element(
-  /// Iterator to the initial position in the sequence
-  const GlobIter<ElementType, PatternType> & first,
-  /// Iterator to the final position in the sequence
-  const GlobIter<ElementType, PatternType> & last,
-  /// Element comparison function, defaults to std::less
-  Compare                                    compare
-    = std::less<const ElementType &>())
+    typename GlobInputIt,
+    class Compare = std::less<
+        const typename dash::iterator_traits<GlobInputIt>::value_type &> >
+GlobInputIt min_element(
+    /// Iterator to the initial position in the sequence
+    const typename std::enable_if<
+        dash::iterator_traits<GlobInputIt>::is_global_iterator::value,
+        GlobInputIt>::type &first,
+    /// Iterator to the final position in the sequence
+    const GlobInputIt &last,
+    /// Element comparison function, defaults to std::less
+    Compare compare = Compare())
 {
-  typedef dash::GlobIter<ElementType, PatternType> globiter_t;
-  typedef PatternType                               pattern_t;
-  typedef typename pattern_t::index_type              index_t;
-  typedef typename std::decay<ElementType>::type      value_t;
+  typedef typename GlobInputIt::pattern_type     pattern_t;
+  typedef typename pattern_t::index_type         index_t;
+  typedef typename std::decay<
+      typename dash::iterator_traits<GlobInputIt>::value_type>::type value_t;
 
   // return last for empty array
   if (first == last) {
@@ -184,7 +185,7 @@ GlobIter<ElementType, PatternType> min_element(
   // Get local address range between global iterators:
   auto    local_idx_range    = dash::local_index_range(first, last);
   // Pointer to local minimum element:
-  const   ElementType * lmin = nullptr;
+  const   value_t * lmin = nullptr;
   // Local offset of local minimum element, or -1 if no element found:
   index_t l_idx_lmin         = -1;
   if (local_idx_range.begin == local_idx_range.end) {
@@ -194,10 +195,10 @@ GlobIter<ElementType, PatternType> min_element(
     trace.enter_state("local");
 
     // Pointer to first element in local memory:
-    const ElementType * lbegin        = first.globmem().lbegin();
+    const value_t * lbegin        = first.globmem().lbegin();
     // Pointers to first / final element in local range:
-    const ElementType * l_range_begin = lbegin + local_idx_range.begin;
-    const ElementType * l_range_end   = lbegin + local_idx_range.end;
+    const value_t * l_range_begin = lbegin + local_idx_range.begin;
+    const value_t * l_range_end   = lbegin + local_idx_range.end;
 
     lmin = dash::min_element(l_range_begin, l_range_end, compare);
 
@@ -229,7 +230,7 @@ GlobIter<ElementType, PatternType> min_element(
   // found:
   local_min_t local_min;
   local_min.value   = l_idx_lmin < 0
-                      ? ElementType()
+                      ? value_t()
                       : *lmin;
   local_min.g_index = l_idx_lmin < 0
                       ? -1
@@ -293,9 +294,9 @@ GlobIter<ElementType, PatternType> min_element(
   // iterator 'first' is relative to start of input range, convert to start
   // of its referenced container (= container.begin()), then apply global
   // offset of minimum element:
-  globiter_t minimum = (first - first.gpos()) + gi_minimum;
+  auto minimum = (first - first.gpos()) + gi_minimum;
   DASH_LOG_DEBUG("dash::min_element >", minimum,
-                 "=", static_cast<ElementType>(*minimum));
+                 "=", static_cast<value_t>(*minimum));
 
   return minimum;
 }

--- a/dash/include/dash/algorithm/Transform.h
+++ b/dash/include/dash/algorithm/Transform.h
@@ -8,14 +8,12 @@
 #include <dash/algorithm/Operation.h>
 #include <dash/algorithm/Accumulate.h>
 
-#include <dash/iterator/GlobIter.h>
+#include <dash/Iterator.h>
 
 #include <dash/internal/Config.h>
 #include <dash/util/Trace.h>
 
 #include <dash/dart/if/dart_communication.h>
-
-#include <iterator>
 
 #ifdef DASH_ENABLE_OPENMP
 #include <omp.h>
@@ -69,6 +67,272 @@ dart_ret_t transform_impl(
                         op);
   dart_flush_local(dest);
   return result;
+}
+
+struct transform_impl_local_input_it{};
+struct transform_impl_glob_input_it{};
+
+/**
+ * Transform operation on ranges with identical distribution and start
+ * offset.
+ * In this case, no communication is needed as all output values can be
+ * obtained from input values in local memory:
+ *
+ * \note
+ * This function does not execute the transformation as atomic operation
+ * on elements. Use \c dash::transform if concurrent access to elements is
+ * possible.
+ *
+ * <pre>
+ *   input a: [ u0 | u1 | u2 | ... ]
+ *              op   op   op   ...
+ *   input b: [ u0 | u1 | u2 | ... ]
+ *              =    =    =    ...
+ *   output:  [ u0 | u1 | u2 | ... ]
+ * </pre>
+ */
+template <
+    typename ValueType,
+    class InputAIt,
+    class InputBIt,
+    class GlobOutputIt,
+    class BinaryOperation>
+GlobOutputIt transform_local(
+    InputAIt        in_a_first,
+    InputAIt        in_a_last,
+    InputBIt        in_b_first,
+    GlobOutputIt        out_first,
+    BinaryOperation binary_op)
+{
+  DASH_LOG_DEBUG("dash::transform_local()");
+  DASH_ASSERT_MSG(in_a_first.pattern() == in_b_first.pattern(),
+                  "dash::transform_local: "
+                  "distributions of input ranges differ");
+  DASH_ASSERT_MSG(in_a_first.pattern() == out_first.pattern(),
+                  "dash::transform_local: "
+                  "distributions of input- and output ranges differ");
+  // Local subrange of input range a:
+  auto local_range_a   = dash::local_range(in_a_first, in_a_last);
+  ValueType * lbegin_a = local_range_a.begin;
+  ValueType * lend_a   = local_range_a.end;
+  if (lbegin_a == lend_a) {
+    // Local input range is empty, return initial output iterator to indicate
+    // that no values have been transformed:
+    DASH_LOG_DEBUG("dash::transform_local", "local range empty");
+    return out_first;
+  }
+  // Global offset of first local element:
+  auto g_offset_first    = in_a_first.pattern().global(0);
+  // Number of elements in global ranges:
+  auto num_gvalues       = dash::distance(in_a_first, in_b_first);
+  DASH_LOG_TRACE_VAR("dash::transform_local", num_gvalues);
+  // Number of local elements:
+  DASH_LOG_TRACE("dash::transform_local", "local elements:", lend_a-lbegin_a);
+  // Local subrange of input range b:
+  ValueType * lbegin_b   = (in_b_first + g_offset_first).local();
+  // Local pointer of initial output element:
+  ValueType * lbegin_out = (out_first  + g_offset_first).local();
+  // Generate output values:
+#ifdef DASH_ENABLE_OPENMP
+  dash::util::UnitLocality uloc;
+  auto n_threads = uloc.num_domain_threads();
+  DASH_LOG_DEBUG("dash::transform_local", "thread capacity:",  n_threads);
+  if (n_threads > 1) {
+    auto l_size = lend_a - lbegin_a;
+    // TODO: Vectorize.
+    // Documentation of Intel MIC intrinsics, see:
+    // https://software.intel.com/de-de/node/523533
+    // https://software.intel.com/de-de/node/523387
+    #pragma omp parallel for num_threads(n_threads) schedule(static)
+    for (int i = 0; i < l_size; i++) {
+      lbegin_out[i] = binary_op(lbegin_a[i], lbegin_b[i]);
+    }
+    return out_first + num_gvalues;
+  }
+#endif
+  // No OpenMP or insufficient number of threads for parallelization:
+  for (; lbegin_a != lend_a; ++lbegin_a, ++lbegin_b, ++lbegin_out) {
+    *lbegin_out = binary_op(*lbegin_a, *lbegin_b);
+  }
+  // Return out_end iterator past final transformed element;
+  return out_first + num_gvalues;
+}
+
+template <
+    class InputIt,
+    class GlobInputIt,
+    class GlobOutputIt,
+    class BinaryOperation>
+GlobOutputIt transform(
+    /// Iterator on begin of first local range
+    InputIt in_a_first,
+    /// Iterator after last element of local range
+    InputIt in_a_last,
+    /// Iterator on begin of second local range
+    GlobInputIt in_b_first,
+    /// Iterator on first element of global output range
+    GlobOutputIt out_first,
+    /// Reduce operation
+    BinaryOperation binary_op,
+    ///Specialization for a global input iterator
+    transform_impl_glob_input_it)
+{
+  using iterator_traits = dash::iterator_traits<InputIt>;
+  DASH_LOG_DEBUG("dash::transform(gaf, gal, gbf, goutf, binop)");
+  auto in_first = in_a_first;
+  auto in_last  = in_a_last;
+
+  if (in_b_first == out_first) {
+    // Output range is rhs input range: C += A
+    // Input is (in_a_first, in_a_last).
+  } else {
+    DASH_THROW(
+      dash::exception::NotImplemented,
+      "dash::transform is only implemented for out = op(in,out)");
+    // Output range different from rhs input range: C = A+B
+    // Input is (in_a_first, in_a_last) + (in_b_first, in_b_last):
+
+    // TODO:
+    // in_range.allocate(...);
+    // in_first = in_range.begin();
+    // in_last  = in_range.end();
+  }
+
+  dash::util::Trace trace("transform");
+
+  // Pattern of input ranges a and b, and output range:
+  auto pattern_in_a = in_a_first.pattern();
+  auto pattern_in_b = in_b_first.pattern();
+  auto pattern_out  = out_first.pattern();
+
+#if __NON_ATOMIC__
+  // Fast path: check if transform operation is local-only:
+  if (pattern_in_a == pattern_in_b &&
+      pattern_in_a == pattern_out) {
+    // Identical pattern in all ranges
+    if (in_a_first.pos() == in_b_first.pos() &&
+        in_a_first.pos() == out_first.pos()) {
+      trace.enter_state("local");
+      // All units operate on local ranges that have identical distribution:
+      auto out_last = dash::transform_local<iterator_traits::value_type>(
+                        in_a_first,
+                        in_a_last,
+                        in_b_first,
+                        out_first,
+                        binary_op);
+      trace.exit_state("local");
+      return out_last;
+    }
+  }
+#endif
+  // Resolve teams from global iterators:
+  dash::Team & team_in_a        = pattern_in_a.team();
+  DASH_ASSERT_MSG(
+    team_in_a == pattern_in_b.team(),
+    "dash::transform: Different teams in input ranges");
+  DASH_ASSERT_MSG(
+    team_in_a == pattern_out.team(),
+    "dash::transform: Different teams in input- and output ranges");
+  // Resolve local range from global range:
+  auto l_index_range_in_a       = local_index_range(in_a_first, in_a_last);
+  DASH_LOG_TRACE_VAR("dash::transform", l_index_range_in_a.begin);
+  DASH_LOG_TRACE_VAR("dash::transform", l_index_range_in_a.end);
+  // Local range to global offset:
+  auto global_offset            = pattern_in_a.global(
+                                    l_index_range_in_a.begin);
+  DASH_LOG_TRACE_VAR("dash::transform", global_offset);
+  // Number of elements in local range:
+  size_t num_local_elements     = l_index_range_in_a.end -
+                                  l_index_range_in_a.begin;
+  DASH_LOG_TRACE_VAR("dash::transform", num_local_elements);
+  // Global iterator to dart_gptr_t:
+  dart_gptr_t dest_gptr         = (out_first + global_offset).dart_gptr();
+  // Native pointer to local sub-range:
+  auto l_values          = (in_a_first + global_offset).local();
+  // Send accumulate message:
+  trace.enter_state("transform_blocking");
+  dash::internal::transform_blocking_impl(
+      dest_gptr,
+      l_values,
+      num_local_elements,
+      binary_op.dart_operation());
+  trace.exit_state("transform_blocking");
+
+  return out_first + global_offset + num_local_elements;
+
+}
+
+template <
+    class InputIt,
+    class GlobInputIt,
+    class GlobOutputIt,
+    class BinaryOperation>
+GlobOutputIt transform(
+    /// Iterator on begin of first local range
+    InputIt in_a_first,
+    /// Iterator after last element of local range
+    InputIt in_a_last,
+    /// Iterator on begin of second local range
+    GlobInputIt in_b_first,
+    /// Iterator on first element of global output range
+    GlobOutputIt out_first,
+    /// Reduce operation
+    BinaryOperation binary_op,
+    transform_impl_local_input_it)
+{
+  DASH_LOG_DEBUG("dash::transform(af, al, bf, outf, binop)");
+  // Outut range different from rhs input range is not supported yet
+  auto in_first = in_a_first;
+  auto in_last  = in_a_last;
+
+  using value_type = typename dash::iterator_traits<InputIt>::value_type;
+  std::vector<value_type> in_range;
+  if (in_b_first == out_first) {
+    // Output range is rhs input range: C += A
+    // Input is (in_a_first, in_a_last).
+  } else {
+    // Output range different from rhs input range: C = A+B
+    // Input is (in_a_first, in_a_last) + (in_b_first, in_b_last):
+    std::transform(
+      in_a_first, in_a_last,
+      in_b_first,
+      std::back_inserter(in_range),
+      binary_op);
+    in_first = in_range.data();
+    in_last  = in_first + in_range.size();
+  }
+
+  dash::util::Trace trace("transform");
+
+  // Resolve local range from global range:
+  // Number of elements in local range:
+  size_t num_local_elements     = std::distance(in_first, in_last);
+  // Global iterator to dart_gptr_t:
+  dart_gptr_t dest_gptr         = out_first.dart_gptr();
+  // Send accumulate message:
+  trace.enter_state("transform_blocking");
+  dash::internal::transform_blocking_impl(
+      dest_gptr,
+      in_first,
+      num_local_elements,
+      binary_op.dart_operation());
+  trace.exit_state("transform_blocking");
+  // The position past the last element transformed in global element space
+  // cannot be resolved from the size of the local range if the local range
+  // spans over more than one block. Otherwise, the difference of two global
+  // iterators is not well-defined. The corresponding invariant is:
+  //   g_out_last == g_out_first + (l_in_last - l_in_first)
+  // Example:
+  //   unit:            0       1       0
+  //   local offset:  | 0 1 2 | 0 1 2 | 3 4 5 | ...
+  //   global offset: | 0 1 2   3 4 5   6 7 8   ...
+  //   range:          [- - -           - -]
+  // When iterating in local memory range [0,5[ of unit 0, the position of the
+  // global iterator to return is 8 != 5
+  // For ranges over block borders, we would have to resolve the global
+  // position past the last element transformed from the iterator's pattern
+  // (see dash::PatternIterator).
+  return out_first + num_local_elements;
 }
 
 } // namespace internal
@@ -150,276 +414,66 @@ OutputIt transform(
  * \ingroup  DashAlgorithms
  */
 template<
-  typename ValueType,
-  class InputIt,
+  class InputIt1,
   class GlobInputIt,
   class GlobOutputIt,
   class BinaryOperation >
 GlobOutputIt transform(
   /// Iterator on begin of first local range
-  InputIt         in_a_first,
+  InputIt1         in_a_first,
   /// Iterator after last element of local range
-  InputIt         in_a_last,
+  InputIt1         in_a_last,
   /// Iterator on begin of second local range
   GlobInputIt     in_b_first,
-  /// Iterator on first element of global output range 
+  /// Iterator on first element of global output range
   GlobOutputIt    out_first,
   /// Reduce operation
   BinaryOperation binary_op);
 
-/**
- * Transform operation on ranges with identical distribution and start
- * offset.
- * In this case, no communication is needed as all output values can be
- * obtained from input values in local memory:
- *
- * \note
- * This function does not execute the transformation as atomic operation
- * on elements. Use \c dash::transform if concurrent access to elements is
- * possible.
- *
- * <pre>
- *   input a: [ u0 | u1 | u2 | ... ]
- *              op   op   op   ...
- *   input b: [ u0 | u1 | u2 | ... ]
- *              =    =    =    ...
- *   output:  [ u0 | u1 | u2 | ... ]
- * </pre>
- */
-template<
-  typename ValueType,
-  class InputAIt,
-  class InputBIt,
-  class OutputIt,
-  class BinaryOperation >
-OutputIt transform_local(
-  InputAIt        in_a_first,
-  InputAIt        in_a_last,
-  InputBIt        in_b_first,
-  OutputIt        out_first,
-  BinaryOperation binary_op)
-{
-  DASH_LOG_DEBUG("dash::transform_local()");
-  DASH_ASSERT_MSG(in_a_first.pattern() == in_b_first.pattern(),
-                  "dash::transform_local: "
-                  "distributions of input ranges differ");
-  DASH_ASSERT_MSG(in_a_first.pattern() == out_first.pattern(),
-                  "dash::transform_local: "
-                  "distributions of input- and output ranges differ");
-  // Local subrange of input range a:
-  auto local_range_a   = dash::local_range(in_a_first, in_a_last);
-  ValueType * lbegin_a = local_range_a.begin;
-  ValueType * lend_a   = local_range_a.end;
-  if (lbegin_a == lend_a) {
-    // Local input range is empty, return initial output iterator to indicate
-    // that no values have been transformed:
-    DASH_LOG_DEBUG("dash::transform_local", "local range empty");
-    return out_first;
-  }
-  // Global offset of first local element:
-  auto g_offset_first    = in_a_first.pattern().global(0);
-  // Number of elements in global ranges:
-  auto num_gvalues       = dash::distance(in_a_first, in_b_first);
-  DASH_LOG_TRACE_VAR("dash::transform_local", num_gvalues);
-  // Number of local elements:
-  DASH_LOG_TRACE("dash::transform_local", "local elements:", lend_a-lbegin_a);
-  // Local subrange of input range b:
-  ValueType * lbegin_b   = (in_b_first + g_offset_first).local();
-  // Local pointer of initial output element:
-  ValueType * lbegin_out = (out_first  + g_offset_first).local();
-  // Generate output values:
-#ifdef DASH_ENABLE_OPENMP
-  dash::util::UnitLocality uloc;
-  auto n_threads = uloc.num_domain_threads();
-  DASH_LOG_DEBUG("dash::transform_local", "thread capacity:",  n_threads);
-  if (n_threads > 1) {
-    auto l_size = lend_a - lbegin_a;
-    // TODO: Vectorize.
-    // Documentation of Intel MIC intrinsics, see:
-    // https://software.intel.com/de-de/node/523533
-    // https://software.intel.com/de-de/node/523387
-    #pragma omp parallel for num_threads(n_threads) schedule(static)
-    for (int i = 0; i < l_size; i++) {
-      lbegin_out[i] = binary_op(lbegin_a[i], lbegin_b[i]);
-    }
-    return out_first + num_gvalues;
-  }
-#endif
-  // No OpenMP or insufficient number of threads for parallelization:
-  for (; lbegin_a != lend_a; ++lbegin_a, ++lbegin_b, ++lbegin_out) {
-    *lbegin_out = binary_op(*lbegin_a, *lbegin_b);
-  }
-  // Return out_end iterator past final transformed element;
-  return out_first + num_gvalues;
-}
 
 /**
  * Local lhs input ranges on global output range.
  *
  */
-template<
-  typename ValueType,
-  class InputIt,
-  class GlobInputIt,
-  class GlobOutputIt,
-  class BinaryOperation >
+template <
+    class InputIt,
+    class GlobInputIt,
+    class GlobOutputIt,
+    class BinaryOperation>
 GlobOutputIt transform(
-  InputIt         in_a_first,
-  InputIt         in_a_last,
-  GlobInputIt     in_b_first,
-  GlobOutputIt    out_first,
-  BinaryOperation binary_op)
+    InputIt         in_a_first,
+    InputIt         in_a_last,
+    GlobInputIt     in_b_first,
+    GlobOutputIt    out_first,
+    BinaryOperation binary_op)
 {
-  DASH_LOG_DEBUG("dash::transform(af, al, bf, outf, binop)");
-  // Outut range different from rhs input range is not supported yet
-  auto in_first = in_a_first;
-  auto in_last  = in_a_last;
-  std::vector<ValueType> in_range;
-  if (in_b_first == out_first) {
-    // Output range is rhs input range: C += A
-    // Input is (in_a_first, in_a_last).
-  } else {
-    // Output range different from rhs input range: C = A+B
-    // Input is (in_a_first, in_a_last) + (in_b_first, in_b_last):
-    std::transform(
-      in_a_first, in_a_last,
+  using InputIt_traits_t    = dash::iterator_traits<InputIt>;
+  using InputIt_is_global_t = typename InputIt_traits_t::is_global_iterator;
+
+  using GlobInputIt_traits_t  = dash::iterator_traits<GlobInputIt>;
+  using GlobOutputIt_traits_t = dash::iterator_traits<GlobOutputIt>;
+
+  // currently we support only two cases: the range [in_a_first, in_a_last] may
+  // be defined by global or non-global  iterators (i.e., any STL iterator).
+  // However, in_b_first and out_first have to be global iterators.
+  static_assert(
+      GlobInputIt_traits_t::is_global_iterator::value,
+      "in_b_first must be a global iterator");
+
+  static_assert(
+      GlobOutputIt_traits_t::is_global_iterator::value,
+      "out_first must be a global iterator");
+
+  return internal::transform(
+      in_a_first,
+      in_a_last,
       in_b_first,
-      std::back_inserter(in_range),
-      binary_op);
-    in_first = in_range.data();
-    in_last  = in_first + in_range.size();
-  }
-
-  dash::util::Trace trace("transform");
-
-  // Resolve local range from global range:
-  // Number of elements in local range:
-  size_t num_local_elements     = std::distance(in_first, in_last);
-  // Global iterator to dart_gptr_t:
-  dart_gptr_t dest_gptr         = out_first.dart_gptr();
-  // Send accumulate message:
-  trace.enter_state("transform_blocking");
-  dash::internal::transform_blocking_impl(
-      dest_gptr,
-      in_first,
-      num_local_elements,
-      binary_op.dart_operation());
-  trace.exit_state("transform_blocking");
-  // The position past the last element transformed in global element space
-  // cannot be resolved from the size of the local range if the local range
-  // spans over more than one block. Otherwise, the difference of two global
-  // iterators is not well-defined. The corresponding invariant is:
-  //   g_out_last == g_out_first + (l_in_last - l_in_first)
-  // Example:
-  //   unit:            0       1       0
-  //   local offset:  | 0 1 2 | 0 1 2 | 3 4 5 | ...
-  //   global offset: | 0 1 2   3 4 5   6 7 8   ...
-  //   range:          [- - -           - -]
-  // When iterating in local memory range [0,5[ of unit 0, the position of the
-  // global iterator to return is 8 != 5
-  // For ranges over block borders, we would have to resolve the global
-  // position past the last element transformed from the iterator's pattern
-  // (see dash::PatternIterator).
-  return out_first + num_local_elements;
-}
-
-/**
- * Specialization of \c dash::transform for global lhs input range.
- */
-template<
-  typename ValueType,
-  class PatternType,
-  class GlobInputIt,
-  class GlobOutputIt,
-  class BinaryOperation >
-GlobOutputIt transform(
-  GlobIter<ValueType, PatternType> in_a_first,
-  GlobIter<ValueType, PatternType> in_a_last,
-  GlobInputIt                      in_b_first,
-  GlobOutputIt                     out_first,
-  BinaryOperation                  binary_op = dash::plus<ValueType>())
-{
-  DASH_LOG_DEBUG("dash::transform(gaf, gal, gbf, goutf, binop)");
-  auto in_first = in_a_first;
-  auto in_last  = in_a_last;
-
-  if (in_b_first == out_first) {
-    // Output range is rhs input range: C += A
-    // Input is (in_a_first, in_a_last).
-  } else {
-    DASH_THROW(
-      dash::exception::NotImplemented,
-      "dash::transform is only implemented for out = op(in,out)");
-    // Output range different from rhs input range: C = A+B
-    // Input is (in_a_first, in_a_last) + (in_b_first, in_b_last):
-
-    // TODO:
-    // in_range.allocate(...);
-    // in_first = in_range.begin();
-    // in_last  = in_range.end();
-  }
-
-  dash::util::Trace trace("transform");
-
-  // Pattern of input ranges a and b, and output range:
-  auto pattern_in_a = in_a_first.pattern();
-  auto pattern_in_b = in_b_first.pattern();
-  auto pattern_out  = out_first.pattern();
-
-#if __NON_ATOMIC__
-  // Fast path: check if transform operation is local-only:
-  if (pattern_in_a == pattern_in_b &&
-      pattern_in_a == pattern_out) {
-    // Identical pattern in all ranges
-    if (in_a_first.pos() == in_b_first.pos() &&
-        in_a_first.pos() == out_first.pos()) {
-      trace.enter_state("local");
-      // All units operate on local ranges that have identical distribution:
-      auto out_last = dash::transform_local<ValueType>(
-                        in_a_first,
-                        in_a_last,
-                        in_b_first,
-                        out_first,
-                        binary_op);
-      trace.exit_state("local");
-      return out_last;
-    }
-  }
-#endif
-  // Resolve teams from global iterators:
-  dash::Team & team_in_a        = pattern_in_a.team();
-  DASH_ASSERT_MSG(
-    team_in_a == pattern_in_b.team(),
-    "dash::transform: Different teams in input ranges");
-  DASH_ASSERT_MSG(
-    team_in_a == pattern_out.team(),
-    "dash::transform: Different teams in input- and output ranges");
-  // Resolve local range from global range:
-  auto l_index_range_in_a       = local_index_range(in_a_first, in_a_last);
-  DASH_LOG_TRACE_VAR("dash::transform", l_index_range_in_a.begin);
-  DASH_LOG_TRACE_VAR("dash::transform", l_index_range_in_a.end);
-  // Local range to global offset:
-  auto global_offset            = pattern_in_a.global(
-                                    l_index_range_in_a.begin);
-  DASH_LOG_TRACE_VAR("dash::transform", global_offset);
-  // Number of elements in local range:
-  size_t num_local_elements     = l_index_range_in_a.end -
-                                  l_index_range_in_a.begin;
-  DASH_LOG_TRACE_VAR("dash::transform", num_local_elements);
-  // Global iterator to dart_gptr_t:
-  dart_gptr_t dest_gptr         = (out_first + global_offset).dart_gptr();
-  // Native pointer to local sub-range:
-  ValueType * l_values          = (in_a_first + global_offset).local();
-  // Send accumulate message:
-  trace.enter_state("transform_blocking");
-  dash::internal::transform_blocking_impl(
-      dest_gptr,
-      l_values,
-      num_local_elements,
-      binary_op.dart_operation());
-  trace.exit_state("transform_blocking");
-
-  return out_first + global_offset + num_local_elements;
+      out_first,
+      binary_op,
+      typename std::conditional<
+          InputIt_is_global_t::value,
+          internal::transform_impl_glob_input_it,
+          internal::transform_impl_local_input_it>::type());
 }
 
 /**

--- a/dash/include/dash/algorithm/Transform.h
+++ b/dash/include/dash/algorithm/Transform.h
@@ -21,6 +21,103 @@
 
 namespace dash {
 
+#ifdef DOXYGEN
+
+/**
+ * Apply a given function to elements in a range and store the result in
+ * another range, beginning at \c out_first.
+ * Corresponding to \c MPI_Accumulate, the unary operation is executed
+ * atomically on single elements.
+ *
+ * Precondition: All elements in the input range are contained in a single
+ * block so that
+ *
+ * <tt>
+ *   g_out_last == g_out_first + (l_in_last - l_in_first)
+ * </tt>
+ *
+ * Semantics:
+ *
+ * <tt>
+ *   unary_op(in_first[0]), unary_op(in_first[1]), ..., unary_op(in_first[n])
+ * </tt>
+ *
+ * \returns  Output iterator to the element past the last element transformed.
+ *
+ * \ingroup  DashAlgorithms
+ */
+template<
+  typename ValueType,
+  class InputIt,
+  class OutputIt,
+  class UnaryOperation >
+OutputIt transform(
+  InputIt        in_first,
+  InputIt        in_last,
+  OutputIt       out_first,
+  UnaryOperation unary_op);
+
+/**
+ * Apply a given function to pairs of elements from two ranges and store the
+ * result in another range, beginning at \c out_first.
+ *
+ * Corresponding to \c MPI_Accumulate, the binary operation is executed
+ * atomically on single elements.
+ *
+ * Precondition: All elements in the input range are contained in a single
+ * block so that
+ *
+ *   g_out_last == g_out_first + (l_in_last - l_in_first)
+ *
+ * Semantics:
+ *
+ *   binary_op(in_a[0], in_b[0]),
+ *   binary_op(in_a[1], in_b[1]),
+ *   ...,
+ *   binary_op(in_a[n], in_b[n])
+ *
+ * Example:
+ * \code
+ *   gptr_diff_t num_transformed_elements =
+ *                 dash::distance(
+ *                   dash::transform(in.begin(), in.end(),  // A
+ *                                   out.begin(),           // B
+ *                                   out.begin(),           // C = op(A, B)
+ *                                   dash::plus<int>()),    // op
+ *                   out.end());
+ *
+ * \endcode
+ *
+ * \returns  Output iterator to the element past the last element transformed.
+ * \see      dash::accumulate
+ * \see      DashReduceOperations
+ *
+ * \tparam   InputIt         Iterator on first (local) input range
+ * \tparam   GlobInputIt     Iterator on second (global) input range
+ * \tparam   GlobOutputIt    Iterator on global result range
+ * \tparam   BinaryOperation Reduce operation type
+ *
+ * \ingroup  DashAlgorithms
+ */
+template<
+  class InputIt1,
+  class GlobInputIt,
+  class GlobOutputIt,
+  class BinaryOperation >
+GlobOutputIt transform(
+  /// Iterator on begin of first local range
+  InputIt1         in_a_first,
+  /// Iterator after last element of local range
+  InputIt1         in_a_last,
+  /// Iterator on begin of second local range
+  GlobInputIt     in_b_first,
+  /// Iterator on first element of global output range
+  GlobOutputIt    out_first,
+  /// Reduce operation
+  BinaryOperation binary_op);
+
+#else
+
 namespace internal {
 
 /**
@@ -337,104 +434,8 @@ GlobOutputIt transform(
 
 } // namespace internal
 
-/**
- * Apply a given function to elements in a range and store the result in
- * another range, beginning at \c out_first.
- * Corresponding to \c MPI_Accumulate, the unary operation is executed
- * atomically on single elements.
- *
- * Precondition: All elements in the input range are contained in a single
- * block so that
- *
- * <tt>
- *   g_out_last == g_out_first + (l_in_last - l_in_first)
- * </tt>
- *
- * Semantics:
- *
- * <tt>
- *   unary_op(in_first[0]), unary_op(in_first[1]), ..., unary_op(in_first[n])
- * </tt>
- *
- * \returns  Output iterator to the element past the last element transformed.
- *
- * \ingroup  DashAlgorithms
- */
-template<
-  typename ValueType,
-  class InputIt,
-  class OutputIt,
-  class UnaryOperation >
-OutputIt transform(
-  InputIt        in_first,
-  InputIt        in_last,
-  OutputIt       out_first,
-  UnaryOperation unary_op);
-
-/**
- * Apply a given function to pairs of elements from two ranges and store the
- * result in another range, beginning at \c out_first.
- *
- * Corresponding to \c MPI_Accumulate, the binary operation is executed
- * atomically on single elements.
- *
- * Precondition: All elements in the input range are contained in a single
- * block so that
- *
- *   g_out_last == g_out_first + (l_in_last - l_in_first)
- *
- * Semantics:
- *
- *   binary_op(in_a[0], in_b[0]),
- *   binary_op(in_a[1], in_b[1]),
- *   ...,
- *   binary_op(in_a[n], in_b[n])
- *
- * Example:
- * \code
- *   gptr_diff_t num_transformed_elements =
- *                 dash::distance(
- *                   dash::transform(in.begin(), in.end(),  // A
- *                                   out.begin(),           // B
- *                                   out.begin(),           // C = op(A, B)
- *                                   dash::plus<int>()),    // op
- *                   out.end());
- *
- * \endcode
- *
- * \returns  Output iterator to the element past the last element transformed.
- * \see      dash::accumulate
- * \see      DashReduceOperations
- *
- * \tparam   InputIt         Iterator on first (local) input range
- * \tparam   GlobInputIt     Iterator on second (global) input range
- * \tparam   GlobOutputIt    Iterator on global result range
- * \tparam   BinaryOperation Reduce operation type
- *
- * \ingroup  DashAlgorithms
- */
-template<
-  class InputIt1,
-  class GlobInputIt,
-  class GlobOutputIt,
-  class BinaryOperation >
-GlobOutputIt transform(
-  /// Iterator on begin of first local range
-  InputIt1         in_a_first,
-  /// Iterator after last element of local range
-  InputIt1         in_a_last,
-  /// Iterator on begin of second local range
-  GlobInputIt     in_b_first,
-  /// Iterator on first element of global output range
-  GlobOutputIt    out_first,
-  /// Reduce operation
-  BinaryOperation binary_op);
 
 
-/**
- * Local lhs input ranges on global output range.
- *
- */
 template <
     class InputIt,
     class GlobInputIt,
@@ -499,6 +500,8 @@ GlobAsyncRef<ValueType> transform(
     dash::exception::NotImplemented,
     "Async variant of dash::transform is not implemented");
 }
+
+#endif
 
 } // namespace dash
 

--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -406,7 +406,7 @@ public:
    */
   constexpr bool is_local() const
   {
-    return (dash::Team::All().myid() == lpos().unit);
+    return (_globmem->team().myid() == lpos().unit);
   }
 
   /**
@@ -442,7 +442,7 @@ public:
     local_pos_t local_pos = _pattern->local(idx);
     DASH_LOG_TRACE_VAR("GlobIter.local= >", local_pos.unit);
     DASH_LOG_TRACE_VAR("GlobIter.local= >", local_pos.index);
-    if (dash::Team::All().myid() != local_pos.unit) {
+    if (_globmem->team().myid() != local_pos.unit) {
       // Iterator position does not point to local element
       return nullptr;
     }

--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -134,30 +134,19 @@ private:
 
 protected:
   /// Global memory used to dereference iterated values.
-  GlobMemType          * _globmem;
+  GlobMemType          * _globmem         = nullptr;
   /// Pattern that specifies the iteration order (access pattern).
-  const PatternType    * _pattern;
+  const PatternType    * _pattern         = nullptr;
   /// Current position of the iterator in global canonical index space.
   index_type             _idx             = 0;
   /// Maximum position allowed for this iterator.
   index_type             _max_idx         = 0;
-  /// Unit id of the active unit
-  team_unit_t            _myid;
   /// Pointer to first element in local memory
   local_pointer          _lbegin          = nullptr;
 
 public:
-  /**
-   * Default constructor.
-   */
-  constexpr GlobIter()
-  : _globmem(nullptr),
-    _pattern(nullptr),
-    _idx(0),
-    _max_idx(0),
-    _myid(dash::Team::All().myid()),
-    _lbegin(nullptr)
-  { }
+
+  constexpr GlobIter() = default;
 
   /**
    * Constructor, creates a global iterator on global memory following
@@ -165,13 +154,12 @@ public:
    */
   constexpr GlobIter(
     GlobMemType       * gmem,
-	  const PatternType & pat,
-	  index_type          position = 0)
+    const PatternType & pat,
+    index_type          position = 0)
   : _globmem(gmem),
     _pattern(&pat),
     _idx(position),
     _max_idx(pat.size() - 1),
-    _myid(pat.team().myid()),
     _lbegin(_globmem->lbegin())
   { }
 
@@ -179,17 +167,14 @@ public:
    * Copy constructor.
    */
   template <
-    class    P_,
-    class    GM_,
     class    Ptr_,
     class    Ref_ >
   constexpr GlobIter(
-    const GlobIter<nonconst_value_type, P_, GM_, Ptr_, Ref_> & other)
+    const GlobIter<nonconst_value_type, PatternType, GlobMemType, Ptr_, Ref_> & other)
   : _globmem(other._globmem)
   , _pattern(other._pattern)
   , _idx    (other._idx)
   , _max_idx(other._max_idx)
-  , _myid   (other._myid)
   , _lbegin (other._lbegin)
   { }
 
@@ -197,17 +182,14 @@ public:
    * Move constructor.
    */
   template <
-    class    P_,
-    class    GM_,
     class    Ptr_,
     class    Ref_ >
   constexpr GlobIter(
-    GlobIter<nonconst_value_type, P_, GM_, Ptr_, Ref_> && other)
+    GlobIter<nonconst_value_type, PatternType, GlobMemType, Ptr_, Ref_> && other)
   : _globmem(other._globmem)
   , _pattern(other._pattern)
   , _idx    (other._idx)
   , _max_idx(other._max_idx)
-  , _myid   (other._myid)
   , _lbegin (other._lbegin)
   { }
 
@@ -216,18 +198,15 @@ public:
    */
   template <
     typename T_,
-    class    P_,
-    class    GM_,
     class    Ptr_,
     class    Ref_ >
   self_t & operator=(
-    const GlobIter<T_, P_, GM_, Ptr_, Ref_ > & other)
+    const GlobIter<T_, PatternType, GlobMemType, Ptr_, Ref_ > & other)
   {
     _globmem = other._globmem;
     _pattern = other._pattern;
     _idx     = other._idx;
     _max_idx = other._max_idx;
-    _myid    = other._myid;
     _lbegin  = other._lbegin;
     return *this;
   }
@@ -237,18 +216,15 @@ public:
    */
   template <
     typename T_,
-    class    P_,
-    class    GM_,
     class    Ptr_,
     class    Ref_ >
   self_t & operator=(
-    GlobIter<T_, P_, GM_, Ptr_, Ref_ > && other)
+    GlobIter<T_, PatternType, GlobMemType, Ptr_, Ref_ > && other)
   {
     _globmem = other._globmem;
     _pattern = other._pattern;
     _idx     = other._idx;
     _max_idx = other._max_idx;
-    _myid    = other._myid;
     _lbegin  = other._lbegin;
     // no ownership to transfer
     return *this;
@@ -430,7 +406,7 @@ public:
    */
   constexpr bool is_local() const
   {
-    return (_myid == lpos().unit);
+    return (dash::Team::All().myid() == lpos().unit);
   }
 
   /**
@@ -466,7 +442,7 @@ public:
     local_pos_t local_pos = _pattern->local(idx);
     DASH_LOG_TRACE_VAR("GlobIter.local= >", local_pos.unit);
     DASH_LOG_TRACE_VAR("GlobIter.local= >", local_pos.index);
-    if (_myid != local_pos.unit) {
+    if (dash::Team::All().myid() != local_pos.unit) {
       // Iterator position does not point to local element
       return nullptr;
     }

--- a/dash/include/dash/iterator/IteratorTraits.h
+++ b/dash/include/dash/iterator/IteratorTraits.h
@@ -1,0 +1,72 @@
+#ifndef DASH__ITERATOR_TRAITS_H__INCLUDED
+#define DASH__ITERATOR_TRAITS_H__INCLUDED
+
+#include <iterator>
+#include <type_traits>
+
+#include <dash/Meta.h>
+
+#include <dash/iterator/GlobIter.h>
+#include <dash/iterator/GlobViewIter.h>
+
+namespace dash {
+
+namespace detail {
+
+template <typename Iterator>
+struct is_global_iterator : std::false_type {
+};
+
+template <
+    typename ElementType,
+    class PatternType,
+    class GlobMemType,
+    class PointerType,
+    class ReferenceType>
+struct is_global_iterator<GlobViewIter<
+    ElementType,
+    PatternType,
+    GlobMemType,
+    PointerType,
+    ReferenceType>> : std::true_type {
+};
+
+template <
+    typename ElementType,
+    class PatternType,
+    class GlobMemType,
+    class PointerType,
+    class ReferenceType>
+struct is_global_iterator<GlobIter<
+    ElementType,
+    PatternType,
+    GlobMemType,
+    PointerType,
+    ReferenceType>> : std::true_type {
+};
+
+/// iterator traits index_type
+
+DASH__META__DEFINE_TRAIT__HAS_TYPE(index_type)
+
+template <class _Iter, bool = has_type_index_type<_Iter>::value>
+struct iterator_traits_index_type {
+  typedef typename _Iter::index_type type;
+};
+
+template <class _Iter>
+struct iterator_traits_index_type<_Iter, false> {
+  typedef dash::default_index_t type;
+};
+
+}  // namespace detail
+
+template <typename Iterator>
+struct iterator_traits : std::iterator_traits<Iterator> {
+  using is_global_iterator = typename detail::is_global_iterator<Iterator>;
+  using index_type =
+      typename detail::iterator_traits_index_type<Iterator>::type;
+};
+
+}  // namespace dash
+#endif

--- a/dash/include/dash/view/ViewOrigin.h
+++ b/dash/include/dash/view/ViewOrigin.h
@@ -48,8 +48,9 @@ public:
   self_t & operator=(self_t &&)         = default;
   self_t & operator=(const self_t &)    = default;
 
+  template <std::size_t N>
   constexpr explicit ViewOrigin(
-      std::initializer_list<index_type> extents)
+      std::array<dim_t, N> extents)
   : _extents(extents)
   , _index_set(*this)
   { }
@@ -65,7 +66,7 @@ public:
   constexpr bool operator==(const self_t & rhs) const {
     return (this == &rhs);
   }
-  
+
   constexpr bool operator!=(const self_t & rhs) const {
     return !(*this == rhs);
   }
@@ -101,7 +102,7 @@ public:
   }
 
   // ---- size ------------------------------------------------------------
-  
+
   template <dim_t SizeDim = 0>
   constexpr index_type size() const {
     return extent<SizeDim>() *

--- a/dash/test/algorithm/TransformTest.cc
+++ b/dash/test/algorithm/TransformTest.cc
@@ -28,7 +28,7 @@ TEST_F(TransformTest, ArrayLocalPlusLocal)
   dash::barrier();
 
   // Identical start offsets in all ranges (begin() = 0):
-  dash::transform<int>(
+  dash::transform(
       array_in.begin(), array_in.end(), // A
       array_dest.begin(),               // B
       array_dest.begin(),               // C = op(A,B)
@@ -81,7 +81,7 @@ TEST_F(TransformTest, ArrayGlobalPlusLocalBlocking)
   for (size_t block_idx = 0; block_idx < dash::size(); ++block_idx) {
     auto block_offset  = block_idx * num_elem_local;
     auto transform_end =
-      dash::transform<int>(&(*local.begin()), &(*local.end()), // A
+      dash::transform(&(*local.begin()), &(*local.end()), // A
                            array_dest.begin() + block_offset,  // B
                            array_dest.begin() + block_offset,  // B = op(B,A)
                            dash::plus<int>());                 // op
@@ -138,7 +138,7 @@ TEST_F(TransformTest, ArrayGlobalPlusGlobalBlocking)
   dash::barrier();
 
   // Accumulate local range to every block in the array:
-  dash::transform<int>(array_values.begin(), array_values.end(), // A
+  dash::transform(array_values.begin(), array_values.end(), // A
                        array_dest.begin(),                       // B
                        array_dest.begin(),                       // B = B op A
                        dash::plus<int>());                       // op

--- a/dash/test/types/GlobIterTest.cc
+++ b/dash/test/types/GlobIterTest.cc
@@ -25,3 +25,34 @@ TEST_F(GlobIterTest, IteratorTypes)
         "Array<Atomic<T>>::const_iterator not trivially copyable");
   }
 }
+
+TEST_F(GlobIterTest, RemoteIterator){
+  using array_t = dash::Array<int>;
+  array_t                        values(dash::size());
+  dash::Array<array_t::iterator> iterators(dash::size());
+
+  int myid = dash::myid();
+  *(values.lbegin())    = myid;
+  *(iterators.lbegin()) = values.begin()+myid;
+
+  values.barrier();
+  iterators.barrier();
+
+  int right_neighbor = (myid + 1) % dash::size();
+  array_t::iterator it = iterators[right_neighbor];
+  // check positions of iterators
+  // that has to work independently of the memory
+  ASSERT_EQ_U(it.pos(), right_neighbor);
+
+  // increment neighbors value
+  // that does not work, as the position depends on the global memory instance
+  // which is not available on the remote unit (at given pointer)
+  /*
+  auto gref = *it;
+  ++gref;
+
+  values.barrier();
+  int newval =  *(values.lbegin());
+  ASSERT_EQ_U(newval, myid+1);
+  */
+}

--- a/dash/test/types/GlobIterTest.cc
+++ b/dash/test/types/GlobIterTest.cc
@@ -1,0 +1,27 @@
+
+#include "../TestBase.h"
+#include "../TestLogHelpers.h"
+#include "GlobIterTest.h"
+
+#include <type_traits>
+#include <dash/Array.h>
+#include <dash/Atomic.h>
+
+
+TEST_F(GlobIterTest, IteratorTypes)
+{
+  {
+    using array_t = dash::Array<int>;
+    static_assert(std::is_trivially_copyable<array_t::iterator>::value,
+        "Array::iterator not trivially copyable");
+    static_assert(std::is_trivially_copyable<array_t::const_iterator>::value,
+        "Array::const_iterator not trivially copyable");
+  }
+  {
+    using array_t = dash::Array<dash::Atomic<int>>;
+    static_assert(std::is_trivially_copyable<array_t::iterator>::value,
+        "Array<Atomic<T>>::iterator not trivially copyable");
+    static_assert(std::is_trivially_copyable<array_t::const_iterator>::value,
+        "Array<Atomic<T>>::const_iterator not trivially copyable");
+  }
+}

--- a/dash/test/types/GlobIterTest.h
+++ b/dash/test/types/GlobIterTest.h
@@ -1,0 +1,15 @@
+#ifndef DASH__TEST__GLOBREF_TEST_H_
+#define DASH__TEST__GLOBREF_TEST_H_
+
+#include <gtest/gtest.h>
+
+#include "../TestBase.h"
+
+
+/**
+ * Test fixture for global iterators
+ */
+class GlobIterTest: public dash::test::TestBase {
+};
+
+#endif // DASH__TEST__GLOBREF_TEST_H_


### PR DESCRIPTION
We have talked couple of times about introducing DASH iterator traits. I have finally found some time to start implementing it.
The main reason is that as soon as we change the internal template parameter types for `GlobIter`, `GlobViewIter` and their other friends, our DASH algorithms do not compile anymore. This is because the iterator types are hard-coded into the algorithms interface which of course is not really a generic interface. We are on the way to implement additional global iterators (e.g. `GlobListIter`, `HaloIter`, etc.) and all of them should be applicable to our algorithms. If one cannot use the generic variant we always can specialize it for specific iterator traits instead of the concrete iterator type. I struggled with this stuff while integrating memory spaces and expect to need it for additional features such as Alpakka and so on.

The basic interface can be found in the [IteratorTraits.h](https://github.com/dash-project/dash/compare/development...rkowalewski:feat-iterator-traits?expand=1#diff-a5900ca4cfdf9ac684b4ec01d867e706R65). It is simply an extension of `std::iterator_traits` and I not not claim to be complete. This is subject to discussion here.

I modified couple of algorithms to use the iterator traits interface. A very nice example can be found in [Transform.h](https://github.com/dash-project/dash/compare/development...rkowalewski:feat-iterator-traits?expand=1#diff-4b4f4f666df31f6b6e1196aa861ec43bR444). It shows how we can use tag dispatching based on the iterator traits to delegate to the proper implementation. The public interface is not "polluted" with implementation specific types and `static_assert` statements tell the user what variants we currently support. As a positive side effect we not not need the to specify the value type for `dash::transform` anymore (see `TransformTest.cc`).
Tag dispatching in general accords very well with future features like execution policies and enables to hide the implementation details in internal namespaces. If tag dispatching is too much overkill we can always use SFINAE. An example for this can be found in [MinMax.h](https://github.com/dash-project/dash/compare/development...rkowalewski:feat-iterator-traits?expand=1#diff-e80ab11ec934ebb2b008bc1bca927879R156). It uses SFINAE to decide if we call `dash::min_element` on a global or a local (STL) iterator. I am not claiming that this is the best solution here, comments are always welcome.

However, we have an easily extensible iterator traits interface now and I think it greatly simplifies changing internal implementation details.

