### PR TITLE
[FIX] pos is not a member of GlobPtr

### DIFF
--- a/dash/include/dash/algorithm/Copy.h
+++ b/dash/include/dash/algorithm/Copy.h
@@ -232,7 +232,7 @@ GlobOutputIt copy_impl(
   DASH_LOG_TRACE("dash::copy_impl()",
                  "l_in_first:",  in_first,
                  "l_in_last:",   in_last,
-                 "g_out_first:", out_first.pos());
+                 "g_out_first:", out_first);
 
   auto num_elements = std::distance(in_first, in_last);
   dart_handle_t handle;


### PR DESCRIPTION
I am not sure why this compilation error occurred today. It seems that this bug has been persistent for a long time.  This bug manifests with ENABLE_TRACE=1 in [CopyTest](https://github.com/dash-project/dash/blob/development/dash/test/algorithm/CopyTest.cc#L448), where a `GlobPtr` is passed as the output iterator. Mysterious. Anyway, it is a fix.