### PR TITLE
Move content of `.gitignore` to `.gitmodules`.

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,2 +1,0 @@
-[submodule "vendor/googletest"]
-    ignore = all

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vendor/googletest"]
 	path = vendor/googletest
 	url = https://github.com/google/googletest.git
+	ignore = all


### PR DESCRIPTION
Git does not read any full fledged config file from the repository, in
particular any `.gitconfig`. Thus this file is useless, without a
`include.path` statement in any config file Git is reading (i.e.,
`.git/config`). Though it reads `.gitmodules` and as the content of
`.gitconfig` is sub-modules related anyway, it has an effect, if it is in
this file. Do so.