### PR TITLE
Prohibit implicit conversion between different GlobPtr

### DIFF
--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -197,9 +197,32 @@ public:
   constexpr GlobPtr(const self_t & other)      = default;
 
   /**
+   * Copy constructor (memory space conversion).
+   */
+  template <class MemSpaceT>
+  constexpr GlobPtr(const GlobPtr<ElementType, MemSpaceT> & other)
+  : _rbegin_gptr(other._rbegin_gptr)
+  , _mem_space(reinterpret_cast<const MemorySpace *>(other._mem_space))
+  , _lsize(other._lsize)
+  , _unit_end(other._unit_end)
+  { }
+
+  /**
    * Assignment operator.
    */
   self_t & operator=(const self_t & rhs)       = default;
+
+  /**
+   * Assignment operator (memory space conversion).
+   */
+  template<class MemSpaceT>
+  self_t & operator=(const GlobPtr<ElementType, MemSpaceT>& other) {
+    _rbegin_gptr = other._rbegin_gptr;
+    _mem_space   = reinterpret_cast<const MemorySpace *>(other._mem_space);
+    _lsize       = other._lsize;
+    _unit_end    = other._unit_end;
+    return *this;
+  }
 
   /**
    * Cast operator.

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -197,32 +197,18 @@ public:
   constexpr GlobPtr(const self_t & other)      = default;
 
   /**
-   * Copy constructor.
-   */
-  template <typename T, class MemSpaceT>
-  constexpr GlobPtr(const GlobPtr<T, MemSpaceT> & other)
-  : _rbegin_gptr(other._rbegin_gptr)
-  , _mem_space(reinterpret_cast<const MemorySpace *>(other._mem_space))
-  , _lsize(other._lsize)
-  , _unit_end(other._unit_end)
-  { }
-
-  /**
    * Assignment operator.
    */
   self_t & operator=(const self_t & rhs)       = default;
 
   /**
-   * Assignment operator.
+   * Cast operator.
    */
   template <typename T, class MemSpaceT>
-  self_t & operator=(const GlobPtr<T, MemSpaceT> & other)
-  {
-    _rbegin_gptr = other._rbegin_gptr;
-    _mem_space   = reinterpret_cast<const MemorySpace *>(other._mem_space);
-    _lsize       = other._lsize;
-    _unit_end    = other._unit_end;
-    return *this;
+  explicit
+  operator GlobPtr<T, MemSpaceT>() {
+    return GlobPtr<T, MemSpaceT>(
+      reinterpret_cast<const MemSpaceT *>(_mem_space), _rbegin_gptr);
   }
 
   /**

--- a/dash/test/types/GlobPtrTest.cc
+++ b/dash/test/types/GlobPtrTest.cc
@@ -1,0 +1,35 @@
+
+#include "../TestBase.h"
+#include "../TestLogHelpers.h"
+#include "GlobPtrTest.h"
+
+#include <dash/Array.h>
+#include <dash/algorithm/Fill.h>
+#include <dash/algorithm/Copy.h>
+
+
+TEST_F(GlobPtrTest, CastAssignment)
+{
+  auto igptr = dash::memalloc<int>(1);
+  auto cgptr = dash::memalloc<char>(1);
+  dash::memfree(cgptr);
+
+  igptr[0] = 255;
+  ASSERT_EQ_U(255, igptr[0]);
+
+  // should not work!
+  //decltype(igptr) igptr2 = dgptr;
+
+  // should do!
+  cgptr = static_cast<decltype(cgptr)>(igptr);
+
+  cgptr[0] = 0;
+  cgptr[1] = 0;
+  cgptr[2] = 0;
+  cgptr[3] = 0;
+
+  ASSERT_EQ_U(0, igptr[0]);
+
+  dash::memfree(igptr);
+
+}

--- a/dash/test/types/GlobPtrTest.h
+++ b/dash/test/types/GlobPtrTest.h
@@ -1,0 +1,24 @@
+#ifndef DASH__TEST__GLOBREF_TEST_H_
+#define DASH__TEST__GLOBREF_TEST_H_
+
+#include <gtest/gtest.h>
+
+#include "../TestBase.h"
+
+
+/**
+ * Test fixture for \c dash::GlobRef.
+ */
+class GlobPtrTest : public dash::test::TestBase {
+protected:
+  size_t _dash_id    = 0;
+  size_t _dash_size  = 0;
+
+  virtual void SetUp() {
+    dash::test::TestBase::SetUp();
+    _dash_id   = dash::myid();
+    _dash_size = dash::size();
+  }
+};
+
+#endif // DASH__TEST__GLOBREF_TEST_H_


### PR DESCRIPTION
Prohibit implicit conversion between different GlobPtr types and provide explicit conversion operator

Equivalent in C++
```
double *dbuf = new double[N];
int *ibuf = dbuf; // << not allowed
int *ibuf = static_cast<int*>(dbuf); // allowed, you know what you do!
```

See new test case for an example.

Thanks to @tuxamito for reporting this