### PR TITLE
GlobRef: Fix compiler warning in conversion operators

### DIFF
--- a/dash/include/dash/GlobAsyncRef.h
+++ b/dash/include/dash/GlobAsyncRef.h
@@ -142,6 +142,8 @@ public:
   /**
    * Implicit conversion to const.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, nonconst_value_type>::value,void>>
   operator GlobAsyncRef<const_value_type>() {
     return GlobAsyncRef<const_value_type>(_gptr);
   }
@@ -149,6 +151,8 @@ public:
   /**
    * Excpliti conversion to non-const.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, const_value_type>::value,void>>
   explicit
   operator GlobAsyncRef<nonconst_value_type>() {
     return GlobAsyncRef<nonconst_value_type>(_gptr);

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -191,6 +191,8 @@ public:
   /**
    * Implicit cast to const.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, nonconst_value_type>::value,void>>
   operator GlobRef<const_value_type> () const {
     return GlobRef<const_value_type>(_gptr);
   }
@@ -198,6 +200,8 @@ public:
   /**
    * Explicit cast to non-const
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, const_value_type>::value,void>>
   explicit
   operator GlobRef<nonconst_value_type> () const {
     return GlobRef<nonconst_value_type>(_gptr);

--- a/dash/include/dash/atomic/GlobAtomicAsyncRef.h
+++ b/dash/include/dash/atomic/GlobAtomicAsyncRef.h
@@ -119,11 +119,15 @@ public:
   inline bool operator==(const T & value) const = delete;
   inline bool operator!=(const T & value) const = delete;
 
+  template<class = std::enable_if<
+                     std::is_same<value_type, nonconst_value_type>::value,void>>
   operator GlobAsyncRef<const_atomic_t>()
   {
     return GlobAsyncRef<const_atomic_t>(_gptr);
   }
 
+  template<class = std::enable_if<
+                     std::is_same<value_type, const_value_type>::value,void>>
   explicit
   operator GlobAsyncRef<nonconst_atomic_t>()
   {

--- a/dash/include/dash/atomic/GlobAtomicRef.h
+++ b/dash/include/dash/atomic/GlobAtomicRef.h
@@ -119,6 +119,8 @@ return load();
   /**
    * Implicit conversion to const type.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, nonconst_value_type>::value,void>>
   operator const_type() const {
     return const_type(_gptr);
   }
@@ -126,6 +128,8 @@ return load();
   /**
    * Explicit conversion to non-const type.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, const_value_type>::value,void>>
   explicit
   operator nonconst_type() const {
     return nonconst_type(_gptr);


### PR DESCRIPTION
Introduced by #458, only reported by Intel compiler