### PR TITLE
Fix local allocation that are not power of 2

### DIFF
--- a/dart-impl/mpi/src/dart_mem.c
+++ b/dart-impl/mpi/src/dart_mem.c
@@ -118,15 +118,10 @@ _mark_parent(struct dart_buddy * self, int index) {
 
 size_t
 dart_buddy_alloc(struct dart_buddy * self, size_t s) {
-  int size;
   // honor the alignment
-  s >>= DART_MEM_ALIGN_BITS;
-	if (s == 0) {
-		size = 1;
-	}
-	else {
-		size = (int)next_pow_of_2(s);
-	}
+  int size = (s >> DART_MEM_ALIGN_BITS);
+  if ((size<<DART_MEM_ALIGN_BITS) < s) ++size;
+  size = (int)next_pow_of_2(size);
 	int length = 1 << self->level;
 
 	if (size > length)

--- a/dash/include/dash/GlobAsyncRef.h
+++ b/dash/include/dash/GlobAsyncRef.h
@@ -142,6 +142,8 @@ public:
   /**
    * Implicit conversion to const.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, nonconst_value_type>::value,void>>
   operator GlobAsyncRef<const_value_type>() {
     return GlobAsyncRef<const_value_type>(_gptr);
   }
@@ -149,6 +151,8 @@ public:
   /**
    * Excpliti conversion to non-const.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, const_value_type>::value,void>>
   explicit
   operator GlobAsyncRef<nonconst_value_type>() {
     return GlobAsyncRef<nonconst_value_type>(_gptr);

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -191,6 +191,8 @@ public:
   /**
    * Implicit cast to const.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, nonconst_value_type>::value,void>>
   operator GlobRef<const_value_type> () const {
     return GlobRef<const_value_type>(_gptr);
   }
@@ -198,6 +200,8 @@ public:
   /**
    * Explicit cast to non-const
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, const_value_type>::value,void>>
   explicit
   operator GlobRef<nonconst_value_type> () const {
     return GlobRef<nonconst_value_type>(_gptr);

--- a/dash/include/dash/atomic/GlobAtomicAsyncRef.h
+++ b/dash/include/dash/atomic/GlobAtomicAsyncRef.h
@@ -119,11 +119,15 @@ public:
   inline bool operator==(const T & value) const = delete;
   inline bool operator!=(const T & value) const = delete;
 
+  template<class = std::enable_if<
+                     std::is_same<value_type, nonconst_value_type>::value,void>>
   operator GlobAsyncRef<const_atomic_t>()
   {
     return GlobAsyncRef<const_atomic_t>(_gptr);
   }
 
+  template<class = std::enable_if<
+                     std::is_same<value_type, const_value_type>::value,void>>
   explicit
   operator GlobAsyncRef<nonconst_atomic_t>()
   {

--- a/dash/include/dash/atomic/GlobAtomicRef.h
+++ b/dash/include/dash/atomic/GlobAtomicRef.h
@@ -119,6 +119,8 @@ return load();
   /**
    * Implicit conversion to const type.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, nonconst_value_type>::value,void>>
   operator const_type() const {
     return const_type(_gptr);
   }
@@ -126,6 +128,8 @@ return load();
   /**
    * Explicit conversion to non-const type.
    */
+  template<class = std::enable_if<
+                     std::is_same<value_type, const_value_type>::value,void>>
   explicit
   operator nonconst_type() const {
     return nonconst_type(_gptr);

--- a/dash/test/dart/DARTMemAllocTest.cc
+++ b/dash/test/dart/DARTMemAllocTest.cc
@@ -6,28 +6,37 @@
 
 TEST_F(DARTMemAllocTest, SmallLocalAlloc)
 {
-
   typedef int value_t;
   dart_gptr_t gptr1;
   ASSERT_EQ_U(
     DART_OK,
-    dart_memalloc(sizeof(value_t), DART_TYPE_LONG, &gptr1));
+    dart_memalloc(3, DART_TYPE_INT, &gptr1));
   ASSERT_NE_U(
     DART_GPTR_NULL,
     gptr1);
-  value_t *baseptr;
-  ASSERT_EQ_U(
-    DART_OK,
-    dart_gptr_getaddr(gptr1, (void**)&baseptr));
 
-
-  // check that different allocation receives a different pointer
   dart_gptr_t gptr2;
   ASSERT_EQ_U(
     DART_OK,
-    dart_memalloc(sizeof(value_t), DART_TYPE_LONG, &gptr2));
+    dart_memalloc(1, DART_TYPE_INT, &gptr2));
+  ASSERT_NE_U(
+    DART_GPTR_NULL,
+    gptr2);
 
+
+  // check that different allocation receives a different pointer
   ASSERT_NE(gptr1, gptr2);
+
+  // test for overlap of small allocations
+  value_t *baseptr1;
+  ASSERT_EQ_U(
+    DART_OK,
+    dart_gptr_getaddr(gptr1, (void**)&baseptr1));
+  value_t *baseptr2;
+  ASSERT_EQ_U(
+    DART_OK,
+    dart_gptr_getaddr(gptr2, (void**)&baseptr2));
+  ASSERT_LE(baseptr1+4, baseptr2);
 
   ASSERT_EQ_U(
     DART_OK,
@@ -45,7 +54,7 @@ TEST_F(DARTMemAllocTest, LocalAlloc)
   dart_gptr_t gptr;
   ASSERT_EQ_U(
     DART_OK,
-    dart_memalloc(block_size * sizeof(value_t), DART_TYPE_LONG, &gptr));
+    dart_memalloc(block_size, DART_TYPE_INT, &gptr));
   ASSERT_NE_U(
     DART_GPTR_NULL,
     gptr);
@@ -59,7 +68,7 @@ TEST_F(DARTMemAllocTest, LocalAlloc)
   dart_gptr_t gptr2;
   ASSERT_EQ_U(
     DART_OK,
-    dart_memalloc(block_size * sizeof(value_t), DART_TYPE_LONG, &gptr2));
+    dart_memalloc(block_size, DART_TYPE_INT, &gptr2));
   ASSERT_NE(gptr, gptr2);
 
   ASSERT_EQ_U(


### PR DESCRIPTION
Previously, an allocation of 12 Byte would have chopped down to 8 and the next allocation could have overwritten parts of the first allocation. 

Thanks to @tuxamito for finding and reporting this one. Mea cupla!