### PR TITLE
Only add the OpenMP_C(XX)_FLAGS when omp is present

### DIFF
--- a/CMakeExt/CompilerFlags.cmake
+++ b/CMakeExt/CompilerFlags.cmake
@@ -139,7 +139,9 @@ endif()
 
 set (CXX_GDB_FLAG "-g"
      CACHE STRING "C++ compiler (clang++) debug symbols flag")
-set (CXX_OMP_FLAG ${OpenMP_CXX_FLAGS})
+if(OPENMP_FOUND)
+  set (CXX_OMP_FLAG ${OpenMP_CXX_FLAGS})
+endif()
 
 # Set C++ compiler flags:
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
@@ -189,7 +191,9 @@ endif()
 
 set (CC_GDB_FLAG "-g"
      CACHE STRING "C compiler (clang) debug symbols flag")
-set (CC_OMP_FLAG  ${OpenMP_C_FLAGS})
+if(OPENMP_FOUND)
+  set (CC_OMP_FLAG  ${OpenMP_C_FLAGS})
+endif()
 
 # Set C compiler flags:
 if ("${CMAKE_C_COMPILER_ID}" MATCHES ".*Clang")


### PR DESCRIPTION
Since CMake 3.10. the OpenMP_C(XX)_FLAGS variable will be `NOTFOUND`,
leading to invalid calls to CXX/CC. Only set the flags when `OPENMP_FOUND` is true.

refs #505