### PR TITLE
Smaller fixes to DASH Teams

### DIFF
--- a/dash/include/dash/Init.h
+++ b/dash/include/dash/Init.h
@@ -77,7 +77,7 @@ namespace dash
    *
    * \ingroup DashLib
    */
-  ssize_t size();
+  size_t size();
 
   /**
    * A global barrier involving all units.

--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -236,6 +236,14 @@ public:
   }
 
   /**
+   * Initialize the global team.
+   */
+  static void initialize()
+  {
+    Team::All().init_team();
+  }
+
+  /**
    * Finalize all teams.
    * Frees global memory allocated by \c dash::Team::All().
    */
@@ -255,6 +263,7 @@ public:
     }
 
     Team::All().free();
+    Team::All().reset_team();
   }
 
   /**
@@ -466,13 +475,6 @@ public:
 
   inline team_unit_t myid() const
   {
-    if (_myid == -1 && dash::is_initialized() && _dartid != DART_TEAM_NULL) {
-      DASH_ASSERT_RETURNS(
-        dart_team_myid(_dartid, &_myid),
-        DART_OK);
-    } else if (!dash::is_initialized()) {
-      _myid = -1;
-    }
     return _myid;
   }
 
@@ -483,13 +485,6 @@ public:
    */
   inline size_t size() const
   {
-    if (_size == 0 && dash::is_initialized() && _dartid != DART_TEAM_NULL) {
-      DASH_ASSERT_RETURNS(
-        dart_team_size(_dartid, &_size),
-        DART_OK);
-    } else if (!dash::is_initialized()) {
-      _size = 0;
-    }
     return _size;
   }
 
@@ -579,6 +574,23 @@ private:
       dash::Team::_teams.erase(
         team->_dartid);
     }
+  }
+
+  void init_team()
+  {
+    DASH_ASSERT_RETURNS(
+      dart_team_size(_dartid, &_size),
+      DART_OK);
+
+    DASH_ASSERT_RETURNS(
+      dart_team_myid(_dartid, &_myid),
+      DART_OK);
+  }
+
+  void reset_team()
+  {
+    _myid = UNDEFINED_TEAM_UNIT_ID;
+    _size = 0;
   }
 
 private:

--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -181,8 +181,10 @@ public:
       Team::unregister_team(this);
     }
 
-    if (_group != DART_GROUP_NULL)
+    if (_group != DART_GROUP_NULL) {
       dart_group_destroy(&_group);
+      _group = DART_GROUP_NULL;
+    }
 
     if (_child) {
       delete(_child);

--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -108,12 +108,11 @@ private:
 
   bool get_group() const
   {
-    if (dash::is_initialized() && !_has_group) {
+    if (dash::is_initialized() && _group != DART_GROUP_NULL) {
       DASH_LOG_DEBUG("Team.get_group()");
       dart_team_get_group(_dartid, &_group);
-      _has_group = true;
     }
-    return _has_group;
+    return _group != DART_GROUP_NULL;
   }
 
 protected:
@@ -138,7 +137,6 @@ public:
       // Take ownership of data from source
       _deallocs = std::move(t._deallocs);
       std::swap(_parent,    t._parent);
-      std::swap(_has_group, t._has_group);
       std::swap(_group,     t._group);
       std::swap(_dartid,    t._dartid);
       _position     = t._position;
@@ -159,7 +157,6 @@ public:
       // Take ownership of data from source
       _deallocs = std::move(t._deallocs);
       std::swap(_parent,    t._parent);
-      std::swap(_has_group, t._has_group);
       std::swap(_group,     t._group);
       std::swap(_dartid,    t._dartid);
       _position     = t._position;
@@ -184,7 +181,7 @@ public:
       Team::unregister_team(this);
     }
 
-    if (_has_group)
+    if (_group != DART_GROUP_NULL)
       dart_group_destroy(&_group);
 
     if (_child) {
@@ -593,7 +590,6 @@ private:
   size_t                  _num_siblings = 0;
   mutable size_t          _size         = 0;
   mutable team_unit_t     _myid         = UNDEFINED_TEAM_UNIT_ID;
-  mutable bool            _has_group    = false;
   mutable dart_group_t    _group        = DART_GROUP_NULL;
 
   /// Deallocation list for freeing memory acquired via

--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -598,12 +598,12 @@ private:
 private:
 
   dart_team_t             _dartid;
+  mutable team_unit_t     _myid         = UNDEFINED_TEAM_UNIT_ID;
+  mutable size_t          _size         = 0;
   Team                  * _parent       = nullptr;
   Team                  * _child        = nullptr;
   size_t                  _position     = 0;
   size_t                  _num_siblings = 0;
-  mutable size_t          _size         = 0;
-  mutable team_unit_t     _myid         = UNDEFINED_TEAM_UNIT_ID;
   mutable dart_group_t    _group        = DART_GROUP_NULL;
 
   /// Deallocation list for freeing memory acquired via

--- a/dash/src/Init.cc
+++ b/dash/src/Init.cc
@@ -118,7 +118,7 @@ dash::global_unit_t dash::myid()
   return dash::Team::GlobalUnitID();
 }
 
-ssize_t dash::size()
+size_t dash::size()
 {
   return dash::Team::All().size();
 }

--- a/dash/src/Init.cc
+++ b/dash/src/Init.cc
@@ -51,6 +51,9 @@ void dash::init(int * argc, char ** *argv)
 
   dash::_initialized = true;
 
+  // initialize global team
+  dash::Team::initialize();
+
   if (dash::util::Config::get<bool>("DASH_INIT_BREAKPOINT")) {
     DASH_LOG_DEBUG("Process ID", getpid());
     if (dash::myid() == 0) {

--- a/dash/src/Team.cc
+++ b/dash/src/Team.cc
@@ -70,6 +70,7 @@ Team::Team(
   if (DART_TEAM_NULL != id &&
       DART_TEAM_ALL != id) {
     Team::register_team(this);
+    init_team();
   }
 }
 

--- a/dash/test/algorithm/AccumulateTest.cc
+++ b/dash/test/algorithm/AccumulateTest.cc
@@ -35,7 +35,7 @@ TEST_F(AccumulateTest, SimpleStart) {
 TEST_F(AccumulateTest, OpMult) {
   const size_t num_elem_local = 1;
   using value_t = uint64_t;
-  size_t num_elem_total       = std::max(static_cast<ssize_t>(32), dash::size());
+  size_t num_elem_total       = std::max(static_cast<size_t>(32), dash::size());
   value_t value = 2, start = 10;
 
   dash::Array<uint64_t> target(num_elem_total, dash::BLOCKED);

--- a/dash/test/team/TeamLocalityTest.cc
+++ b/dash/test/team/TeamLocalityTest.cc
@@ -75,7 +75,7 @@ TEST_F(TeamLocalityTest, SplitCore)
   }
 
   dash::Team & team = dash::Team::All();
-  int num_split     = std::min(dash::size(), ssize_t(3));
+  int num_split     = std::min(dash::size(), size_t(3));
 
   dash::util::TeamLocality tloc(team);
 
@@ -333,14 +333,14 @@ TEST_F(TeamLocalityTest, SplitGroups)
     // TODO: If requested split was not possible, this yields an incorrect
     //       failure:
     //  EXPECT_EQ_U(group_1_units, group_1.units());
-  } 
+  }
   if (group_2_tags.size() > 1) {
     DASH_LOG_DEBUG("TeamLocalityTest.SplitGroups", "group:", group_2_tags);
     const auto & group_2 = tloc.group(group_2_tags);
     DASH_LOG_DEBUG_VAR("TeamLocalityTest.SplitGroups", group_2);
 
     EXPECT_EQ_U(group_2_units, group_2.units());
-  } 
+  }
 
   tloc.split_groups();
 

--- a/dash/test/types/AtomicTest.cc
+++ b/dash/test/types/AtomicTest.cc
@@ -398,7 +398,7 @@ TEST_F(AtomicTest, AtomicInterface){
   using value_t = int;
   using atom_t  = dash::Atomic<value_t>;
   using array_t = dash::Array<atom_t>;
-  size_t num_elem = std::max(static_cast<ssize_t>(10), dash::size());
+  size_t num_elem = std::max(static_cast<size_t>(10), dash::size());
 
   array_t array(num_elem);
 


### PR DESCRIPTION
1) `dash::size()` now returns `size_t` instead of `ssize_t`
2) Initialization of `_myid` and `_size` members is moved from `Team::myid()` and `Team::size()` into c'tor / delayed initialization.
3) The `_has_group` flag has been replaced by comparison of `_group` again `DART_GROUP_NULL`
4) Reorder Team members to close gap