### PR TITLE
Use the CMake CXX Compiler in DASH Compiler Wrapper

### DIFF
--- a/CMakeExt/GenerateDASHCXX.cmake
+++ b/CMakeExt/GenerateDASHCXX.cmake
@@ -35,7 +35,11 @@ endif()
 
 
 if (";${DART_IMPLEMENTATIONS_LIST};" MATCHES ";mpi;")
-  set(DASHCC ${MPI_CXX_COMPILER})
+  foreach (MPI_C_LIB ${MPI_C_LIBRARIES})
+    set(ADDITIONAL_LIBRARIES_WRAP
+        "${ADDITIONAL_LIBRARIES_WRAP} ${MPI_C_LIB}")
+  endforeach()
+  set(DASHCC ${CMAKE_CXX_COMPILER})
   set(DART_IMPLEMENTATION "mpi")
   configure_file(
     ${CMAKE_SOURCE_DIR}/dash/scripts/dashcc/dashcxx.in

--- a/CMakeExt/MPI.cmake
+++ b/CMakeExt/MPI.cmake
@@ -156,6 +156,7 @@ if (NOT DEFINED MPI_IMPL_ID)
   set (MPI_C_LIBRARIES  ${MPI_C_LIBRARIES}  CACHE STRING "MPI C libraries")
   set (MPI_LINK_FLAGS   ${MPI_LINK_FLAGS}   CACHE STRING "MPI link flags")
 
+  message(STATUS "Detected MPI library: ${MPI_IMPL_ID}")
 else (NOT DEFINED MPI_IMPL_ID)
 
   message(STATUS "Using previously detected MPI library: ${MPI_IMPL_ID}")


### PR DESCRIPTION
The compiler wrapper does not use the correct c++ compiler. As an example, if I set `CC=clang` and `CXX=clang++` and execute CMake with these settings we use of course clang to compile our library. However, the CompilerWrapper is set to mpicxx (in case of MPI) which may be different from the underlying c++ compiler. This pull request addresses this issue.
Since I am not really a CMake expert reviews are welcome.