### PR TITLE
Use Correct GTest Macros for Floating Point Comparison

### DIFF
--- a/dash/test/TestBase.h
+++ b/dash/test/TestBase.h
@@ -157,8 +157,8 @@ public:
   }
 };
 
-#define ASSERT_EQ_U(_e, _a)                     \
-  do {                                          \
+#define ASSERT_EQ_U(_e, _a)                                                \
+  do {                                                                     \
     ::testing::internal::EQAsserter<decltype(_e), decltype(_a)>{}(_e, _a); \
   } while (0)
 

--- a/dash/test/TestBase.h
+++ b/dash/test/TestBase.h
@@ -120,21 +120,47 @@ struct float_type_helper<float, float> {
   using type = float;
 };
 
-#define ASSERT_EQ_U(_e,_a)                                          \
-  do {                                                              \
-    if (std::is_floating_point<decltype(_e)>::value                 \
-     || std::is_floating_point<decltype(_a)>::value) {              \
-      using value_type =                                            \
-              typename ::testing::internal::float_type_helper<      \
-                                decltype(_e), decltype(_a)>::type;  \
-      EXPECT_PRED_FORMAT2(                                          \
-        ::testing::internal::assert_float_eq<value_type>,(_e),(_a)) \
-            << "Unit " << dash::myid().id;                          \
-    }                                                               \
-    else {                                                          \
-      EXPECT_EQ(_e,_a)        << "Unit " << dash::myid().id;        \
-    }                                                               \
-  } while(0)
+template <
+    class T,
+    class S,
+    bool isAnyFP =
+        std::is_floating_point<T>::value || std::is_floating_point<S>::value>
+class EQAsserter {
+  using lhs_t = typename std::remove_cv<T>::type;
+  using rhs_t = typename std::remove_cv<S>::type;
+
+public:
+  void operator()(lhs_t const & _e, rhs_t const & _a)
+  {
+    EXPECT_EQ(_e, _a) << "Unit " << dash::myid().id;
+  }
+};
+
+template <class T, class S>
+class EQAsserter<T, S, true> {
+  using value_t = typename ::testing::internal::float_type_helper<
+      typename std::remove_cv<T>::type,
+      typename std::remove_cv<S>::type>::type;
+
+  using lhs_t = typename std::remove_cv<T>::type;
+  using rhs_t = typename std::remove_cv<S>::type;
+
+public:
+  void operator()(lhs_t const& _e, rhs_t const& _a)
+  {
+    if (std::is_same<value_t, double>::value) {
+      EXPECT_DOUBLE_EQ(_e, _a) << "Unit " << dash::myid().id;
+    }
+    else if (std::is_same<value_t, float>::value) {
+      EXPECT_FLOAT_EQ(_e, _a) << "Unit " << dash::myid().id;
+    }
+  }
+};
+
+#define ASSERT_EQ_U(_e, _a)                     \
+  do {                                          \
+    ::testing::internal::EQAsserter<decltype(_e), decltype(_a)>{}(_e, _a); \
+  } while (0)
 
 #define EXPECT_EQ_U(e,a) ASSERT_EQ_U(e,a)
 
@@ -249,7 +275,7 @@ class TestBase : public ::testing::Test {
     LOG_MESSAGE("===> Running test case %s.%s ...",
                 test_info->test_case_name(), test_info->name());
     dash::init(&TESTENV::argc, &TESTENV::argv);
-    
+
     LOG_MESSAGE("-==- DASH initialized with %lu units", dash::size());
     dash::barrier();
   }

--- a/dash/test/algorithm/CopyTest.cc
+++ b/dash/test/algorithm/CopyTest.cc
@@ -38,7 +38,9 @@ TEST_F(CopyTest, BlockingGlobalToLocalBlock)
   int * dest_end = dash::copy(array.begin(),
                               array.begin() + num_elem_per_unit,
                               local_copy);
-  EXPECT_EQ_U(local_copy + num_elem_per_unit, dest_end);
+  auto val = local_copy + num_elem_per_unit;
+
+  EXPECT_EQ_U(val, dest_end);
   for (auto l = 0; l < num_elem_per_unit; ++l) {
     EXPECT_EQ_U(static_cast<int>(array[l]),
                 local_copy[l]);

--- a/dash/test/algorithm/SortTest.cc
+++ b/dash/test/algorithm/SortTest.cc
@@ -293,8 +293,6 @@ static void perform_test(GlobIter begin, GlobIter end)
       0,
       begin.pattern().team().dart_id());
 
-  begin.pattern().team().barrier();
-
   dash::sort(begin, end);
 
   mysum = std::accumulate(lbegin, lend, 0);
@@ -307,8 +305,6 @@ static void perform_test(GlobIter begin, GlobIter end)
       DART_OP_SUM,
       0,
       begin.pattern().team().dart_id());
-
-  begin.pattern().team().barrier();
 
   if (dash::myid() == 0) {
 
@@ -341,10 +337,6 @@ TEST_F(SortTest, PlausibilityWithStdSort)
 
   value_t mysum, realsum, truesum;
 
-  static_assert(
-      std::is_same<int64_t, long>::value,
-      "Type Check to ensure the correct MPI Datatype");
-
   rand_range(array.begin(), array.end());
 
   array.barrier();
@@ -356,7 +348,13 @@ TEST_F(SortTest, PlausibilityWithStdSort)
       &(array.local[num_local_elem]),
       static_cast<value_t>(0));
 
-  MPI_Allreduce(&mysum, &truesum, 1, MPI_LONG, MPI_SUM, MPI_COMM_WORLD);
+  dart_allreduce(
+      &mysum,
+      &truesum,
+      1,
+      dash::dart_datatype<value_t>::value,
+      DART_OP_SUM,
+      array.team().dart_id());
 
   dash::sort(array.begin(), array.end());
 
@@ -365,7 +363,13 @@ TEST_F(SortTest, PlausibilityWithStdSort)
       &(array.local[num_local_elem]),
       static_cast<value_t>(0));
 
-  MPI_Allreduce(&mysum, &realsum, 1, MPI_LONG, MPI_SUM, MPI_COMM_WORLD);
+  dart_allreduce(
+      &mysum,
+      &realsum,
+      1,
+      dash::dart_datatype<value_t>::value,
+      DART_OP_SUM,
+      array.team().dart_id());
 
   auto const diff = realsum - truesum;
 

--- a/dash/test/dart/DARTLocalityTest.cc
+++ b/dash/test/dart/DARTLocalityTest.cc
@@ -137,7 +137,7 @@ TEST_F(DARTLocalityTest, ExcludeLocalityDomain)
     DART_ERR_NOTFOUND,
     dart_domain_find(loc_team_all_copy, ul->domain_tag, &no_domain));
   EXPECT_EQ_U(
-    NULL, no_domain);
+    nullptr, no_domain);
 
   dart_domain_destroy(loc_team_all_copy);
 }


### PR DESCRIPTION
I have experienced some errors with floating point comparison in our units tests while implementing `dash::sort`. This pull request fixes that and ensures that we always use the right GTest marcos instead of relying on the internal GTest API which may change in future.