### PR TITLE
Feat coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       - image: dashproject/ci:openmpi2
     environment:
       MPI_EXEC_FLAGS: "--allow-run-as-root --map-by core"
-      GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*:GlobRefTest.IsLocal:HaloTest.HaloMatrixWrapper*:ThreadsafetyTest.ConcurrentAlgorithm"
+      GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*:HaloTest.HaloMatrixWrapper*"
       GTEST_OUTPUT: "xml:test-results.xml"
       CC: gcc
       CXX: g++

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
     environment:
       MPI_EXEC_FLAGS: "--allow-run-as-root --map-by core"
       GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*:GlobRefTest.IsLocal:HaloTest.HaloMatrixWrapper*:ThreadsafetyTest.ConcurrentAlgorithm"
+      GTEST_OUTPUT: "xml:test-results.xml"
       CC: gcc
       CXX: g++
     steps:
@@ -103,6 +104,8 @@ jobs:
       - run: bash build.cov.sh -f
       - run: cd build.cov && make coverage | grep -v "LOG"
       - run: bash <(curl -s https://codecov.io/bash)
+      - store_test_results:
+          path: build.cov/dash/test-results.xml
       - store_artifacts:
           path: build.cov/dash/coverage.xml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,22 @@ jobs:
           path: /tmp/build-logs
       - store_test_results:
           path: /tmp/build-tests
+  coverage:
+    docker:
+      - image: dashproject/ci:openmpi2
+    environment:
+      MPI_EXEC_FLAGS: "--allow-run-as-root --map-by core"
+      GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*"
+      CC: gcc
+      CXX: g++
+    steps:
+      - run: apt update && apt install lcov gcovr -y
+      - checkout
+      - run: bash build.cov.sh -f
+      - run: cd build.cov && make coverage | grep -v "LOG"
+      - run: bash <(curl -s https://codecov.io/bash)
+      - store_artifacts:
+          path: build.cov/dash/coverage.xml
 
 workflows:
   version: 2
@@ -98,4 +114,5 @@ workflows:
       - gnu_openmpi2
       - gnu_openmpi3
       - clang_mpich
+      - coverage
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,8 @@ workflows:
   build_and_test:
     jobs:
       - coverage
-      #      - gnu_mpich
-      #      - gnu_openmpi2
-      #      - gnu_openmpi3
-      #      - clang_mpich
+      - gnu_mpich
+      - gnu_openmpi2
+      - gnu_openmpi3
+      - clang_mpich
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       - image: dashproject/ci:openmpi2
     environment:
       MPI_EXEC_FLAGS: "--allow-run-as-root --map-by core"
-      GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*:HaloTest.HaloMatrixWrapper*"
+      GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*"
       GTEST_OUTPUT: "xml:test-results.xml"
       CC: gcc
       CXX: g++

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,11 @@ jobs:
       - image: dashproject/ci:openmpi2
     environment:
       MPI_EXEC_FLAGS: "--allow-run-as-root --map-by core"
-      GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*"
+      GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*:GlobRefTest.IsLocal:HaloTest.HaloMatrixWrapper*:ThreadsafetyTest.ConcurrentAlgorithm"
       CC: gcc
       CXX: g++
     steps:
-      - run: apt update && apt install lcov gcovr -y
+      - run: apt update && apt install lcov gcovr curl -y
       - checkout
       - run: bash build.cov.sh -f
       - run: cd build.cov && make coverage | grep -v "LOG"
@@ -110,9 +110,9 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - gnu_mpich
-      - gnu_openmpi2
-      - gnu_openmpi3
-      - clang_mpich
       - coverage
+      #      - gnu_mpich
+      #      - gnu_openmpi2
+      #      - gnu_openmpi3
+      #      - clang_mpich
 

--- a/CMakeExt/CodeCoverage.cmake
+++ b/CMakeExt/CodeCoverage.cmake
@@ -1,6 +1,4 @@
-set(LCOV_CONFIG_PATH "${CMAKE_SOURCE_DIR}/config/dash-lcovrc")
-
-# Copyright (c) 2012 - 2015, Lars Bilke
+# Copyright (c) 2012 - 2017, Lars Bilke
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -28,7 +26,7 @@ set(LCOV_CONFIG_PATH "${CMAKE_SOURCE_DIR}/config/dash-lcovrc")
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-#
+# CHANGES:
 #
 # 2012-01-31, Lars Bilke
 # - Enable Code Coverage
@@ -37,164 +35,210 @@ set(LCOV_CONFIG_PATH "${CMAKE_SOURCE_DIR}/config/dash-lcovrc")
 # - Added support for Clang.
 # - Some additional usage instructions.
 #
+# 2016-02-03, Lars Bilke
+# - Refactored functions to use named parameters
+#
+# 2017-06-02, Lars Bilke
+# - Merged with modified version from github.com/ufz/ogs
+#
+#
 # USAGE:
-
-# 0. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
-#      http://stackoverflow.com/a/22404544/80480
 #
 # 1. Copy this file into your cmake modules path.
 #
 # 2. Add the following line to your CMakeLists.txt:
-#      INCLUDE(CodeCoverage)
+#      include(CodeCoverage)
 #
-# 3. Set compiler flags to turn off optimization and enable coverage:
-#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
-#	 SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+# 3. Append necessary compiler flags:
+#      APPEND_COVERAGE_COMPILER_FLAGS()
 #
-# 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
-#    which runs your test executable and produces a lcov code coverage report:
+# 4. If you need to exclude additional directories from the report, specify them
+#    using the COVERAGE_EXCLUDES variable before calling SETUP_TARGET_FOR_COVERAGE.
 #    Example:
-#	 SETUP_TARGET_FOR_COVERAGE(
-#				my_coverage_target  # Name for custom target.
-#				test_driver         # Name of the test driver executable that runs the tests.
-#									# NOTE! This should always have a ZERO as exit code
-#									# otherwise the coverage generation will not complete.
-#				coverage            # Name of output directory.
-#				)
+#      set(COVERAGE_EXCLUDES 'dir1/*' 'dir2/*')
 #
-# 4. Build a Debug build:
-#	 cmake -DCMAKE_BUILD_TYPE=Debug ..
-#	 make
-#	 make my_coverage_target
+# 5. Use the functions described below to create a custom make target which
+#    runs your test executable and produces a code coverage report.
 #
+# 6. Build a Debug build:
+#      cmake -DCMAKE_BUILD_TYPE=Debug ..
+#      make
+#      make my_coverage_target
 #
+
+include(CMakeParseArguments)
 
 # Check prereqs
-FIND_PROGRAM( GCOV_PATH gcov )
-FIND_PROGRAM( LCOV_PATH lcov )
-FIND_PROGRAM( GENHTML_PATH genhtml )
-FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+find_program( GCOV_PATH gcov )
+find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
+find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
+find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program( SIMPLE_PYTHON_EXECUTABLE python )
 
-IF(NOT GCOV_PATH)
-	MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
-ENDIF() # NOT GCOV_PATH
+if(NOT GCOV_PATH)
+    message(FATAL_ERROR "gcov not found! Aborting...")
+endif() # NOT GCOV_PATH
 
-IF(NOT CMAKE_COMPILER_IS_GNUCXX)
-	# Clang version 3.0.0 and greater now supports gcov as well.
-	MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+    if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
+        message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+    endif()
+elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
+    message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+endif()
 
-	IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-		MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
-	ENDIF()
-ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX
+set(COVERAGE_COMPILER_FLAGS "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE INTERNAL "")
 
-SET(CMAKE_CXX_FLAGS_COVERAGE
-    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+set(CMAKE_CXX_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
     CACHE STRING "Flags used by the C++ compiler during coverage builds."
     FORCE )
-SET(CMAKE_C_FLAGS_COVERAGE
-    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+set(CMAKE_C_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
     CACHE STRING "Flags used by the C compiler during coverage builds."
     FORCE )
-SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
     ""
     CACHE STRING "Flags used for linking binaries during coverage builds."
     FORCE )
-SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
     ""
     CACHE STRING "Flags used by the shared libraries linker during coverage builds."
     FORCE )
-MARK_AS_ADVANCED(
+mark_as_advanced(
     CMAKE_CXX_FLAGS_COVERAGE
     CMAKE_C_FLAGS_COVERAGE
     CMAKE_EXE_LINKER_FLAGS_COVERAGE
     CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
 
-IF ( NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverage"))
-  MESSAGE( WARNING "Code coverage results with an optimized (non-Debug) build may be misleading" )
-ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    link_libraries(gcov)
+else()
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+endif()
 
-# Param _targetname     The name of new the custom make target
-# Param _testrunner     The name of the target which runs the tests.
-#						MUST return ZERO always, even on errors.
-#						If not, no coverage report will be created!
-# Param _outputname     lcov output is generated as _outputname.info
-#                       HTML report is generated in _outputname/index.html
-# Optional fourth parameter is passed as arguments to _testrunner
-#   Pass them in list form, e.g.: "-j;2" for -j 2
-FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# SETUP_TARGET_FOR_COVERAGE(
+#     NAME testrunner_coverage                    # New target name
+#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES testrunner                     # Dependencies to build first
+# )
+function(SETUP_TARGET_FOR_COVERAGE)
 
-	IF(NOT LCOV_PATH)
-		MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
-	ENDIF() # NOT LCOV_PATH
+    set(options NONE)
+    set(oneValueArgs NAME)
+    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-	IF(NOT GENHTML_PATH)
-		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
-	ENDIF() # NOT GENHTML_PATH
+    if(NOT LCOV_PATH)
+        message(FATAL_ERROR "lcov not found! Aborting...")
+    endif() # NOT LCOV_PATH
 
-	SET(coverage_info "${CMAKE_BINARY_DIR}/${_outputname}.info")
-	SET(coverage_cleaned "${coverage_info}.cleaned")
+    if(NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif() # NOT GENHTML_PATH
 
-  separate_arguments(test_command UNIX_COMMAND "${_testrunner}")
+    # Setup target
+    add_custom_target(${Coverage_NAME}
 
-	# Setup target
-	ADD_CUSTOM_TARGET(${_targetname}
+        # Cleanup lcov
+        COMMAND ${LCOV_PATH} --directory . --zerocounters
+        # Create baseline to make sure untouched files show up in the report
+        COMMAND ${LCOV_PATH} -c -i -d . -o ${Coverage_NAME}.base
 
-		# Cleanup lcov
-		${LCOV_PATH} --directory . --zerocounters --config-file ${LCOV_CONFIG_PATH}
+        # Run tests
+        COMMAND ${Coverage_EXECUTABLE}
 
-		# Run tests
-		COMMAND ${test_command} ${ARGV3}
+        # Capturing lcov counters and generating report
+        COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
+        # add baseline counters
+        COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total
+        COMMAND ${LCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${GENHTML_PATH} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
 
-		# Capturing lcov counters and generating report
-		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${coverage_info}
-		COMMAND ${LCOV_PATH} --remove ${coverage_info} 'tests/*' '/usr/*' 'gtest/*' --output-file ${coverage_cleaned}
-		COMMAND ${GENHTML_PATH} -o ${_outputname} ${coverage_cleaned}
-		COMMAND ${CMAKE_COMMAND} -E remove ${coverage_info} ${coverage_cleaned}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+    )
+    
+    # Show where to find the lcov info report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+    )
 
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
-	)
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
 
-	# Show info where to find the report
-	ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
-		COMMAND ;
-		COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
-	)
+endfunction() # SETUP_TARGET_FOR_COVERAGE
 
-ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# SETUP_TARGET_FOR_COVERAGE_COBERTURA(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+# )
+function(SETUP_TARGET_FOR_COVERAGE_COBERTURA)
 
-# Param _targetname     The name of new the custom make target
-# Param _testrunner     The name of the target which runs the tests
-# Param _outputname     cobertura output is generated as _outputname.xml
-# Optional fourth parameter is passed as arguments to _testrunner
-#   Pass them in list form, e.g.: "-j;2" for -j 2
-FUNCTION(SETUP_TARGET_FOR_COVERAGE_COBERTURA _targetname _testrunner _outputname)
+    set(options NONE)
+    set(oneValueArgs NAME)
+    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-	IF(NOT PYTHON_EXECUTABLE)
-		MESSAGE(FATAL_ERROR "Python not found! Aborting...")
-	ENDIF() # NOT PYTHON_EXECUTABLE
+    if(NOT SIMPLE_PYTHON_EXECUTABLE)
+        message(FATAL_ERROR "python not found! Aborting...")
+    endif() # NOT SIMPLE_PYTHON_EXECUTABLE
 
-	IF(NOT GCOVR_PATH)
-		MESSAGE(FATAL_ERROR "gcovr not found! Aborting...")
-	ENDIF() # NOT GCOVR_PATH
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
 
-	ADD_CUSTOM_TARGET(${_targetname}
+    # Combine excludes to several -e arguments
+    set(COBERTURA_EXCLUDES "")
+    foreach(EXCLUDE ${COVERAGE_EXCLUDES})
+        set(COBERTURA_EXCLUDES "-e ${EXCLUDE} ${COBERTURA_EXCLUDES}")
+    endforeach()
 
-		# Run tests
-		${_testrunner} ${ARGV3}
+    add_custom_target(${Coverage_NAME}
 
-		# Running gcovr
-		COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} -e '${CMAKE_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-		COMMENT "Running gcovr to produce Cobertura code coverage report."
-	)
+        # Run tests
+        ${Coverage_EXECUTABLE}
 
-	# Show info where to find the report
-	ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
-		COMMAND ;
-		COMMENT "Cobertura code coverage report saved in ${_outputname}.xml."
-	)
+        # Running gcovr
+        COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} ${COBERTURA_EXCLUDES}
+            -o ${Coverage_NAME}.xml
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        COMMENT "Running gcovr to produce Cobertura code coverage report."
+    )
 
-ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE_COBERTURA
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
+    )
+
+endfunction() # SETUP_TARGET_FOR_COVERAGE_COBERTURA
+
+function(APPEND_COVERAGE_COMPILER_FLAGS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+endfunction() # APPEND_COVERAGE_COMPILER_FLAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,10 @@ option(ENABLE_NASTYMPI
        "Specify whether the NastyMPI proxy should be enabled" off)
 
 if (BUILD_COVERAGE_TESTS)
+  include(${CMAKE_SOURCE_DIR}/CMakeExt/CodeCoverage.cmake)
+  # This has to be done globally as otherwise linking might fail
+  append_coverage_compiler_flags()
+
   set(BUILD_TESTS TRUE CACHE BOOLEAN
       "Whether tests are built with code coverage (lcov) support.
        Implies BUILD_TESTS. Requires GCC." on)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CI Status](https://circleci.com/gh/dash-project/dash.svg?style=shield&circle-token=cd221e93159f5c97477c9699f3b7adc54d344ae6)](https://circleci.com/gh/dash-project/dash)
 [![Build Status](https://travis-ci.org/dash-project/dash.svg?branch=development)](https://travis-ci.org/dash-project/dash) [![Documentation Status](https://readthedocs.org/projects/dash/badge/?version=latest)](http://dash.readthedocs.io/en/latest/?badge=latest) [![Documentation](https://codedocs.xyz/dash-project/dash.svg)](https://codedocs.xyz/dash-project/dash/)
+[![codecov](https://codecov.io/gh/dash-project/dash/branch/development/graph/badge.svg)](https://codecov.io/gh/dash-project/dash)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/491/badge)](https://bestpractices.coreinfrastructure.org/projects/491)
 
 

--- a/build.cov.sh
+++ b/build.cov.sh
@@ -58,7 +58,7 @@ rm -Rf $BUILD_DIR/*
                         -DENVIRONMENT_TYPE=default \
                         -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0/ \
                         -DDART_IMPLEMENTATIONS=mpi \
-                        -DENABLE_THREADSUPPORT=ON \
+                        -DENABLE_THREADSUPPORT=OFF \
                         -DENABLE_DEV_COMPILER_WARNINGS=OFF \
                         -DENABLE_EXT_COMPILER_WARNINGS=OFF \
                         -DENABLE_LT_OPTIMIZATION=OFF \

--- a/dash/CMakeLists.txt
+++ b/dash/CMakeLists.txt
@@ -491,10 +491,11 @@ if (BUILD_TESTS)
       if (BUILD_COVERAGE_TESTS)
         # exclude stdlib
         set(COVERAGE_EXCLUDES '/usr/*')
+        separate_arguments(EXEC_FLAGS UNIX_COMMAND $ENV{MPI_EXEC_FLAGS})
         if (${dart_variant} STREQUAL "mpi")
           setup_target_for_coverage_cobertura(
             NAME coverage
-            EXECUTABLE mpirun -n 4 $ENV{MPI_EXEC_FLAGS} ${CMAKE_BINARY_DIR}/dash/${DASH_TEST}
+            EXECUTABLE mpirun -n 4 ${EXEC_FLAGS} ${CMAKE_BINARY_DIR}/dash/${DASH_TEST}
             DEPENDENCIES coverage)
         else()
           setup_target_for_coverage_cobertura(

--- a/dash/CMakeLists.txt
+++ b/dash/CMakeLists.txt
@@ -489,12 +489,18 @@ if (BUILD_TESTS)
 
       # Code Coverage
       if (BUILD_COVERAGE_TESTS)
+        # exclude stdlib
+        set(COVERAGE_EXCLUDES '/usr/*')
         if (${dart_variant} STREQUAL "mpi")
-          setup_target_for_coverage(
-            coverage "mpirun -n 4 ${CMAKE_BINARY_DIR}/bin/${DASH_TEST}" coverage)
+          setup_target_for_coverage_cobertura(
+            NAME coverage
+            EXECUTABLE mpirun -n 4 $ENV{MPI_EXEC_FLAGS} ${CMAKE_BINARY_DIR}/dash/${DASH_TEST}
+            DEPENDENCIES coverage)
         else()
-          setup_target_for_coverage(
-            coverage "${DASH_TEST}" coverage)
+          setup_target_for_coverage_cobertura(
+            NAME coverage
+            EXECUTABLE "${CMAKE_BINARY_DIR}/dash/${DASH_TEST}"
+            DEPENDENCIES coverage)
         endif()
       endif()
 


### PR DESCRIPTION
This PR fixes the broken code-coverage reporting and adds a codecov.io integration.

The coverage target is an additional target which is run on circleci along with the other CI targets. The reports are then automatically uploaded to codecov.io where they can be inspected.

Report for this branch: https://codecov.io/gh/dash-project/dash/branch/feat-coverage

**Notes on coverage testing**

- Multithreading is disabled, as MPI+Multithreading+Coverage-Flags often segfaults on CI
- Halo Tests are disabled as they are broken (fail, but not detected as `EXPECT_EQ` instead of `EXPECT_EQ_U` is used).
- Locality Tests are disabled as CPU pinning cannot be ensured
- OpenMPI2 is used as HDF5 has some problems with OpenMPI3 (in fact it works, but prints error messages)
- cobertura is used as coverage tester as xml report is required. This means for running the coverage tests locally, `gcovr` is needed.

If you like, we can also add a nice coverage badge to the readme.