### PR TITLE
Bug 551 lapack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,29 @@ jobs:
           path: /tmp/build-logs
       - store_test_results:
           path: /tmp/build-tests
+
+  minimal:
+    docker:
+      - image: dashproject/ci:minimal
+    environment:
+      MPI_EXEC_FLAGS: "--allow-run-as-root --map-by core"
+      GTEST_FILTER: "-TeamLocalityTest.*:DARTLocalityTest.*"
+      DASH_MAKE_PROCS: 2
+      DASH_MAX_UNITS: 4
+      DASH_BUILDEX: ON
+      CC: gcc
+      CXX: c++
+    steps:
+      - checkout
+      - run: bash dash/scripts/dash-ci.sh Release
+      - run:
+          command: bash dash/scripts/circleci/collect-artifacts.sh
+          when: always
+      - store_artifacts:
+          path: /tmp/build-logs
+      - store_test_results:
+          path: /tmp/build-tests
+
   coverage:
     docker:
       - image: dashproject/ci:openmpi3
@@ -116,6 +139,7 @@ workflows:
   build_and_test:
     jobs:
       - coverage
+      - minimal
       - gnu_mpich
       - gnu_openmpi2
       - gnu_openmpi3

--- a/CMakeExt/LAPACK.cmake
+++ b/CMakeExt/LAPACK.cmake
@@ -4,7 +4,7 @@ find_package(BLAS)
 find_package(LAPACK)
 
 if (BLAS_FOUND)
-  check_library_exists(${BLAS_LIBRARIES} "cblas_sgemm" BLAS_IS_CBLAS)
+  check_library_exists(${BLAS_LIBRARIES} "cblas_sgemm" "C" BLAS_IS_CBLAS)
   if(${BLAS_IS_CBLAS})
   else()
     message(STATUS "No CBLAS Interface found, try manually")

--- a/dash/scripts/dash-ci.sh
+++ b/dash/scripts/dash-ci.sh
@@ -6,6 +6,15 @@ CMD_DEPLOY=$BASEPATH/dash/scripts/dash-ci-deploy.sh
 CMD_TEST=$BASEPATH/dash/scripts/dash-test.sh
 FAILED=false
 
+print_env()
+{
+  if [ -z "$CC" ];  then DASH_CC="cc";   else DASH_CC=$CC;   fi
+  if [ -z "$CXX" ]; then DASH_CXX="c++"; else DASH_CXX=$CXX; fi
+  echo -n "[-> ENV    ] " && cmake --version  | head -1
+  echo -n "[-> ENV    ] " && ${DASH_CC} --version  | head -1
+  echo -n "[-> ENV    ] " && ${DASH_CXX} --version | head -1
+}
+
 run_ci()
 {
   BUILD_TYPE=${1}
@@ -84,6 +93,8 @@ run_ci()
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ORIG}
   fi
 }
+
+print_env
 
 if [ $# != 0 ]; then
   for buildtype in "$@" ; do

--- a/dash/scripts/docker-testing/minimal/dockerfile
+++ b/dash/scripts/docker-testing/minimal/dockerfile
@@ -1,0 +1,42 @@
+# Dockerfile for the DASH project
+# This container provides an environment for our minimal system requirements
+FROM          ubuntu:14.04
+
+MAINTAINER    The DASH Team <team@dash-project.org>
+
+RUN           apt-get update -y    \
+           && apt-get install -y   \
+                  git              \
+                  build-essential  \
+                  libz-dev         \
+                  cmake            \
+                  uuid-runtime
+
+# Install PAPI from source
+WORKDIR       /tmp
+
+ADD           http://icl.utk.edu/projects/papi/downloads/papi-5.4.1.tar.gz papi.tgz
+RUN           tar -xf papi.tgz
+RUN           cd papi*/src/                     \
+              && ./configure --prefix=/opt/papi \
+              && make                           \
+              && make install
+
+# Openmpi 2.1
+ADD           https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.3.tar.gz ompi.tgz
+RUN           tar -xf ompi.tgz
+RUN           cd openmpi*                         \
+           && ./configure --prefix=/opt/openmpi   \
+                          --enable-mpi-thread-multiple \
+           && make                                \
+           && make install
+ENV           PATH=${PATH}:/opt/openmpi/bin
+ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/openmpi/lib
+
+# Prepare env
+ENV           PAPI_BASE=/opt/papi
+ENV           LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PAPI_BASE}/lib:${HDF5_BASE}/lib
+ENV           VERBOSE_CI='true'
+
+# Set workdir to dash home
+WORKDIR       /opt/dash


### PR DESCRIPTION
This PR fixes the LAPACK cmake skript. The first assumption in the issue, that the number of arguments has changed was not correct. The only difference is that the `LOCATION` variable must not be empty. 

To ensure that this fix is backward compatible with cmake 2.8, an additional docker container is added, providing a minimal system environment:

```
openmpi 2.1
cmake version 2.8.12.2
gcc (Ubuntu 4.8.4-2ubuntu1~14.04.4) 4.8.4
g++ (Ubuntu 4.8.4-2ubuntu1~14.04.4) 4.8.4
```

The release build is also tested on the minimal environment in CI.