### PR TITLE
Fix `ostream operator<<` for `DistributionSpec`.

### DIFF
--- a/dash/include/dash/Dimensional.h
+++ b/dash/include/dash/Dimensional.h
@@ -323,7 +323,7 @@ std::ostream & operator<<(
     if (distspec._values[d].type == dash::internal::DIST_TILE) {
       os << "TILE(" << distspec._values[d].blocksz << ")";
     }
-    else if (distspec._values[d].type == dash::internal::DIST_BLOCKED) {
+    else if (distspec._values[d].type == dash::internal::DIST_BLOCKCYCLIC) {
       os << "BLOCKCYCLIC(" << distspec._values[d].blocksz << ")";
     }
     else if (distspec._values[d].type == dash::internal::DIST_CYCLIC) {


### PR DESCRIPTION
`DIST_BLOCKCYCLIC` was mishandled.

before:

```
$ cout << dash::DistributionSpec<2>(dash::BLOCKCYCLIC(1), dash::BLOCKED) << endl;
dash::DistributionSpec<2>(, BLOCKCYCLIC(18446744073709551615))
```

after:

```
$ cout << dash::DistributionSpec<1>(dash::BLOCKCYCLIC(1), dash::BLOCKED) << endl;
dash::DistributionSpec<1>(BLOCKCYCLIC(1), BLOCKED)
```

Note that the `ostream operator<<` for `Distribution` does not have this
typo.