### PR TITLE
Delayed Initialization for dash::Mutex

### DIFF
--- a/dart-if/include/dash/dart/if/dart_synchronization.h
+++ b/dart-if/include/dash/dart/if/dart_synchronization.h
@@ -29,6 +29,11 @@ extern "C" {
  */
 typedef struct dart_lock_struct *dart_lock_t;
 
+/**
+ * Null value for \ref dart_lock_t to reset a DART lock instance. The lock
+ * has to be initialized using \ref dart_team_lock_init.
+ */
+#define DART_LOCK_NULL ((dart_lock_t)NULL)
 
 /**
  * Collective operation to initialize the \c lock object.

--- a/dart-if/include/dash/dart/if/dart_synchronization.h
+++ b/dart-if/include/dash/dart/if/dart_synchronization.h
@@ -108,6 +108,17 @@ dart_ret_t dart_lock_try_acquire(
 dart_ret_t dart_lock_release(
   dart_lock_t   lock)   DART_NOTHROW;
 
+/**
+ * Whether the lock has been properly initialized.
+ *
+ * \return true if the DART lock is properly initialized
+ *         false  otherwise.
+ *
+ * \threadsafe_none
+ * \ingroup DartInitialization
+ */
+dart_ret_t dart_lock_initialized(
+    struct dart_lock_struct const *lock) DART_NOTHROW;
 
 /** \cond DART_HIDDEN_SYMBOLS */
 #define DART_INTERFACE_OFF
@@ -118,4 +129,3 @@ dart_ret_t dart_lock_release(
 #endif
 
 #endif /* DART_SYNCHRONIZATION_H_INCLUDED */
-

--- a/dart-if/include/dash/dart/if/dart_synchronization.h
+++ b/dart-if/include/dash/dart/if/dart_synchronization.h
@@ -117,7 +117,7 @@ dart_ret_t dart_lock_release(
  * \threadsafe_none
  * \ingroup DartInitialization
  */
-dart_ret_t dart_lock_initialized(
+bool dart_lock_initialized(
     struct dart_lock_struct const *lock) DART_NOTHROW;
 
 /** \cond DART_HIDDEN_SYMBOLS */

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_synchronization_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_synchronization_priv.h
@@ -1,0 +1,8 @@
+#ifndef DART_SYNCHRONIZATION_PRIV_H_INCLUDED
+#define DART_SYNCHRONIZATION_PRIV_H_INCLUDED
+
+#include <dash/dart/if/dart_synchronization.h>
+
+dart_ret_t dart__mpi__destroylocks() DART_INTERNAL;
+
+#endif // DART_SYNCHRONIZATION_PRIV_H_INCLUDED

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_synchronization_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_synchronization_priv.h
@@ -3,6 +3,6 @@
 
 #include <dash/dart/if/dart_synchronization.h>
 
-dart_ret_t dart__mpi__destroylocks() DART_INTERNAL;
+dart_ret_t dart__mpi__destroylocks(struct dart_lock_struct* allocated_locks);
 
 #endif // DART_SYNCHRONIZATION_PRIV_H_INCLUDED

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_team_private.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_team_private.h
@@ -192,6 +192,8 @@ typedef struct dart_team_data {
 
   dart_team_t teamid;
 
+  struct dart_lock_struct *allocated_locks;
+
 } dart_team_data_t;
 
 /* @brief Initiate the free-team-list and allocated-team-list.

--- a/dart-impl/mpi/src/dart_initialization.c
+++ b/dart-impl/mpi/src/dart_initialization.c
@@ -18,7 +18,6 @@
 #include <dash/dart/mpi/dart_globmem_priv.h>
 #include <dash/dart/mpi/dart_communication_priv.h>
 #include <dash/dart/mpi/dart_locality_priv.h>
-#include <dash/dart/mpi/dart_synchronization_priv.h>
 #include <dash/dart/mpi/dart_segment.h>
 
 #define DART_LOCAL_ALLOC_SIZE (1024*1024*16)
@@ -293,8 +292,6 @@ dart_ret_t dart_exit()
                    unitid.id);
     return DART_ERR_OTHER;
   }
-
-  dart__mpi__destroylocks();
 
   dart_segment_info_t *seginfo = dart_segment_get_info(&team_data->segdata, 0);
 

--- a/dart-impl/mpi/src/dart_initialization.c
+++ b/dart-impl/mpi/src/dart_initialization.c
@@ -18,6 +18,7 @@
 #include <dash/dart/mpi/dart_globmem_priv.h>
 #include <dash/dart/mpi/dart_communication_priv.h>
 #include <dash/dart/mpi/dart_locality_priv.h>
+#include <dash/dart/mpi/dart_synchronization_priv.h>
 #include <dash/dart/mpi/dart_segment.h>
 
 #define DART_LOCAL_ALLOC_SIZE (1024*1024*16)
@@ -292,6 +293,8 @@ dart_ret_t dart_exit()
                    unitid.id);
     return DART_ERR_OTHER;
   }
+
+  dart__mpi__destroylocks();
 
   dart_segment_info_t *seginfo = dart_segment_get_info(&team_data->segdata, 0);
 

--- a/dart-impl/mpi/src/dart_synchronization.c
+++ b/dart-impl/mpi/src/dart_synchronization.c
@@ -53,7 +53,7 @@ dart_ret_t dart_team_lock_init(dart_team_t teamid, dart_lock_t* lock)
   dart_gptr_t gptr_list;
   dart_team_unit_t unitid;
 
-  *lock = NULL;
+  *lock = DART_LOCK_NULL;
 
 
   dart_team_data_t *team_data = dart_adapt_teamlist_get(teamid);
@@ -404,7 +404,7 @@ dart_ret_t dart_team_lock_destroy(dart_lock_t* lock)
   dart__base__mutex_destroy(&(*lock)->mutex);
   DART_LOG_DEBUG("dart_team_lock_free: done in team %d", teamid);
   free(*lock);
-  *lock = NULL;
+  *lock = DART_LOCK_NULL;
   return DART_OK;
 }
 

--- a/dart-impl/mpi/src/dart_synchronization.c
+++ b/dart-impl/mpi/src/dart_synchronization.c
@@ -408,6 +408,9 @@ dart_ret_t dart_team_lock_destroy(dart_lock_t* lock)
   return DART_OK;
 }
 
-
-
-
+dart_ret_t dart_lock_initialized(struct dart_lock_struct const * lock)
+{
+  return lock &&
+    !DART_GPTR_ISNULL(lock->gptr_tail) &&
+         !DART_GPTR_ISNULL(lock->gptr_list);
+}

--- a/dart-impl/mpi/src/dart_synchronization.c
+++ b/dart-impl/mpi/src/dart_synchronization.c
@@ -408,7 +408,7 @@ dart_ret_t dart_team_lock_destroy(dart_lock_t* lock)
   return DART_OK;
 }
 
-dart_ret_t dart_lock_initialized(struct dart_lock_struct const * lock)
+bool dart_lock_initialized(struct dart_lock_struct const * lock)
 {
   return lock &&
     !DART_GPTR_ISNULL(lock->gptr_tail) &&

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -18,6 +18,7 @@
 
 #include <dash/dart/mpi/dart_team_private.h>
 #include <dash/dart/mpi/dart_group_priv.h>
+#include <dash/dart/mpi/dart_synchronization_priv.h>
 
 #include <limits.h>
 
@@ -590,11 +591,9 @@ dart_ret_t dart_team_create(
     return DART_ERR_INVAL;
   }
 
-
   if (group->mpi_group == MPI_GROUP_NULL) {
     return DART_OK;
   }
-
 
   dart_team_data_t *parent_team_data = dart_adapt_teamlist_get(teamid);
   if (parent_team_data == NULL) {
@@ -633,6 +632,8 @@ dart_ret_t dart_team_create(
     MPI_Comm_rank(team_data->comm, &rank);
     team_data->unitid = rank;
     MPI_Comm_size(team_data->comm, &team_data->size);
+
+    team_data->allocated_locks = NULL;
 
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)
     dart_allocate_shared_comm(team_data);

--- a/dart-impl/mpi/src/dart_team_group.c
+++ b/dart-impl/mpi/src/dart_team_group.c
@@ -662,6 +662,7 @@ dart_ret_t dart_team_destroy(
 
   dart_team_data_t *team_data = dart_adapt_teamlist_get(*teamid);
   if (team_data == NULL) {
+    DART_LOG_ERROR("Found invalid or unknown team %d\n", *teamid);
     return DART_ERR_INVAL;
   }
 
@@ -680,7 +681,12 @@ dart_ret_t dart_team_destroy(
   /* -- Release the communicator associated with teamid -- */
   MPI_Comm_free(&comm);
 
+  dart_segment_fini(&team_data->segdata);
+
   dart_adapt_teamlist_dealloc(*teamid);
+
+  dart__mpi__destroylocks(team_data->allocated_locks);
+  team_data->allocated_locks = NULL;
 
   DART_LOG_DEBUG("dart_team_destroy > teamid:%d", *teamid);
 

--- a/dash/include/dash/Mutex.h
+++ b/dash/include/dash/Mutex.h
@@ -97,7 +97,7 @@ public:
 private:
   dash::Team const* _team{nullptr};
   std::unique_ptr<std::remove_pointer<dart_lock_t>::type, DestroyDARTLock>
-      _mutex{nullptr};
+      _mutex{DART_LOCK_NULL};
 };  // class Mutex
 
 }  // namespace dash

--- a/dash/include/dash/Mutex.h
+++ b/dash/include/dash/Mutex.h
@@ -73,6 +73,8 @@ public:
    * Collective initialization of the DART lock.
    *
    * This function is not thread-safe
+   *
+   * @return True if lock was successfully initialized, False otherwise
    */
   bool init();
 

--- a/dash/include/dash/Mutex.h
+++ b/dash/include/dash/Mutex.h
@@ -34,7 +34,7 @@ private:
   struct DestroyDARTLock {
     void operator()(dart_lock_t lock)
     {
-      if (nullptr != lock) {
+      if (DART_LOCK_NULL != lock && dart_initialized()) {
         auto ret = dart_team_lock_destroy(&lock);
 
         if (ret != DART_OK) {

--- a/dash/include/dash/Mutex.h
+++ b/dash/include/dash/Mutex.h
@@ -34,7 +34,7 @@ private:
   struct DestroyDARTLock {
     void operator()(dart_lock_t lock)
     {
-      if (DART_LOCK_NULL != lock && dart_initialized()) {
+      if (DART_LOCK_NULL != lock) {
         auto ret = dart_team_lock_destroy(&lock);
 
         if (ret != DART_OK) {

--- a/dash/include/dash/Mutex.h
+++ b/dash/include/dash/Mutex.h
@@ -2,16 +2,17 @@
 #define DASH__MUTEX_H__INCLUDED
 
 #include <dash/Team.h>
+#include <dash/dart/if/dart_synchronization.h>
 
 namespace dash {
 
 /**
  * Behaves similar to \c std::mutex and is used to ensure mutual exclusion
  * within a dash team.
- * 
+ *
  * \note This works properly with \c std::lock_guard
  * \note Mutex cannot be placed in DASH containers
- * 
+ *
  * \code
  * // just for demonstration, better use atomic operations
  * dash::Mutex mx; // mutex for dash::Team::All();
@@ -30,50 +31,73 @@ class Mutex {
 private:
   using self_t = Mutex;
 
+  struct DestroyDARTLock {
+    void operator()(dart_lock_t lock)
+    {
+      if (nullptr != lock) {
+        auto ret = dart_team_lock_destroy(&lock);
+
+        if (ret != DART_OK) {
+          DASH_LOG_ERROR(
+              "Failed to destroy DART lock! "
+              "(dart_team_lock_destroy failed)");
+        }
+      }
+    }
+  };
+
 public:
   /**
    * DASH Mutex is only valid for a dash team. If no team is passed, team all
    * is used.
-   * 
+   *
    * This function is not thread-safe
    * @param team team for mutual exclusive accesses
    */
-  explicit Mutex(Team & team = dash::Team::All());
-  
-  Mutex(const Mutex & other)               = delete;
-  Mutex(Mutex && other)                    = default;
+  explicit Mutex(Team& team = dash::Team::All());
 
-  self_t & operator=(const self_t & other) = delete;
-  self_t & operator=(self_t && other)      = default;
-  
+  Mutex(const Mutex& other) = delete;
+  Mutex(Mutex&& other)      = default;
+
+  self_t& operator=(const self_t& other) = delete;
+  self_t& operator=(self_t&& other) = default;
+
   /**
    * Collective destructor to destruct a DART lock.
-   * 
+   *
    * This function is not thread-safe
    */
-  ~Mutex();
-  
+  ~Mutex() = default;
+
+  /**
+   * Collective initialization of the DART lock.
+   *
+   * This function is not thread-safe
+   */
+  bool init();
+
   /**
    * Block until the lock was acquired.
    */
   void lock();
-  
+
   /**
    * Try to acquire the lock and return immediately.
    * @return True if lock was successfully aquired, False otherwise
    */
   bool try_lock();
-  
+
   /**
    * Release the lock acquired through \c lock() or \c try_lock().
    */
   void unlock();
-  
+
 private:
-  dart_lock_t   _mutex;
-}; // class Mutex
+  dash::Team const* _team{nullptr};
+  std::unique_ptr<std::remove_pointer<dart_lock_t>::type, DestroyDARTLock>
+      _mutex{nullptr};
+};  // class Mutex
 
-} // namespace dash
+}  // namespace dash
 
-#endif // DASH__MUTEX_H__INCLUDED
-
+#endif  // DASH__MUTEX_H__INCLUDED

--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -181,7 +181,9 @@ public:
     }
 
     if (_group != DART_GROUP_NULL) {
-      dart_group_destroy(&_group);
+      DASH_ASSERT_RETURNS(
+        dart_group_destroy(&_group),
+        DART_OK);
       _group = DART_GROUP_NULL;
     }
 
@@ -195,6 +197,13 @@ public:
     }
 
     free();
+
+    if (DART_TEAM_NULL != _dartid &&
+        DART_TEAM_ALL  != _dartid) {
+      DASH_ASSERT_RETURNS(
+        dart_team_destroy(&_dartid),
+        DART_OK);
+    }
   }
 
   /**

--- a/dash/src/Mutex.cc
+++ b/dash/src/Mutex.cc
@@ -22,6 +22,7 @@ bool Mutex::init() {
         DASH_LOG_ERROR(
             "Failed to initialize DART lock! "
             "(dart_team_lock_init failed)");
+        return false;
     }
 
     _mutex.reset(m);

--- a/dash/src/Mutex.cc
+++ b/dash/src/Mutex.cc
@@ -3,33 +3,52 @@
 
 namespace dash {
 
-Mutex::Mutex(Team & team){
-  dart_ret_t ret = dart_team_lock_init(team.dart_id(), &_mutex);
-  DASH_ASSERT_EQ(DART_OK, ret, "dart_team_lock_init failed");
+Mutex::Mutex(Team& team)
+  : _team(&team)
+{
+  init();
 }
 
-Mutex::~Mutex(){
-  dart_ret_t ret = dart_team_lock_destroy(&_mutex);
-  if (ret != DART_OK) {
-    DASH_LOG_ERROR("Failed to destroy DART lock! "
-                   "(dart_team_lock_free failed)");
+bool Mutex::init() {
+  if (dart_lock_initialized(_mutex.get())) {
+    DASH_LOG_ERROR("DART lock is already initialized");
+    return false;
   }
+  if (*_team != dash::Team::Null() && dash::is_initialized()) {
+    dart_lock_t m;
+    dart_ret_t ret = dart_team_lock_init(_team->dart_id(), &m);
+
+    if (ret != DART_OK) {
+        DASH_LOG_ERROR(
+            "Failed to initialize DART lock! "
+            "(dart_team_lock_init failed)");
+    }
+
+    _mutex.reset(m);
+    return true;
+  }
+
+  return false;
 }
 
 void Mutex::lock(){
-  dart_ret_t ret = dart_lock_acquire(_mutex);
+  DASH_ASSERT(dart_lock_initialized(_mutex.get()));
+  dart_ret_t ret = dart_lock_acquire(_mutex.get());
   DASH_ASSERT_EQ(DART_OK, ret, "dart_lock_acquire failed");
 }
 
 bool Mutex::try_lock(){
   int32_t result;
-  dart_ret_t ret = dart_lock_try_acquire(_mutex, &result);
+
+  DASH_ASSERT(dart_lock_initialized(_mutex.get()));
+  dart_ret_t ret = dart_lock_try_acquire(_mutex.get(), &result);
   DASH_ASSERT_EQ(DART_OK, ret, "dart_lock_try_acquire failed");
   return static_cast<bool>(result);
 }
 
 void Mutex::unlock(){
-  dart_ret_t ret = dart_lock_release(_mutex);
+  DASH_ASSERT(dart_lock_initialized(_mutex.get()));
+  dart_ret_t ret = dart_lock_release(_mutex.get());
   DASH_ASSERT_EQ(DART_OK, ret, "dart_lock_acquire failed");
 }
 

--- a/dash/src/Team.cc
+++ b/dash/src/Team.cc
@@ -94,17 +94,14 @@ Team::split(
 
   size_t num_split = 0;
 
-  for (unsigned i = 0; i < num_parts; i++) {
-    DASH_ASSERT_RETURNS(
-      dart_group_create(&sub_groups[i]),
-      DART_OK);
-  }
-
   DASH_ASSERT_RETURNS(
     dart_team_get_group(_dartid, &group),
     DART_OK);
   DASH_ASSERT_RETURNS(
     dart_group_split(group, num_parts, &num_split, sub_groups),
+    DART_OK);
+  DASH_ASSERT_RETURNS(
+    dart_group_destroy(&group),
     DART_OK);
   dart_team_t oldteam = _dartid;
   // Create a child Team for every part with parent set to

--- a/dash/test/types/AtomicTest.cc
+++ b/dash/test/types/AtomicTest.cc
@@ -507,6 +507,15 @@ TEST_F(AtomicTest, MutexInterface){
   }
 }
 
+dash::Mutex mx_delayed;
+
+TEST_F(AtomicTest, MutexInterfaceDelayed){
+  ASSERT_TRUE_U(mx_delayed.init());
+  {
+    std::lock_guard<dash::Mutex> lg(mx_delayed);
+    LOG_MESSAGE("thread %d acquired lock", dash::Team::All().myid().id);
+  }
+}
 
 TEST_F(AtomicTest, AtomicSignal){
   using value_t = int;


### PR DESCRIPTION
Our `dash::Mutex` did not support delayed initialization until now. There are  use cases which require a global lock handle which can then be reused within the application.

This pull request added this feature and contains additional refactoring, mainly the replacement of the native pointer member in `dash::Mutex` with a `std::unique_ptr`.