### PR TITLE
Make non-collective global memory pool size configurable

### DIFF
--- a/dart-impl/base/include/dash/dart/base/env.h
+++ b/dart-impl/base/include/dash/dart/base/env.h
@@ -1,0 +1,70 @@
+/**
+ * \file dash/dart/base/env.h
+ *
+ * Access to environment variables.
+ */
+
+#ifndef DASH_DART_BASE_ENV_H_
+#define DASH_DART_BASE_ENV_H_
+
+#include <unistd.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <dash/dart/base/macro.h>
+
+struct dart_env_str2int{
+  const char *envstr;
+  int         value;
+};
+
+/**
+ * Parse a integral value from a set of options, e.g., from an enum.
+ * The array values should be null-terminated, i.e., the last entry should
+ * be {NULL, 0}.
+ */
+int
+dart__base__env__str2int(
+  const char                    * env,
+  const struct dart_env_str2int * values,
+  int                             fallback);
+
+/**
+ * Returns the number provided in the environment variable or \c fallback
+ * if the environment variable is not set or does not represent a number.
+ */
+int
+dart__base__env__number(const char *env, int fallback);
+
+/**
+ * Parse a size from the provided environment variable.
+ * The size value can be postfixed by 'K', 'M', 'G' for kilo-, mega-, and
+ * gigabyte as well as 'B' for byte.
+ *
+ * \return The parsed value or \c fallback on error.
+ */
+ssize_t dart__base__env__size(const char *env, ssize_t fallback);
+
+/**
+ * Parse a time in microseconds from the provided environment variable.
+ * The time value can be postfixed by 'u'/'us' or 'm'/'ms for micro- and
+ * milli-seconds as well as 's' for seconds.
+ *
+ * \return The parsed value or \c fallback on error.
+ */
+uint64_t dart__base__env__us(const char *env, uint64_t fallback);
+
+/**
+ * Returns a Boolean value parsed from the environment variable.
+ * Possible values are '0'/'1', 'True'/'False', 'Yes'/'No'
+ * (both lower- and upper-case).
+ *
+ * \return The parsed value (false on error).
+ */
+bool dart__base__env__bool(const char *env, bool fallback);
+
+/**
+ * Returns the string value of the environment variable or NULL if not set.
+ */
+const char* dart__base__env__string(const char *env);
+
+#endif /* DASH_DART_BASE_ENV_H_ */

--- a/dart-impl/base/src/env.c
+++ b/dart-impl/base/src/env.c
@@ -66,11 +66,11 @@ dart__base__env__number(const char *env, int fallback)
 
 ssize_t dart__base__env__size(const char *env, ssize_t fallback)
 {
-  size_t res = fallback;
+  ssize_t res = fallback;
   const char *envstr = getenv(env);
   if (envstr != NULL) {
     char *endptr;
-    if (sizeof(size_t) == sizeof(long long int)) {
+    if (sizeof(ssize_t) == sizeof(long long int)) {
       res = strtoll(envstr, &endptr, 10);
     } else {
       res = strtol(envstr, &endptr, 10);
@@ -80,10 +80,13 @@ ssize_t dart__base__env__size(const char *env, ssize_t fallback)
       // check for B, K, M, or G suffix
       switch(*endptr) {
       case 'G':
+      case 'g':
         res *= 1024; /* fall-through */
       case 'M':
+      case 'm':
         res *= 1024; /* fall-through */
       case 'K':
+      case 'k':
         res *= 1024; /* fall-through */
       case 'B':
         break;

--- a/dart-impl/base/src/env.c
+++ b/dart-impl/base/src/env.c
@@ -1,0 +1,145 @@
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <stdint.h>
+#include <dash/dart/base/env.h>
+#include <dash/dart/base/logging.h>
+
+
+/**
+ * Returns the string value of the environment variable or NULL if not set.
+ */
+const char* dart__base__env__string(const char *env)
+{
+  return getenv(env);
+}
+
+int
+dart__base__env__str2int(
+  const char                    * env,
+  const struct dart_env_str2int * values,
+  int                             fallback)
+{
+  int res = fallback;
+  if (values != NULL) {
+    int i = 0;
+    const char *envstr = getenv(env);
+    if (envstr != NULL) {
+      bool found = false;
+      const struct dart_env_str2int *val;
+      while ((val = &values[i++])->envstr != NULL) {
+        if (strcasecmp(envstr, val->envstr) == 0) {
+          res = val->value;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        DART_LOG_WARN("Unknown value %s found in environment variable %s",
+                      envstr, env);
+      }
+    }
+  }
+
+  return res;
+}
+
+/**
+ * Returns the number provided in the environment variable or -1
+ * if the environment variable is not set or does not represent a number.
+ */
+int
+dart__base__env__number(const char *env, int fallback)
+{
+  int result = fallback;
+  char *endptr;
+  const char *envstr = getenv(env);
+  if (envstr && *envstr != '\0') {
+    result = strtol(envstr, &endptr, 10);
+    if (*endptr != '\0') {
+      // parsing failed
+      result = -1;
+    }
+  }
+  return result;
+}
+
+ssize_t dart__base__env__size(const char *env, ssize_t fallback)
+{
+  size_t res = fallback;
+  const char *envstr = getenv(env);
+  if (envstr != NULL) {
+    char *endptr;
+    if (sizeof(size_t) == sizeof(long long int)) {
+      res = strtoll(envstr, &endptr, 10);
+    } else {
+      res = strtol(envstr, &endptr, 10);
+    }
+    DART_LOG_TRACE("%s: %s (%lu %s)", env, envstr, res, endptr);
+    if (*endptr != '\0') {
+      // check for B, K, M, or G suffix
+      switch(*endptr) {
+      case 'G':
+        res *= 1024; /* fall-through */
+      case 'M':
+        res *= 1024; /* fall-through */
+      case 'K':
+        res *= 1024; /* fall-through */
+      case 'B':
+        break;
+      default:
+        DART_LOG_WARN("Unknown size unit '%s' in %s! Assuming bytes...",
+                      endptr, env);
+      }
+    }
+  }
+  DART_LOG_TRACE("%s: %s (%lu)", env, envstr, res);
+  return res;
+}
+
+
+uint64_t dart__base__env__us(const char *env, uint64_t fallback)
+{
+  uint64_t res = fallback;
+  const char *envstr = getenv(env);
+  if (envstr != NULL) {
+    char *endptr;
+    res = strtoll(envstr, &endptr, 10);
+    DART_LOG_TRACE("%s: %s (%lu %s)", env, envstr, res, endptr);
+    if (*endptr != '\0') {
+      // check for B, K, M, or G suffix
+      switch(*endptr) {
+      case 's': // seconds
+        res *= 1000; /* fall-through */
+      case 'm': // milliseconds
+        res *= 1000; /* fall-through */
+      case 'u': // microseconds
+        break;
+      default:
+        DART_LOG_WARN("Unknown time unit '%s' in %s! Assuming microsends...",
+                      endptr, env);
+      }
+    }
+  }
+  DART_LOG_TRACE("%s: %s (%lu)", env, envstr, res);
+  return res;
+}
+
+
+
+bool dart__base__env__bool(const char *env, bool fallback)
+{
+  bool res = fallback;
+  const char *envstr = getenv(env);
+  if (envstr != NULL) {
+    if (strcasecmp(envstr, "yes")  == 0 ||
+        strcasecmp(envstr, "true") == 0 ||
+        atoi(envstr)                > 0)
+    {
+      res = true;
+    }
+  }
+
+  DART_LOG_TRACE("%s: %s (%i)", env, envstr, res);
+  return res;
+}

--- a/dart-impl/base/src/logging.c
+++ b/dart-impl/base/src/logging.c
@@ -11,6 +11,7 @@
 
 #include <dash/dart/base/logging.h>
 #include <dash/dart/base/mutex.h>
+#include <dash/dart/base/env.h>
 
 
 /* Width of unit id field in log messages in number of characters */
@@ -58,27 +59,25 @@ static const char *loglevel_names[DART_LOGLEVEL_NUM_LEVEL] = {
     "TRACE"
 };
 
+static const struct dart_env_str2int env_vals[] = {
+  {"ERROR", DART_LOGLEVEL_ERROR},
+  {"WARN",  DART_LOGLEVEL_WARN},
+  {"INFO",  DART_LOGLEVEL_INFO},
+  {"DEBUG", DART_LOGLEVEL_DEBUG},
+  {"TRACE", DART_LOGLEVEL_TRACE},
+  {NULL, -1}
+};
+
 static
 enum dart__base__logging_loglevel
-env_loglevel()
+dart__logging__log_level()
 {
   static enum dart__base__logging_loglevel level = DART_LOGLEVEL_TRACE;
-  static int log_level_parsed = 0;
-  if (!log_level_parsed) {
-    const char *envstr = getenv(DART_LOGLEVEL_ENVSTR);
-    if (envstr) {
-      if (strcmp(envstr, "ERROR") == 0) {
-        level = DART_LOGLEVEL_ERROR;
-      } else if (strcmp(envstr, "WARN") == 0) {
-        level = DART_LOGLEVEL_WARN;
-      } else if (strcmp(envstr, "INFO") == 0) {
-        level = DART_LOGLEVEL_INFO;
-      } else if (strcmp(envstr, "DEBUG") == 0) {
-        level = DART_LOGLEVEL_DEBUG;
-      } else if (strcmp(envstr, "TRACE") == 0) {
-        level = DART_LOGLEVEL_TRACE;
-      }
-    }
+  static int parsed = 0;
+  if (!parsed) {
+    parsed = 1;
+    level  = dart__base__env__str2int(DART_LOGLEVEL_ENVSTR, env_vals,
+                                      DART_LOGLEVEL_TRACE);
   }
 
   return level;
@@ -109,7 +108,7 @@ dart__base__log_message(
   ...
 )
 {
-  if (level > env_loglevel() ||
+  if (level > dart__logging__log_level() ||
       level > DART_LOGLEVEL_TRACE) {
     return;
   }

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_mpi_env.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_mpi_env.h
@@ -1,0 +1,15 @@
+/**
+ * \file dash/dart/mpi/dart_mpi_env.h
+ *
+ * Collection of environment variable names specific for DART-MPI.
+ */
+#ifndef DART__MPI__ENV_H__
+#define DART__MPI__ENV_H__
+
+/**
+ * Environment variable used for setting the size of the memory pool backing
+ * non-collective global memory allocations.
+ */
+#define DART_MEMALLOC_POOLSIZE_ENVSTR "DART_MEMALLOC_POOLSIZE"
+
+#endif // DART__MPI__ENV_H__


### PR DESCRIPTION
As discussed in #572 this PR implements the the configuration of the memory pool backing non-collective global memory allocations. The PR also includes a simple environment variable parser I have written previously.