### PR TITLE
Report errors on CI

### DIFF
--- a/dash/scripts/dash-ci-deploy.sh
+++ b/dash/scripts/dash-ci-deploy.sh
@@ -254,8 +254,8 @@ mkdir -p build
 rm -Rf ./build/*
 (cd ./build && cmake $BASEPATH $BUILD_SETTINGS | nocolor && \
  await_confirm && \
- make -j $MAKE_PROCS VERBOSE=1 $MAKE_TARGET
+ make -j $MAKE_PROCS VERBOSE=1 $MAKE_TARGET || exit 1
  if echo "$BUILD_TYPE" | grep "Coverage"; then
    cp -a ./ $INSTALL_PATH
  fi) && \
-exit_message
+exit_message || exit 1


### PR DESCRIPTION
The current `eval | tee`... calls ignore the error code of the `eval` invocation. That way we never know when a build breaks. See #570 for an example. The source wasn't building at all and the runners still reported success.

Note that `EXEC_WRAP` isn't used any more (right?) so I removed it.
I used a `OUTPUT="$CMD"; RETVAL=$?; echo $OUTPUT...`-construct so we get the correct return type (becuase `pipefail` is a bashism). Also note that the errors in the mpich-version are now reported and a failing build will also be reported.
