### PR TITLE
CI: Print filename and line in failed assertions

### DIFF
--- a/dash/test/TestBase.h
+++ b/dash/test/TestBase.h
@@ -128,9 +128,11 @@ class EQAsserter {
   using rhs_t = typename std::remove_cv<S>::type;
 
 public:
-  void operator()(lhs_t const & _e, rhs_t const & _a)
+  void operator()(lhs_t const & _e, rhs_t const & _a,
+                  const char *_file, int line)
   {
-    EXPECT_EQ(_e, _a) << "Unit " << dash::myid().id;
+    EXPECT_EQ(_e, _a) << "Unit " << dash::myid().id << ": "
+                      << _file << ":" << line;
   }
 };
 
@@ -144,20 +146,25 @@ class EQAsserter<T, S, true> {
   using rhs_t = typename std::remove_cv<S>::type;
 
 public:
-  void operator()(lhs_t const& _e, rhs_t const& _a)
+  void operator()(lhs_t const& _e, rhs_t const& _a,
+                  const char *_file, int line)
   {
     if (std::is_same<value_t, double>::value) {
-      EXPECT_DOUBLE_EQ(_e, _a) << "Unit " << dash::myid().id;
+      EXPECT_DOUBLE_EQ(_e, _a) << "Unit " << dash::myid().id << ": "
+                               << _file << ":" << line;
     }
     else if (std::is_same<value_t, float>::value) {
-      EXPECT_FLOAT_EQ(_e, _a) << "Unit " << dash::myid().id;
+      EXPECT_FLOAT_EQ(_e, _a)  << "Unit " << dash::myid().id << ": "
+                               << _file << ":" << line;
     }
   }
 };
 
 #define ASSERT_EQ_U(_e, _a)                                                \
   do {                                                                     \
-    ::testing::internal::EQAsserter<decltype(_e), decltype(_a)>{}(_e, _a); \
+    ::testing::internal::EQAsserter<decltype(_e), decltype(_a)>{}(_e, _a,  \
+                                                                  __FILE__,\
+                                                                  __LINE__); \
   } while (0)
 
 #define EXPECT_EQ_U(e,a) ASSERT_EQ_U(e,a)


### PR DESCRIPTION
This information is lost in the `::testing::internal::EQAsserter` as the filename and line of that class is used. Eventually we should use `static_if` in a macro once we are able to in order to properly print the filename. 