### PR TITLE
Delayed Initialization for dash::Shared

### DIFF
--- a/dash/include/dash/Shared.h
+++ b/dash/include/dash/Shared.h
@@ -87,7 +87,7 @@ public:
   {
     DASH_LOG_DEBUG_VAR("Shared.Shared(value,team,owner)()", owner);
     if (dash::is_initialized()) {
-      init(val);
+      DASH_ASSERT_RETURNS(init(val), true);
     }
   }
 

--- a/dash/include/dash/Shared.h
+++ b/dash/include/dash/Shared.h
@@ -199,10 +199,18 @@ public:
     return const_reference(m_dart_gptr);
   }
 
+  /**
+   * Native pointer to the starting address of the local memory of
+   * the unit that initialized this dash::Shared instance.
+   */
   constexpr value_type const * local() const noexcept {
     return (m_team->myid() == m_owner) ? m_globmem->lbegin() : nullptr;
   }
 
+  /**
+   * Native pointer to the starting address of the local memory of
+   * the unit that initialized this dash::Shared instance.
+   */
   value_type * local() noexcept {
     return (m_team->myid() == m_owner) ? m_globmem->lbegin() : nullptr;
   }

--- a/dash/include/dash/Shared.h
+++ b/dash/include/dash/Shared.h
@@ -128,23 +128,28 @@ public:
           dash::exception::RuntimeError, "runtime not properly initialized");
     }
 
+    if (!(DART_GPTR_ISNULL(_dart_gptr))) {
+      DASH_LOG_ERROR("Shared scalar is already initialized");
+      return false;
+    }
+
     // Shared value is only allocated at unit 0:
     if (_team->myid() == _owner) {
       DASH_LOG_DEBUG(
-          "Shared.Shared(value,team,owner)",
+          "Shared.init(value,team,owner)",
           "allocating shared value in local memory");
       _globmem          = std::make_unique<GlobMem_t>(1, *_team);
       _dart_gptr        = _globmem->begin().dart_gptr();
       auto       lbegin = _globmem->lbegin();
       auto const lend   = _globmem->lend();
 
-      DASH_LOG_DEBUG_VAR("Shared.Shared(value,team,owner) >", val);
+      DASH_LOG_DEBUG_VAR("Shared.init(value,team,owner) >", val);
       std::uninitialized_fill(lbegin, lend, val);
     }
     // Broadcast global pointer of shared value at unit 0 to all units:
     dash::dart_storage<dart_gptr_t> ds(1);
     dart_bcast(&_dart_gptr, ds.nelem, ds.dtype, _owner, _team->dart_id());
-    DASH_LOG_DEBUG_VAR("Shared.Shared(value,team,owner) >", _dart_gptr);
+    DASH_LOG_DEBUG_VAR("Shared.init(value,team,owner) >", _dart_gptr);
 
     return !(DART_GPTR_ISNULL(_dart_gptr));
   }

--- a/dash/include/dash/Shared.h
+++ b/dash/include/dash/Shared.h
@@ -94,12 +94,7 @@ public:
   /**
    * Destructor, frees shared memory.
    */
-  ~Shared()
-  {
-    DASH_LOG_DEBUG("Shared.~Shared()");
-    _globmem.reset();
-    DASH_LOG_DEBUG("Shared.~Shared >");
-  }
+  ~Shared() = default;
 
   /**
    * Copy-constructor: DELETED

--- a/dash/include/dash/Shared.h
+++ b/dash/include/dash/Shared.h
@@ -201,7 +201,8 @@ public:
 
   /**
    * Native pointer to the starting address of the local memory of
-   * the unit that initialized this dash::Shared instance.
+   * the unit that initialized this dash::Shared instance. For other units
+   * it returns a nullptr
    */
   constexpr value_type const * local() const noexcept {
     return (m_team->myid() == m_owner) ? m_globmem->lbegin() : nullptr;

--- a/dash/include/dash/std/memory.h
+++ b/dash/include/dash/std/memory.h
@@ -1,11 +1,11 @@
 #ifndef DASH__STD__MEMORY_H__INCLUDED
 #define DASH__STD__MEMORY_H__INCLUDED
 
+#if (__cplusplus < 201402L)
+
 #include <memory>
 #include <type_traits>
 #include <utility>
-
-#if (__cplusplus < 201402L)
 
 namespace std {
 template <typename T, typename... Args>

--- a/dash/include/dash/std/memory.h
+++ b/dash/include/dash/std/memory.h
@@ -1,0 +1,39 @@
+#ifndef DASH__STD__MEMORY_H__INCLUDED
+#define DASH__STD__MEMORY_H__INCLUDED
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#if (__cplusplus < 201402L)
+
+namespace std {
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique_helper(std::false_type, Args&&... args)
+{
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique_helper(std::true_type, Args&&... args)
+{
+  static_assert(
+      std::extent<T>::value == 0,
+      "make_unique<T[N]>() is forbidden, please use make_unique<T[]>().");
+
+  typedef typename std::remove_extent<T>::type U;
+  return std::unique_ptr<T>(
+      new U[sizeof...(Args)]{std::forward<Args>(args)...});
+}
+
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+  return make_unique_helper<T>(
+      std::is_array<T>(), std::forward<Args>(args)...);
+}
+}  // namespace std
+
+#endif  // __cplusplus < 201402L
+
+#endif  // DASH__STD__MEMORY_H__INCLUDED

--- a/dash/test/container/SharedTest.cc
+++ b/dash/test/container/SharedTest.cc
@@ -274,3 +274,32 @@ TEST_F(SharedTest, AtomicMinMax)
   EXPECT_EQ_U(0, min);
   EXPECT_EQ_U(std::numeric_limits<value_t>::max(), max);
 }
+
+
+dash::Shared<int32_t> shared_delayed{};
+
+TEST_F(SharedTest, DelayedAllocation)
+{
+  EXPECT_TRUE_U(shared_delayed.init(100));
+
+  if (dash::myid() == 0) {
+    EXPECT_TRUE_U(shared_delayed.local());
+    EXPECT_EQ_U(100, *shared_delayed.local());
+  } else {
+    EXPECT_FALSE_U(shared_delayed.local());
+  }
+
+  auto val = shared_delayed.get();
+  EXPECT_EQ_U(100, val);
+
+  shared_delayed.barrier();
+
+  if (dash::myid() == 0) {
+    *shared_delayed.local() = 1000;
+  }
+
+  shared_delayed.barrier();
+
+  val = shared_delayed.get();
+  EXPECT_EQ_U(1000, val);
+}


### PR DESCRIPTION
Similar to #571 we need delayed initialization for `dash::Shared` as well. There are further improvements:

- Like our other containers we provide now a `local()` interface as a shortcut for the owning unit.
- Replace the internal `shared_ptr` encapsulating the `globmem` instance with a `unique_ptr`. I cannot see any reason for `shared_ptr`. Please correct me if I am wrong.