### PR TITLE
For hostnames longer/equal DART_LOCALITY_HOST_MAX_SIZE dash crashes. 

### DIFF
--- a/dart-if/include/dash/dart/if/dart_types.h
+++ b/dart-if/include/dash/dart/if/dart_types.h
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <limits.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -325,7 +326,7 @@ typedef enum
 dart_locality_scope_t;
 
 /** Maximum size of a host name string in \ref dart_hwinfo_t */
-#define DART_LOCALITY_HOST_MAX_SIZE       ((int)(30))
+#define DART_LOCALITY_HOST_MAX_SIZE        (HOST_NAME_MAX)
 /** Maximum size of a domain tag string in \ref dart_hwinfo_t */
 #define DART_LOCALITY_DOMAIN_TAG_MAX_SIZE ((int)(32))
 /** Maximum number of domain scopes in \ref dart_hwinfo_t */

--- a/dart-impl/base/src/hwinfo.c
+++ b/dart-impl/base/src/hwinfo.c
@@ -123,7 +123,9 @@ dart_ret_t dart_hwinfo(
     hw.max_shmem_mbps = 1235;
   }
 
-  gethostname(hw.host, DART_LOCALITY_HOST_MAX_SIZE-1);
+  if(gethostname(hw.host, DART_LOCALITY_HOST_MAX_SIZE) != 0) {
+    hw.host[DART_LOCALITY_HOST_MAX_SIZE-1] = '\0';
+  }
 
 #ifdef DART_ENABLE_LIKWID
   DART_LOG_TRACE("dart_hwinfo: using likwid");

--- a/dart-impl/base/src/hwinfo.c
+++ b/dart-impl/base/src/hwinfo.c
@@ -123,7 +123,7 @@ dart_ret_t dart_hwinfo(
     hw.max_shmem_mbps = 1235;
   }
 
-  gethostname(hw.host, DART_LOCALITY_HOST_MAX_SIZE);
+  gethostname(hw.host, DART_LOCALITY_HOST_MAX_SIZE-1);
 
 #ifdef DART_ENABLE_LIKWID
   DART_LOG_TRACE("dart_hwinfo: using likwid");


### PR DESCRIPTION
The reason is a wrong string length handed over to gethostname.