### PR TITLE
Fix problems reported by Cray Compiler

### DIFF
--- a/dart-impl/base/src/logging.c
+++ b/dart-impl/base/src/logging.c
@@ -22,7 +22,7 @@
 /* Width of line number field in log messages in number of characters */
 #define LINE_WIDTH 4
 /* Maximum length of a single log message in number of characters */
-#define MAX_MESSAGE_LENGTH 256;
+#define MAX_MESSAGE_LENGTH 256
 
 
 static dart_mutex_t logmutex = DART_MUTEX_INITIALIZER;
@@ -115,9 +115,8 @@ dart__base__log_message(
   }
   va_list argp;
   va_start(argp, format);
-  const int maxlen = MAX_MESSAGE_LENGTH;
-  char      msg_buf[maxlen];
-  vsnprintf(msg_buf, maxlen, format, argp);
+  char      msg_buf[MAX_MESSAGE_LENGTH];
+  vsnprintf(msg_buf, MAX_MESSAGE_LENGTH, format, argp);
 //  if (sn_ret < 0 || sn_ret >= maxlen) {
 //    break;
 //  }

--- a/dart-impl/mpi/include/dash/dart/mpi/dart_communication_priv.h
+++ b/dart-impl/mpi/include/dash/dart/mpi/dart_communication_priv.h
@@ -240,7 +240,8 @@ dart__mpi__datatype_convert_mpi(
       break;
     default:
       // should not happen!
-      DART_ASSERT_MSG(NULL, "Unknown DART type detected!");
+      DART_ASSERT_MSG(!(dts->kind > DART_KIND_CUSTOM),
+                      "Unknown DART type detected!");
   }
 }
 

--- a/dart-impl/mpi/src/dart_initialization.c
+++ b/dart-impl/mpi/src/dart_initialization.c
@@ -30,7 +30,7 @@ static
 dart_ret_t create_local_alloc(dart_team_data_t *team_data)
 {
   dart_localpool = dart_buddy_new(DART_LOCAL_ALLOC_SIZE);
-  MPI_Win dart_sharedmem_win_local_alloc;
+  MPI_Win dart_sharedmem_win_local_alloc = MPI_WIN_NULL;
   char* *dart_sharedmem_local_baseptr_set = NULL;
 
 #if !defined(DART_MPI_DISABLE_SHARED_WINDOWS)

--- a/dart-impl/mpi/src/dart_mpi_op.c
+++ b/dart-impl/mpi/src/dart_mpi_op.c
@@ -106,7 +106,7 @@ dart_ret_t dart__mpi__op_init()
 
 const char* dart__mpi__op_name(dart_operation_t op)
 {
-  DART_ASSERT(op >= DART_OP_UNDEFINED && op < DART_OP_LAST);
+  DART_ASSERT(op < DART_OP_LAST);
   return dart_op_names[op];
 }
 
@@ -239,7 +239,7 @@ static struct dart_operation_struct * get_op(MPI_Datatype mpi_type)
 
   if (elem == NULL) {
     DART_LOG_ERROR("Unknown MPI datatype %p for custom operation detected!",
-                   mpi_type);
+                   (void*)mpi_type);
   }
   dart__base__mutex_unlock(&hash_mtx);
 

--- a/dash/CMakeLists.txt
+++ b/dash/CMakeLists.txt
@@ -417,7 +417,7 @@ foreach (dart_variant ${DART_IMPLEMENTATIONS_LIST})
         set_target_properties(
           ${exampletarget} PROPERTIES
           COMPILE_FLAGS
-          "${VARIANT_ADDITIONAL_COMPILE_FLAGS} -Wno-unused"
+          "${VARIANT_ADDITIONAL_COMPILE_FLAGS}"
         )
         set_target_properties(
           ${exampletarget} PROPERTIES
@@ -471,7 +471,7 @@ if (BUILD_TESTS)
       set_target_properties(
         ${DASH_TEST} PROPERTIES
         COMPILE_FLAGS
-        "${VARIANT_ADDITIONAL_COMPILE_FLAGS} -Wno-unused -Wno-sign-compare"
+        "${VARIANT_ADDITIONAL_COMPILE_FLAGS}"
       )
       set_target_properties(
         ${DASH_TEST} PROPERTIES

--- a/dash/examples/bench.01.igups/main.cpp
+++ b/dash/examples/bench.01.igups/main.cpp
@@ -418,7 +418,6 @@ double test_dash_local_pointer(
 
   Timer timer;
   auto lbegin = a.lbegin();
-  auto lend   = a.lend();
 
   for (unsigned i = 0; i < REPEAT; ++i) {
     for (unsigned j = 0; j < ELEM_PER_UNIT; ++j) {

--- a/dash/examples/bench.05.array-range/main.cpp
+++ b/dash/examples/bench.05.array-range/main.cpp
@@ -196,9 +196,7 @@ double test_view_gups(
 
   auto lbegin_gidx = a.pattern().global(0);
 
-  auto a_size   = a.size();
   auto ts_start = Timer::Now();
-  auto myid     = pattern.team().myid();
 
   for (auto i = 0; i < REPEAT; ++i) {
     for (auto lidx = 0; lidx < a.lsize(); ++lidx) {
@@ -242,9 +240,7 @@ double test_algo_gups(
 
   auto lbegin_gidx = a.pattern().global(0);
 
-  auto a_size   = a.size();
   auto ts_start = Timer::Now();
-  auto myid     = pattern.team().myid();
   for (auto i = 0; i < REPEAT; ++i) {
     for (auto lidx = 1; lidx < a.lsize(); ++lidx) {
       auto lrange       = dash::local_index_range(

--- a/dash/examples/bench.05.pattern/main.cpp
+++ b/dash/examples/bench.05.pattern/main.cpp
@@ -260,7 +260,6 @@ double test_raw_gups(
 
   auto a_size   = a.size();
   auto ts_start = Timer::Now();
-  auto myid     = dash::myid();
   for (auto i = 0; i < REPEAT; ++i) {
     int l_idx = 0;
     for (auto g_idx = 0; g_idx < a_size; ++g_idx) {

--- a/dash/examples/bench.07.local-copy/main.cpp
+++ b/dash/examples/bench.07.local-copy/main.cpp
@@ -121,10 +121,6 @@ int main(int argc, char** argv)
   size_t num_local_cores = uloc.node_domain().num_cores();
   // Number of physical cores in a single NUMA domain (7 on SuperMUC):
   size_t numa_node_cores = num_local_cores / num_numa_nodes;
-  // Number of physical cores on a single socket (14 on SuperMUC):
-  size_t socket_cores    = numa_node_cores * 2;
-  // Number of processing nodes:
-  size_t num_nodes       = dash::util::Locality::NumNodes();
 
   dash::util::BenchmarkParams bench_params("bench.07.local-copy");
   bench_params.print_header();
@@ -513,7 +509,6 @@ void print_measurement_record(
   if (dash::myid() == 0) {
     std::string mpi_impl = dash__toxstr(DASH_MPI_IMPL_ID);
     size_t block_n     = size / dash::size();
-    size_t g_size_kb   = (size * sizeof(ElementType)) / 1024;
     size_t block_kb    = (block_n * sizeof(ElementType)) / 1024;
     double mbps        = measurement.mb_per_s;
     double init_s      = measurement.time_init_s;

--- a/dash/examples/bench.08.min-element/main.cpp
+++ b/dash/examples/bench.08.min-element/main.cpp
@@ -199,8 +199,6 @@ measurement perform_test(
 
   dash::Shared<IndexType> min_lidx_exp;
 
-  double duration_us;
-
 #ifdef LOAD_BALANCE
   dash::util::TeamLocality tloc(dash::Team::All());
   PatternType pattern(

--- a/dash/examples/bench.08.transform/main.cpp
+++ b/dash/examples/bench.08.transform/main.cpp
@@ -200,8 +200,6 @@ measurement perform_test(
 
   dash::Shared<IndexType> min_lidx_exp;
 
-  double duration_us;
-
 #ifdef LOAD_BALANCE
   dash::util::TeamLocality tloc(dash::Team::All());
   PatternType pattern(
@@ -238,6 +236,7 @@ measurement perform_test(
                                     arr_b.begin(),
                                     arr_c.begin(),
                                     dash::plus<ElementType>());
+    dash__unused(min_git);
     auto time_us  = Timer::ElapsedSince(ts_start);
 
     if (REPEAT == 1 || i == 1) {

--- a/dash/examples/bench.13.allreduce/main.cpp
+++ b/dash/examples/bench.13.allreduce/main.cpp
@@ -93,7 +93,6 @@ int main(int argc, char** argv)
   print_params(bench_params, params);
   print_measurement_header();
 
-  int     multiplier = 1;
   int          round = 0;
   std::array<std::string, 5> testcases {{
                             "dart_allreduce.minmax",
@@ -171,9 +170,6 @@ measurement evaluate(int reps, std::string testcase, benchmark_params params)
       auto&    team = dash::Team::All();
       shared_t g_min(std::numeric_limits<value_t>::max(), dash::team_unit_t{0}, team);
       shared_t g_max(std::numeric_limits<value_t>::min(), dash::team_unit_t{0}, team);
-
-      auto const start_min = static_cast<value_t>(g_min.get());
-      auto const start_max = static_cast<value_t>(g_max.get());
 
       team.barrier();
 

--- a/dash/examples/ex.02.halo-swap/main.cpp
+++ b/dash/examples/ex.02.halo-swap/main.cpp
@@ -86,7 +86,6 @@ int main(int argc, char * argv[])
   dash::init(&argc, &argv);
 
   auto myid = dash::myid();
-  auto size = dash::size();
 
   size_t tilex = 6;
   size_t tiley = 4;

--- a/dash/examples/ex.02.matrix.halo.heat_equation/main.cpp
+++ b/dash/examples/ex.02.matrix.halo.heat_equation/main.cpp
@@ -111,8 +111,6 @@ int main(int argc, char *argv[])
 
   const auto &lview = halomat.view_local();
   auto offset = lview.extent(1);
-  long inner_start = offset + 1;
-  long inner_end = lview.extent(0) * (offset - 1) - 1;
 
   current_halo->matrix().barrier();
 
@@ -125,7 +123,6 @@ int main(int argc, char *argv[])
     current_halo->update_async();
 
     // optimized calculation of inner matrix elements
-    auto* current_begin = current_matrix.lbegin();
     auto* new_begin = new_matrix.lbegin();
 #if 0
     for (auto i = inner_start; i < inner_end; i += offset) {

--- a/dash/examples/ex.02.matrix_global_access/main.cpp
+++ b/dash/examples/ex.02.matrix_global_access/main.cpp
@@ -51,7 +51,6 @@ int main(int argc, char * argv[])
     dash::Team::All(), teamspec_2d );
 
   if (0 == myid) {
-    auto it = matrix.begin();
     for (size_t i = 0; i < w; ++i) {
       for (size_t k = 0; k < h; ++k) {
         matrix[i][k] = 100;

--- a/dash/examples/ex.02.matrix_printed_in_different_ways/main.cpp
+++ b/dash/examples/ex.02.matrix_printed_in_different_ways/main.cpp
@@ -49,7 +49,6 @@ void print_matrix_2(const MatrixT & matrix) {
 template<class MatrixT>
 void print_matrix_3(const MatrixT & matrix) {
   typedef typename MatrixT::value_type value_t;
-  auto rows = matrix.extent(0);
   auto cols = matrix.extent(1);
 
   cout << "print with global iterator:" << endl;
@@ -66,7 +65,6 @@ void print_matrix_3(const MatrixT & matrix) {
 
 template<class MatrixT>
 void print_matrix_4(const MatrixT & matrix) {
-  auto rows = matrix.extent(0);
   auto cols = matrix.extent(1);
 
   cout << "print _L_ocal/_R_emote with global iterator:" << endl;

--- a/dash/examples/ex.02.unordered_map/main.cpp
+++ b/dash/examples/ex.02.unordered_map/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char* argv[])
   for (auto i = 0; i < num_add_elem; i++) {
     key_t    key    = 100 * (myid+1) + i;
     mapped_t mapped = 1.000 * (myid+1) + ((i+1) * 0.001);
-    value_t  value  = std::make_pair(key, mapped);
+    value_t  value  = dash::make_pair(key, mapped);
 
     // Satisfies map concept as specified in STL
     auto insertion   = map.insert(value);

--- a/dash/examples/ex.02.unordered_map/main.cpp
+++ b/dash/examples/ex.02.unordered_map/main.cpp
@@ -100,7 +100,6 @@ int main(int argc, char* argv[])
   dash::init(&argc, &argv);
 
   dart_unit_t myid = dash::myid();
-  size_t num_units = dash::Team::All().size();
 
   // Number of preallocated elements:
   size_type init_global_size  = 0;

--- a/dash/examples/ex.11.simple-stencil/main.cpp
+++ b/dash/examples/ex.11.simple-stencil/main.cpp
@@ -46,10 +46,10 @@ void write_pgm(const std::string & filename, const Array_t & data){
 //    std::vector<element_t> buffer(ext_x);
 
     for(long y=0; y<ext_y; ++y){
-      auto first = data.begin()+ext_x*y; 
-      auto last  = data.begin()+(ext_x*(y+1));
 
 //      BUG!!!!
+//      auto first = data.begin()+ext_x*y; 
+//      auto last  = data.begin()+(ext_x*(y+1));
 //      dash::copy(first, last, buffer.data());
 
       for(long x=0; x<ext_x; ++x){

--- a/dash/include/dash/Pair.h
+++ b/dash/include/dash/Pair.h
@@ -1,7 +1,7 @@
 #ifndef DASH_DASH_INCLUDE_DASH_PAIR_H_
 #define DASH_DASH_INCLUDE_DASH_PAIR_H_
 
-#include <dash/Meta.h>
+#include <dash/meta/TypeInfo.h>
 
 #include <type_traits>
 #include <iostream>
@@ -24,8 +24,8 @@ namespace dash {
     typedef T1 first_type;    /// @c first_type is the first bound type
     typedef T2 second_type;   /// @c second_type is the second bound type
 
-    T1 first;                 /// @c first is a copy of the first object
-    T2 second;                /// @c second is a copy of the second object
+    first_type  first;                 /// @c first is a copy of the first object
+    second_type second;                /// @c second is a copy of the second object
 
     /**
      * The default constructor.
@@ -87,10 +87,7 @@ namespace dash {
     operator=(const Pair& p) = default;
 
     Pair&
-    operator=(Pair&& p)
-    noexcept(
-        std::is_nothrow_move_assignable<T1>::value &&
-        std::is_nothrow_move_assignable<T2>::value) = default;
+    operator=(Pair&& p) = default;
 
     template<class U1, class U2>
     Pair&
@@ -139,8 +136,8 @@ namespace dash {
   inline constexpr bool
   operator<(const Pair<T1, T2>& x, const Pair<T1, T2>& y)
   {
-    return  x.first < y.first
-      || (!(y.first < x.first) && !(x.second >= y.second));
+    return  (((x.first) < (y.first))
+      || (!((y.first) < (x.first)) && !(x.second >= y.second)));
   }
 
   /**

--- a/dash/include/dash/algorithm/Copy.h
+++ b/dash/include/dash/algorithm/Copy.h
@@ -308,9 +308,6 @@ dash::Future<ValueType *> copy_async(
   if (num_local_elem == total_copy_elem) {
     // Entire input range is local:
     DASH_LOG_TRACE("dash::copy_async", "entire input range is local");
-    ValueType * l_out_last = out_first + total_copy_elem;
-    ValueType * l_in_first = in_first.local();
-    ValueType * l_in_last  = l_in_first + total_copy_elem;
 
     // Use memcpy for data ranges below 64 KB
     if (use_memcpy) {

--- a/dash/include/dash/algorithm/Equal.h
+++ b/dash/include/dash/algorithm/Equal.h
@@ -60,7 +60,6 @@ namespace internal {
         "invalid iterator: Need to be a global iterator");
 
     auto& team = first_1.team();
-    auto  myid = team.myid();
     // Global iterators to local range:
     auto index_range_in  = dash::local_range(first_1, last_1);
     auto l_first_1       = index_range_in.begin;
@@ -76,17 +75,17 @@ namespace internal {
       l_result = ::dash::internal::equal_loc_impl(
           l_first_1, l_last_1, first_2.local());
     } else if(common_dist > 0) {
-    l_result = ::dash::internal::equal_overlapping_impl(
-        first_1, last_1, first_2);
-  }
+      l_result = ::dash::internal::equal_overlapping_impl(
+          first_1, last_1, first_2);
+    }
 
-  char r_result         = 0;
+    char r_result         = 0;
 
-  DASH_ASSERT_RETURNS(
-    dart_allreduce(&l_result, &r_result, 1,
-      DART_TYPE_BYTE, DART_OP_BAND, team.dart_id()),
-    DART_OK);
-  return r_result;
+    DASH_ASSERT_RETURNS(
+       dart_allreduce(&l_result, &r_result, 1,
+        DART_TYPE_BYTE, DART_OP_BAND, team.dart_id()),
+      DART_OK);
+    return r_result;
 }
 
 /**

--- a/dash/include/dash/algorithm/Find.h
+++ b/dash/include/dash/algorithm/Find.h
@@ -43,12 +43,9 @@ GlobIter find(
   auto index_range   = dash::local_index_range(first, last);
   auto l_begin_index = index_range.begin;
   auto l_end_index   = index_range.end;
-  auto first_offset  = first.pos();
   if(l_begin_index == l_end_index){
     g_index = std::numeric_limits<p_index_t>::max();
   } else {
-   auto g_begin_index = pattern.global(l_begin_index);
-
     // Pointer to first element in local memory:
     const ElementType * lbegin        = first.globmem().lbegin();
     // Pointers to first / final element in local range:

--- a/dash/include/dash/algorithm/LocalRange.h
+++ b/dash/include/dash/algorithm/LocalRange.h
@@ -315,7 +315,6 @@ local_range(
     return LocalRange<const value_t> { nullptr, nullptr };
   }
   // Local start address from global memory:
-  const auto& pattern = first.pattern();
   auto lbegin  = first.globmem().lbegin();
   // Add local offsets to local start address:
   if (lbegin == nullptr) {

--- a/dash/include/dash/algorithm/Operation.h
+++ b/dash/include/dash/algorithm/Operation.h
@@ -191,7 +191,7 @@ struct multiply
 };
 
 /**
- * Returns second operand. Used as replace reduce operation
+ * Returns first operand. Used as no-op reduce operation
  *
  * \see      dart_operation_t::DART_OP_REPLACE
  *

--- a/dash/include/dash/algorithm/Reduce.h
+++ b/dash/include/dash/algorithm/Reduce.h
@@ -86,7 +86,6 @@ reduce(
 {
   using value_t    = typename std::iterator_traits<LocalInputIter>::value_type;
   using local_result_t = struct dash::internal::local_result<value_t>;
-  auto myid        = team.myid();
   auto l_first     = in_first;
   auto l_last      = in_last;
 

--- a/dash/include/dash/algorithm/Sort.h
+++ b/dash/include/dash/algorithm/Sort.h
@@ -155,8 +155,6 @@ void sort(GlobRandomIt begin, GlobRandomIt end, SortableHash sortable_hash)
 
   using array_t = dash::Array<std::size_t>;
 
-  std::size_t gsize = nunits * NLT_NLE_BLOCK * 2;
-
   // implicit barrier...
   array_t g_partition_data(nunits * nunits * 3, dash::BLOCKED, team);
   std::uninitialized_fill(

--- a/dash/include/dash/algorithm/Transform.h
+++ b/dash/include/dash/algorithm/Transform.h
@@ -275,8 +275,6 @@ GlobOutputIt transform(
 {
   using iterator_traits = dash::iterator_traits<InputIt>;
   DASH_LOG_DEBUG("dash::transform(gaf, gal, gbf, goutf, binop)");
-  auto in_first = in_a_first;
-  auto in_last  = in_a_last;
 
   if (in_b_first == out_first) {
     // Output range is rhs input range: C += A

--- a/dash/include/dash/algorithm/internal/Sort-inl.h
+++ b/dash/include/dash/algorithm/internal/Sort-inl.h
@@ -118,7 +118,6 @@ inline const std::vector<std::size_t> psort__local_histogram(
 {
   DASH_LOG_TRACE("< psort__local_histogram");
 
-  auto const nborders = splitters.size();
   // The first element is 0 and the last element is the total number of local
   // elements in this unit
   auto const sz = splitters.size() + 1;

--- a/dash/include/dash/map/UnorderedMap.h
+++ b/dash/include/dash/map/UnorderedMap.h
@@ -16,9 +16,9 @@
 #include <dash/map/UnorderedMapLocalRef.h>
 #include <dash/map/UnorderedMapLocalIter.h>
 #include <dash/map/UnorderedMapGlobIter.h>
+#include <dash/Pair.h>
 
 #include <iterator>
-#include <utility>
 #include <limits>
 #include <vector>
 #include <functional>
@@ -78,7 +78,7 @@ template<
   typename Hash    = dash::HashLocal<Key>,
   typename Pred    = std::equal_to<Key>,
   typename Alloc   = dash::allocator::EpochSynchronizedAllocator<
-                       std::pair<const Key, Mapped> > >
+                       dash::Pair<const Key, Mapped> > >
 class UnorderedMap
 {
   static_assert(
@@ -109,7 +109,7 @@ public:
   typedef dash::default_index_t                                   index_type;
   typedef dash::default_index_t                              difference_type;
   typedef dash::default_size_t                                     size_type;
-  typedef std::pair<const key_type, mapped_type>                  value_type;
+  typedef dash::Pair<const key_type, mapped_type>                 value_type;
 
   typedef UnorderedMapLocalRef<Key, Mapped, Hash, Pred, Alloc>    local_type;
 
@@ -511,7 +511,7 @@ public:
   {
     DASH_LOG_TRACE("UnorderedMap.[]()", "key:", key);
     iterator      git_value   = insert(
-                                   std::make_pair(key, mapped_type()))
+                                   dash::make_pair(key, mapped_type()))
                                 .first;
     DASH_LOG_TRACE_VAR("UnorderedMap.[]", git_value);
     dart_gptr_t   gptr_mapped = git_value.dart_gptr();
@@ -610,14 +610,14 @@ public:
   // Modifiers
   //////////////////////////////////////////////////////////////////////////
 
-  std::pair<iterator, bool> insert(
+  dash::Pair<iterator, bool> insert(
     /// The element to insert.
     const value_type & value)
   {
     auto && key = value.first;
     DASH_LOG_TRACE("UnorderedMap.insert()", "key:", key);
 
-    auto result = std::make_pair(_end, false);
+    auto result = dash::make_pair(_end, false);
 
     DASH_ASSERT(_globmem != nullptr);
     // Look up existing element at given key:
@@ -730,7 +730,7 @@ private:
    * Using `std::declval()` instead (to generate a compile-time
    * pseudo-instance for member resolution) only works if Key and Mapped
    * are default-constructible.
-   * 
+   *
    * Finally, the distance obtained from
    *
    *   &(lptr_value->second) - lptr_value
@@ -784,7 +784,7 @@ private:
   /**
    * Insert value at specified unit.
    */
-  std::pair<iterator, bool> _insert_at(
+  dash::Pair<iterator, bool> _insert_at(
     team_unit_t        unit,
     /// The element to insert.
     const value_type & value)
@@ -792,7 +792,7 @@ private:
     DASH_LOG_TRACE("UnorderedMap._insert_at()",
                    "unit:",   unit,
                    "key:",    value.first);
-    auto result = std::make_pair(_end, false);
+    auto result = dash::make_pair(_end, false);
     // Increase local size first to reserve storage for the new element.
     // Use atomic increment to prevent hazard when other units perform
     // remote insertion at the local unit:

--- a/dash/include/dash/pattern/MakePattern.h
+++ b/dash/include/dash/pattern/MakePattern.h
@@ -56,7 +56,6 @@ make_team_spec(
     return teamspec;
   }
 
-  auto n_elem_total = sizespec.size();
   // Configure preferable blocking factors:
   std::set<extent_t> blocking;
   if (n_nodes == 1) {

--- a/dash/include/dash/pattern/SeqTilePattern.h
+++ b/dash/include/dash/pattern/SeqTilePattern.h
@@ -760,8 +760,6 @@ public:
     std::array<IndexType, NumDimensions> phase_coords;
     // Coordinates of the block containing the element:
     std::array<IndexType, NumDimensions> block_coords;
-    // Local coordinates of the block containing the element:
-    std::array<IndexType, NumDimensions> l_block_coords;
     for (auto d = 0; d < NumDimensions; ++d) {
       auto vs_coord     = global_coords[d];
       phase_coords[d]   = vs_coord % _blocksize_spec.extent(d);
@@ -1036,8 +1034,6 @@ public:
     std::array<IndexType, NumDimensions> phase_coords;
     // Coordinates of the block containing the element:
     std::array<IndexType, NumDimensions> block_coords;
-    // Local coordinates of the block containing the element:
-    std::array<IndexType, NumDimensions> l_block_coords;
     for (auto d = 0; d < NumDimensions; ++d) {
       auto vs_coord     = global_coords[d];
       phase_coords[d]   = vs_coord % _blocksize_spec.extent(d);

--- a/dash/test/algorithm/ReduceTest.cc
+++ b/dash/test/algorithm/ReduceTest.cc
@@ -37,7 +37,6 @@ TEST_F(ReduceTest, SimpleStart) {
 
 
 TEST_F(ReduceTest, OpMult) {
-  const size_t num_elem_local = 1;
   using value_t = uint64_t;
   size_t num_elem_total       = std::max(static_cast<size_t>(32), dash::size());
   value_t value = 2, start = 10;
@@ -106,10 +105,6 @@ TEST_F(ReduceTest, SimpleStruct) {
 
 
 TEST_F(ReduceTest, StringConcatOperaton) {
-  const size_t num_elem_local = 100;
-  size_t num_elem_total       = _dash_size * num_elem_local;
-  auto value = 2;
-
   // Create a vector
   dash::Array<int> target(4);
   target[0] = 1;

--- a/dash/test/algorithm/STLAlgorithmTest.cc
+++ b/dash/test/algorithm/STLAlgorithmTest.cc
@@ -90,7 +90,7 @@ TEST_F(STLAlgorithmTest, StdCopyGlobalToGlobal) {
     auto a_first = array_a.begin();
     auto b_first = array_b.begin();
     while (a_first != array_a.end()) {
-      *b_first++ == *a_first++;
+      ASSERT_EQ_U(*b_first++ == *a_first++, true);
     }
     DASH_LOG_DEBUG_VAR("STLAlgorithmTest.StdCopyGlobalToGlobal", array_b);
 

--- a/dash/test/algorithm/SortTest.cc
+++ b/dash/test/algorithm/SortTest.cc
@@ -222,7 +222,6 @@ TEST_F(SortTest, MatrixBlockedRow)
   using narray_t =
       dash::NArray<value_t, 2, dash::default_index_t, block_pat_t>;
 
-  size_t team_size = dash::Team::All().size();
   size_t extent_x  = std::sqrt(num_local_elem) * dash::size();
   size_t extent_y  = extent_x;
 
@@ -288,8 +287,6 @@ static void perform_test(GlobIter begin, GlobIter end)
   auto const l_range = dash::local_index_range(begin, end);
 
   auto l_mem_begin = begin.globmem().lbegin();
-
-  auto const n_l_elem = l_range.end - l_range.begin;
 
   auto const lbegin = l_mem_begin + l_range.begin;
   auto const lend   = l_mem_begin + l_range.end;

--- a/dash/test/container/MatrixTest.cc
+++ b/dash/test/container/MatrixTest.cc
@@ -1076,7 +1076,6 @@ TEST_F(MatrixTest, UnderfilledBlockedPatternExtents)
   typedef dash::default_extent_t   extent_t;
   typedef dash::default_index_t     index_t;
 
-  dart_unit_t myid= dash::myid();
   auto numunits = dash::Team::All().size();
 
   dash::TeamSpec<2> teamspec( numunits, 1 );
@@ -1098,10 +1097,11 @@ TEST_F(MatrixTest, UnderfilledBlockedPatternExtents)
   auto lw = (corner[1] + matrix.local.extent(1) < w )
                ? matrix.local.extent(1)
                : w - corner[1];
+  dash__unused(lw);
   auto lh = (corner[0] + matrix.local.extent(0) < h )
                ? matrix.local.extent(0)
                : h - corner[0];
-
+  dash__unused(lh);
   EXPECT_LE_U( corner[1] + matrix.local.extent(1), w );
   EXPECT_LE_U( corner[0] + matrix.local.extent(0), h );
 }
@@ -1178,8 +1178,6 @@ TEST_F(MatrixTest, MatrixLBegin)
 
   dash::fill(matrix.begin(), matrix.end(), myid);
   matrix.barrier();
-
-  int * l_first = matrix.lbegin();
 
   EXPECT_EQ_U(myid, static_cast<int>(*(matrix.lbegin())));
   EXPECT_EQ_U(myid, static_cast<int>(*(matrix.local.block(0).begin())));
@@ -1466,8 +1464,6 @@ TEST_F(MatrixTest, LocalMatrixRefs)
   using value_t = unsigned int;
   using uint    = unsigned int;
 
-  uint myid = static_cast<uint>(dash::Team::GlobalUnitID().id);
-
   const uint nelts = 40;
 
   dash::NArray<value_t, 2> mat(nelts, nelts);
@@ -1566,10 +1562,11 @@ TEST_F(MatrixTest, SubViewMatrix3Dim)
                                         matrix[0].end()));
   
   if (dash::myid().id == 0) {
-  int visited = 0;
+    int visited = 0;
     for (auto it = matrix[0].begin(); it != matrix[0].end();
          ++it, ++visited) {
       double val = *it;
+      dash__unused(val);
     }
     EXPECT_EQ_U(visited, sub_0_size);
   }

--- a/dash/test/pattern/CSRPatternTest.cc
+++ b/dash/test/pattern/CSRPatternTest.cc
@@ -73,7 +73,6 @@ TEST_F(CSRPatternTest, CopyGlobalToLocal) {
 
   typedef int value_t;
 
-  auto   myid   = dash::myid();
   auto & team   = dash::Team::All();
   auto   nunits = team.size();
 
@@ -87,7 +86,6 @@ TEST_F(CSRPatternTest, CopyGlobalToLocal) {
     local_sizes.push_back(tmp);
     sum += tmp;
   }
-  auto max_local_size = local_sizes.back();
 
   DASH_LOG_DEBUG_VAR("CSRPatternTest.InitArray", local_sizes);
 

--- a/dash/test/pattern/SeqTilePatternTest.cc
+++ b/dash/test/pattern/SeqTilePatternTest.cc
@@ -28,7 +28,6 @@ TEST_F(SeqTilePatternTest, Distribute2DimTile)
   // Choose 'inconvenient' extents:
   size_t block_rows   = 3;
   size_t block_cols   = 2;
-  size_t block_size   = block_rows * block_cols;
   size_t size_rows    = (team_size+1) * 3 * block_rows;
   size_t size_cols    = (team_size-1) * 2 * block_cols;
   size_t size         = size_rows * size_cols;

--- a/dash/test/team/UnitIdTest.cc
+++ b/dash/test/team/UnitIdTest.cc
@@ -16,6 +16,7 @@ TEST_F(UnitIdTest, TypeCompatibility)
 
   dash::team_unit_t   l_uid { 12 };
   dash::global_unit_t g_uid { 12 };
+  ASSERT_EQ_U(l_uid.id, g_uid.id);
 
   // this must fail to compile
   //   l_uid = g_uid;


### PR DESCRIPTION
This PR fixes a bunch of problems reported by the Cray compiler (seen while working on  #593):

- Replace usage of `std::pair` with `dash::Pair`, which is a PODType and thus allows for `offsetof` to be used
- Remove `-Wno-unsed` from the `dash/` directory as it should a) not be set outside of `CMakeExt/Compiler.cmake` and b) is not supported by all compilers; This came with a larger set of fixes to remove unused variables.
- Fix some other minor issues