### PR TITLE
Add dash::Future::valid

### DIFF
--- a/dash/include/dash/Future.h
+++ b/dash/include/dash/Future.h
@@ -12,20 +12,41 @@
 
 namespace dash {
 
+/**
+ * Implementation of a future used to wait for an operation to complete
+ * and access the value returned by that operation.
+ */
 template<typename ResultT>
 class Future
 {
-private:
+public:
   typedef Future<ResultT>                self_t;
+
+  /**
+   * Callback function returning the result value.
+   */
   typedef std::function<ResultT (void)>  get_func_t;
+
+  /**
+   * Callback function to test for the availability of the result value.
+   */
   typedef std::function<bool (ResultT*)> test_func_t;
+
+  /**
+   * Callback function called upon destruction.
+   */
   typedef std::function<void (void)>     destroy_func_t;
 
 private:
+  /// Function returning the value
   get_func_t     _get_func;
+  /// Function used to test for the availability of a value
   test_func_t    _test_func;
+  /// Function called upon destruction of the future
   destroy_func_t _destroy_func;
+  /// The value to be returned byt the future
   ResultT        _value;
+  /// Whether or not the value is available
   bool           _ready = false;
 
 public:
@@ -37,18 +58,39 @@ public:
 
 public:
 
-  Future()
+  /**
+   * Default constructor, creates a future that invalid.
+   *
+   * \see dash::Future::valid
+   */
+  Future() noexcept
   { }
 
-  Future(ResultT & result)
+  /**
+   * Create a future from an already available value.
+   */
+  Future(const ResultT & result)
   : _value(result),
     _ready(true)
   { }
 
-  Future(const get_func_t & func)
-  : _get_func(func)
+  /**
+   * Create a future using a function that returns the value.
+   *
+   * \param get_func Function returning the result value.
+   */
+  Future(const get_func_t & get_func)
+  : _get_func(get_func)
   { }
 
+  /**
+   * Create a future using a function that returns the value and a function
+   * to test whether the value returned by \c get_func is ready.
+   *
+   * \param get_func  Function returning the result value.
+   * \param test_func Function returning \c true and assigning the result value
+   *                  to the pointer passed to it if the value is available.
+   */
   Future(
     const get_func_t     & get_func,
     const test_func_t    & test_func)
@@ -56,6 +98,16 @@ public:
     _test_func(test_func)
   { }
 
+  /**
+   * Create a future using a function that returns the value and a function
+   * to test whether the value returned by \c get_func is ready, plus a function
+   * to be called upon destruction of the future.
+   *
+   * \param get_func  Function returning the result value.
+   * \param test_func Function returning \c true and assigning the result value
+   *                  to the pointer passed to it if the value is available.
+   * \param destroy_func Function called upon destruction of the future.
+   */
   Future(
     const get_func_t     & get_func,
     const test_func_t    & test_func,
@@ -65,19 +117,41 @@ public:
     _destroy_func(destroy_func)
   { }
 
+  /**
+   * Copy construction is not permited.
+   */
   Future(const self_t& other) = delete;
+
+  /**
+   * Default move constructor.
+   */
   Future(self_t&& other)      = default;
 
+  /**
+   * Destructor. Calls the \c destroy_func passed to the constructor,
+   * if available.
+   */
   ~Future() {
     if (_destroy_func) {
       _destroy_func();
     }
   }
 
-  /// copy-assignment is not permitted
-  Future<ResultT> & operator=(const self_t& other) = delete;
-  Future<ResultT> & operator=(self_t&& other)      = default;
+  /**
+   * Copy assignment is not permited.
+   */
+  self_t & operator=(const self_t& other) = delete;
 
+  /**
+   * Move assignment is defaulted.
+   */
+  self_t & operator=(self_t&& other)      = default;
+
+
+  /**
+   * Wait for the value to become available. It is safe to call \ref get
+   * after this call returned.
+   */
   void wait()
   {
     DASH_LOG_TRACE_VAR("Future.wait()", _ready);
@@ -95,6 +169,13 @@ public:
     DASH_LOG_TRACE_VAR("Future.wait >", _ready);
   }
 
+  /**
+   * Test whether the value is available. It is safe to call \ref get
+   * after this call returned \c true. This function will block if no
+   * test-function has been provided.
+   *
+   * \return \c true if the value is available, \c false otherwise.
+   */
   bool test()
   {
     if (!_ready && _test_func) {
@@ -103,7 +184,10 @@ public:
     return _ready;
   }
 
-  ResultT & get()
+  /**
+   * Return the value after making sure that the value is available.
+   */
+  ResultT get()
   {
     DASH_LOG_TRACE_VAR("Future.get()", _ready);
     wait();
@@ -111,7 +195,12 @@ public:
     return _value;
   }
 
-  bool valid()
+
+  /**
+   * Check whether the future is valid, i.e., whether either a value or a
+   * function to access the valid has been provided.
+   */
+  bool valid() noexcept
   {
     return (_ready || _get_func != nullptr);
   }

--- a/dash/include/dash/Future.h
+++ b/dash/include/dash/Future.h
@@ -216,6 +216,197 @@ public:
 
 }; // class Future
 
+
+/**
+ * Overload of \ref dash::Future for operations returning \c void.
+ *
+ */
+template<>
+class Future<void>
+{
+public:
+  typedef Future<void>               self_t;
+
+  /**
+   * Callback function to wait for completion.
+   */
+  typedef std::function<void (void)> get_func_t;
+
+  /**
+   * Callback function to test for completion.
+   */
+  typedef std::function<bool (void)> test_func_t;
+
+  /**
+   * Callback function called upon destruction.
+   */
+  typedef std::function<void (void)> destroy_func_t;
+
+private:
+  /// Function returning the value
+  get_func_t     _get_func;
+  /// Function used to test for the availability of a value
+  test_func_t    _test_func;
+  /// Function called upon destruction of the future
+  destroy_func_t _destroy_func;
+  /// Whether or not the value is available
+  bool           _ready = false;
+
+public:
+  // For ostream output
+  template<typename ResultT_>
+  friend std::ostream & operator<<(
+      std::ostream & os,
+      const Future<ResultT_> & future);
+
+public:
+
+  /**
+   * Default constructor, creates a future that invalid.
+   *
+   * \see dash::Future::valid
+   */
+  Future() noexcept
+  { }
+
+  /**
+   * Create a future using a function that returns the value.
+   *
+   * \param get_func  Function blocking until the operation is complete.
+   */
+  Future(const get_func_t & get_func)
+  : _get_func(get_func)
+  { }
+
+  /**
+   * Create a future using a function that returns the value and a function
+   * to test whether the result value is available.
+   *
+   * \param get_func  Function blocking until the operation is complete.
+   * \param test_func Function returning \c true if the value is available.
+   */
+  Future(
+    const get_func_t     & get_func,
+    const test_func_t    & test_func)
+  : _get_func(get_func),
+    _test_func(test_func)
+  { }
+
+  /**
+   * Create a future using a function to wait for completion and a function
+   * to test for completion, plus a function to be called upon destruction
+   * of the future.
+   *
+   * \param get_func  Function to wait for completion.
+   * \param test_func Function returning \c true if the operation is complete.
+   * \param destroy_func Function called upon destruction of the future.
+   */
+  Future(
+    const get_func_t     & get_func,
+    const test_func_t    & test_func,
+    const destroy_func_t & destroy_func)
+  : _get_func(get_func),
+    _test_func(test_func),
+    _destroy_func(destroy_func)
+  { }
+
+  /**
+   * Copy construction is not permited.
+   */
+  Future(const self_t& other) = delete;
+
+  /**
+   * Default move constructor.
+   */
+  Future(self_t&& other)      = default;
+
+  /**
+   * Destructor. Calls the \c destroy_func passed to the constructor,
+   * if available.
+   */
+  ~Future() {
+    if (_destroy_func) {
+      _destroy_func();
+    }
+  }
+
+  /**
+   * Copy assignment is not permited.
+   */
+  self_t& operator=(const self_t& other) = delete;
+
+  /**
+   * Move assignment is defaulted.
+   */
+  self_t & operator=(self_t&& other)      = default;
+
+
+  /**
+   * Wait for the value to become available. It is safe to call \ref get
+   * after this call returned.
+   */
+  void wait()
+  {
+    DASH_LOG_TRACE_VAR("Future.wait()", _ready);
+    if (_ready) {
+      return;
+    }
+    if (!_get_func) {
+      DASH_LOG_ERROR("Future.wait()", "No function");
+      DASH_THROW(
+        dash::exception::RuntimeError,
+        "Future not initialized with function");
+    }
+    _get_func();
+    _ready = true;
+    DASH_LOG_TRACE_VAR("Future.wait >", _ready);
+  }
+
+  /**
+   * Test whether the operation has completed.
+   *
+   * Blocks if no test-function has been provided.
+   *
+   * \return \c true if the value is available, \c false otherwise.
+   */
+  bool test()
+  {
+    if (!_ready) {
+      if (_test_func) {
+        _ready = _test_func();
+      } else if (_get_func) {
+        _get_func();
+        _ready = true;
+      } else {
+        DASH_THROW(
+          dash::exception::RuntimeError,
+          "Future not initialized with function");
+      }
+    }
+    return _ready;
+  }
+
+  /**
+   * Return after making sure that the operation is completed.
+   */
+  void get()
+  {
+    DASH_LOG_TRACE_VAR("Future.get()", _ready);
+    wait();
+    DASH_LOG_TRACE("Future.get >");
+  }
+
+  /**
+   * Check whether the future is valid, i.e., a function to wait for completion
+   * has been provided.
+   */
+  bool valid() noexcept
+  {
+    return (_get_func != nullptr);
+  }
+
+}; // class Future
+
 template<typename ResultT>
 std::ostream & operator<<(
   std::ostream & os,

--- a/dash/include/dash/Future.h
+++ b/dash/include/dash/Future.h
@@ -178,8 +178,17 @@ public:
    */
   bool test()
   {
-    if (!_ready && _test_func) {
-      _ready = _test_func(&_value);
+    if (!_ready) {
+      if (_test_func) {
+        _ready = _test_func(&_value);
+      } else if (_get_func) {
+        _value = _get_func();
+        _ready = true;
+      } else {
+        DASH_THROW(
+          dash::exception::RuntimeError,
+          "Future not initialized with function");
+      }
     }
     return _ready;
   }

--- a/dash/include/dash/Future.h
+++ b/dash/include/dash/Future.h
@@ -38,7 +38,6 @@ public:
 public:
 
   Future()
-  : _ready(false)
   { }
 
   Future(ResultT & result)
@@ -110,6 +109,11 @@ public:
     wait();
     DASH_LOG_TRACE_VAR("Future.get >", _value);
     return _value;
+  }
+
+  bool valid()
+  {
+    return (_ready || _get_func != nullptr);
   }
 
 }; // class Future

--- a/dash/test/types/FutureTest.cc
+++ b/dash/test/types/FutureTest.cc
@@ -1,0 +1,99 @@
+
+#include "../TestBase.h"
+#include "../TestLogHelpers.h"
+#include "FutureTest.h"
+
+#include <dash/Future.h>
+
+
+TEST_F(FutureTest, DefaultCtor)
+{
+  dash::Future<int> fut;
+  ASSERT_EQ_U(false, fut.valid());
+}
+
+TEST_F(FutureTest, ReadyVal)
+{
+  int value = 42;
+  dash::Future<int> fut(value);
+  ASSERT_EQ_U(true, fut.valid());
+  ASSERT_EQ_U(true, fut.test());
+  ASSERT_EQ_U(value, fut.get());
+}
+
+TEST_F(FutureTest, GetFunc)
+{
+  int value = 42;
+
+  dash::Future<int> fut([=](){ return value; });
+
+  ASSERT_EQ_U(true, fut.valid());
+  ASSERT_EQ_U(true, fut.test());
+  ASSERT_EQ_U(value, fut.get());
+}
+
+TEST_F(FutureTest, WaitGetFunc)
+{
+  int value = 42;
+
+  dash::Future<int> fut([=](){ return value; });
+
+  ASSERT_EQ_U(true, fut.valid());
+  fut.wait();
+  ASSERT_EQ_U(value, fut.get());
+}
+
+
+TEST_F(FutureTest, GetTestDestroyFunc)
+{
+  int value = 42;
+  bool destructor_called = false;
+  {
+    dash::Future<int> fut(
+      [=](){ return value; },
+      [=](int *val){
+        // the first call returns false
+        static bool ready = false;
+        bool result = ready;
+        if (!ready) {
+          ready = true;
+        } else {
+          *val = value;
+        }
+        return result;
+      },
+      [&](){
+        destructor_called = true;
+      });
+
+    ASSERT_EQ_U(true, fut.valid());
+    ASSERT_EQ_U(false, fut.test());
+    // the second call to ready() should return true
+    ASSERT_EQ_U(true, fut.test());
+    ASSERT_EQ_U(value, fut.get());
+  }
+  ASSERT_EQ_U(true, destructor_called);
+}
+
+
+TEST_F(FutureTest, VoidFunc)
+{
+  bool destructor_called = false;
+  bool get_called        = false;
+  bool test_called       = false;
+  {
+    dash::Future<void> fut(
+      [&](){ get_called  = true; },
+      [&](){ test_called = true; return false;},
+      [&](){
+        destructor_called = true;
+      });
+
+    ASSERT_EQ_U(true, fut.valid());
+    ASSERT_EQ_U(false, fut.test());
+    fut.get();
+  }
+  ASSERT_EQ_U(true, get_called);
+  ASSERT_EQ_U(true, test_called);
+  ASSERT_EQ_U(true, destructor_called);
+}

--- a/dash/test/types/FutureTest.h
+++ b/dash/test/types/FutureTest.h
@@ -1,0 +1,24 @@
+#ifndef DASH__TEST__GLOBREF_TEST_H_
+#define DASH__TEST__GLOBREF_TEST_H_
+
+#include <gtest/gtest.h>
+
+#include "../TestBase.h"
+
+
+/**
+ * Test fixture for \c dash::Future.
+ */
+class FutureTest : public dash::test::TestBase {
+protected:
+  size_t _dash_id    = 0;
+  size_t _dash_size  = 0;
+
+  virtual void SetUp() {
+    dash::test::TestBase::SetUp();
+    _dash_id   = dash::myid();
+    _dash_size = dash::size();
+  }
+};
+
+#endif // DASH__TEST__GLOBREF_TEST_H_


### PR DESCRIPTION
Used to check whether a future has been properly initialized (which may not be the case in a `std::vector<dash::Future>`). This is used in the DASH port of Lulesh.