### PR TITLE
Bump DASH release number to 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ include(${CMAKE_SOURCE_DIR}/CMakeExt/GenerateConfig.cmake)
 
 ## Version number
 set(DASH_VERSION_MAJOR 0 CACHE STRING "DASH major version number.")
-set(DASH_VERSION_MINOR 3 CACHE STRING "DASH minor version number.")
+set(DASH_VERSION_MINOR 4 CACHE STRING "DASH minor version number.")
 set(DASH_VERSION_PATCH 0 CACHE STRING "DASH patch version number.")
 mark_as_advanced(
   DASH_VERSION_MAJOR

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -95,7 +95,7 @@ mkdir -p $BUILD_DIR/$REPORT_DIR
                         -DENABLE_COMPTIME_RED=OFF \
                         \
                         -DDART_IF_VERSION=3.2 \
-                        -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0/ \
+                        -DINSTALL_PREFIX=$HOME/opt/dash-0.4.0/ \
                         -DDART_IMPLEMENTATIONS=mpi \
                         -DENABLE_THREADSUPPORT=ON \
                         -DENABLE_DEV_COMPILER_WARNINGS=OFF \

--- a/build.cov.sh
+++ b/build.cov.sh
@@ -56,7 +56,7 @@ mkdir -p $BUILD_DIR
 rm -Rf $BUILD_DIR/*
 (cd $BUILD_DIR && cmake -DCMAKE_BUILD_TYPE=Debug \
                         -DENVIRONMENT_TYPE=default \
-                        -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0/ \
+                        -DINSTALL_PREFIX=$HOME/opt/dash-0.4.0/ \
                         -DDART_IMPLEMENTATIONS=mpi \
                         -DENABLE_THREADSUPPORT=OFF \
                         -DENABLE_DEV_COMPILER_WARNINGS=OFF \

--- a/build.debug.sh
+++ b/build.debug.sh
@@ -58,7 +58,7 @@ mkdir -p $BUILD_DIR
 rm -Rf $BUILD_DIR/*
 (cd $BUILD_DIR && cmake -DCMAKE_BUILD_TYPE=Debug \
                         -DENVIRONMENT_TYPE=default \
-                        -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0-dev/ \
+                        -DINSTALL_PREFIX=$HOME/opt/dash-0.4.0-dev/ \
                         -DDART_IMPLEMENTATIONS=mpi \
                         -DENABLE_THREADSUPPORT=ON \
                         -DENABLE_DEV_COMPILER_WARNINGS=ON \

--- a/build.dev.sh
+++ b/build.dev.sh
@@ -58,7 +58,7 @@ mkdir -p $BUILD_DIR
 rm -Rf $BUILD_DIR/*
 (cd $BUILD_DIR && cmake -DCMAKE_BUILD_TYPE=Debug \
                         -DENVIRONMENT_TYPE=default \
-                        -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0-dev/ \
+                        -DINSTALL_PREFIX=$HOME/opt/dash-0.4.0-dev/ \
                         -DDART_IMPLEMENTATIONS=mpi \
                         -DENABLE_THREADSUPPORT=ON \
                         -DENABLE_DEV_COMPILER_WARNINGS=ON \

--- a/build.mic.sh
+++ b/build.mic.sh
@@ -48,7 +48,7 @@ rm -Rf $BUILD_DIR/*
                         -DENVIRONMENT_TYPE=supermic \
                         -DCMAKE_C_COMPILER=mpiicc \
                         -DCMAKE_CXX_COMPILER=mpiicc \
-                        -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0-mic/ \
+                        -DINSTALL_PREFIX=$HOME/opt/dash-0.4.0-mic/ \
                         -DDART_IMPLEMENTATIONS=mpi \
                         -DENABLE_THREADSUPPORT=OFF \
                         -DENABLE_DEV_COMPILER_WARNINGS=OFF \

--- a/build.minimal.sh
+++ b/build.minimal.sh
@@ -50,7 +50,7 @@ mkdir -p $BUILD_DIR
 rm -Rf $BUILD_DIR/*
 (cd $BUILD_DIR && cmake -DCMAKE_BUILD_TYPE=Release \
                         -DENVIRONMENT_TYPE=default \
-                        -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0/ \
+                        -DINSTALL_PREFIX=$HOME/opt/dash-0.4.0/ \
                         -DDART_IMPLEMENTATIONS=mpi \
                         -DENABLE_THREADSUPPORT=OFF \
                         -DENABLE_DEV_COMPILER_WARNINGS=OFF \

--- a/build.nasty.sh
+++ b/build.nasty.sh
@@ -63,7 +63,7 @@ mkdir -p $BUILD_DIR
 rm -Rf $BUILD_DIR/*
 (cd $BUILD_DIR && cmake -DCMAKE_BUILD_TYPE=Release \
                         -DENVIRONMENT_TYPE=default \
-                        -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0-nasty \
+                        -DINSTALL_PREFIX=$HOME/opt/dash-0.4.0-nasty \
                         -DDART_IMPLEMENTATIONS=mpi \
                         -DENABLE_THREADSUPPORT=ON \
                         -DENABLE_DEV_COMPILER_WARNINGS=OFF \

--- a/build.sh
+++ b/build.sh
@@ -58,7 +58,7 @@ rm -Rf $BUILD_DIR/*
                         -DBUILD_SHARED_LIBS=OFF \
                         -DBUILD_GENERIC=OFF \
                         -DENVIRONMENT_TYPE=default \
-                        -DINSTALL_PREFIX=$HOME/opt/dash-0.3.0/ \
+                        -DINSTALL_PREFIX=$HOME/opt/dash-0.4.0/ \
                         -DDART_IMPLEMENTATIONS=mpi \
                         -DENABLE_THREADSUPPORT=ON \
                         -DENABLE_DEV_COMPILER_WARNINGS=OFF \

--- a/release.pl
+++ b/release.pl
@@ -4,7 +4,7 @@ use strict;
 use File::Basename;
 
 my $rdir    = "RELEASE";
-my $version = "0.3.0";
+my $version = "0.4.0";
 my $base    = "$rdir/dash-$version";
 
 if( -e "$base" ) {


### PR DESCRIPTION
Bumping internal version number to 0.4.0 after the 0.3.0 went through.