### PR TITLE
constexpr compile errors with ICC 2019

### DIFF
--- a/dash/include/dash/halo/Halo.h
+++ b/dash/include/dash/halo/Halo.h
@@ -555,7 +555,7 @@ public:
     init_level();
   }
 
-  constexpr RegionSpec() = default;
+  RegionSpec() = default;
 
   /**
    * Returns the region index for a given \ref StencilPoint

--- a/dash/test/memory/GlobStaticMemTest.cc
+++ b/dash/test/memory/GlobStaticMemTest.cc
@@ -178,7 +178,7 @@ TEST_F(GlobStaticMemTest, MakeUniqueMoveSemantics)
   constexpr size_t lcapA = 20;
   constexpr size_t lcapB = lcapA / 2;
 
-  constexpr auto cap_in_bytes = [](size_t lcap) {
+  auto cap_in_bytes = [](size_t lcap) {
     return lcap * sizeof(value_t);
   };
 

--- a/dash/test/memory/GlobStaticMemTest.cc
+++ b/dash/test/memory/GlobStaticMemTest.cc
@@ -178,7 +178,7 @@ TEST_F(GlobStaticMemTest, MakeUniqueMoveSemantics)
   constexpr size_t lcapA = 20;
   constexpr size_t lcapB = lcapA / 2;
 
-  auto cap_in_bytes = [](size_t lcap) {
+  auto const cap_in_bytes = [](size_t lcap) {
     return lcap * sizeof(value_t);
   };
 


### PR DESCRIPTION
- `constexpr` lambdas are not allowed before C++17, see this [proposal](http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4487.pdf)
- `constexpr` of `RegionSpec` makes no sense since not all members can be constructed by a `constexpr`