### PR TITLE
Fix iteration over deallocators in dash::Team

### DIFF
--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -314,11 +314,12 @@ public:
   void free()
   {
     DASH_LOG_DEBUG("Team.free()");
-    for (auto dealloc = _deallocs.rbegin();
-         dealloc != _deallocs.rend();
-         ++dealloc) {
+    std::list<Deallocator>::iterator next = _deallocs.begin();
+    std::list<Deallocator>::iterator dealloc;
+    while ((dealloc = next) != _deallocs.end()) {
       barrier();
       // List changes in iterations
+      ++next;
       DASH_LOG_DEBUG_VAR("Team.free", dealloc->object);
       (dealloc->deallocator)();
     }


### PR DESCRIPTION
List iterators are invalidated if the element they are pointing at is removed, leading to deallocators being dropped and containers trying to deallocate memory upon destruction, potentially after `dash::finalize`.