### PR TITLE
FIX: Remove team dealloc functions in move assignment and construction

### DIFF
--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -912,6 +912,8 @@ public:
     other.m_lsize  = 0;
     other.m_size   = 0;
 
+    other.m_team->unregister_deallocator(&other, std::bind(&Array::deallocate, &other));
+
     // Register deallocator of this array instance at the team
     // instance that has been used to initialized it:
     m_team->register_deallocator(this, std::bind(&Array::deallocate, this));
@@ -986,6 +988,8 @@ public:
     other.m_lend    = nullptr;
     other.m_lsize   = 0;
     other.m_size    = 0;
+
+    other.m_team->unregister_deallocator(&other, std::bind(&Array::deallocate, &other));
 
     m_team->register_deallocator(this, std::bind(&Array::deallocate, this));
 

--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -1047,7 +1047,8 @@ public:
    */
   constexpr const_iterator begin() const noexcept
   {
-    return (const_cast<iterator &>(m_begin));
+    return const_iterator(
+        const_cast<memory_type *>(&m_globmem), m_pattern, m_begin.pos());
   }
 
   /**
@@ -1060,8 +1061,10 @@ public:
   /**
    * Global pointer to the end of the array.
    */
-  constexpr const_iterator end() const noexcept {
-    return (const_cast<iterator &>(m_end));
+  constexpr const_iterator end() const noexcept
+  {
+    return const_iterator(
+        const_cast<memory_type *>(&m_globmem), m_pattern, m_end.pos());
   }
 
   /**

--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -972,7 +972,7 @@ public:
     m_data = std::move(__tmp);
 
 
-    //TODO rko: we have to provide a propery dash::swap for iterators;
+    //TODO rko: we have to provide a proper dash::swap for iterators;
     this->m_begin = iterator{&m_globmem, m_pattern, other.m_begin.pos()};
     this->m_end = iterator{&m_globmem, m_pattern, other.m_end.pos()};
 

--- a/dash/include/dash/Array.h
+++ b/dash/include/dash/Array.h
@@ -971,8 +971,11 @@ public:
                             m_allocator, m_pattern.local_size()}};
     m_data = std::move(__tmp);
 
-    this->m_begin     = other.m_begin;
-    this->m_end       = other.m_end;
+
+    //TODO rko: we have to provide a propery dash::swap for iterators;
+    this->m_begin = iterator{&m_globmem, m_pattern, other.m_begin.pos()};
+    this->m_end = iterator{&m_globmem, m_pattern, other.m_end.pos()};
+
     this->m_lbegin    = other.m_lbegin;
     this->m_lcapacity = other.m_lcapacity;
     this->m_lend      = other.m_lend;

--- a/dash/include/dash/Coevent.h
+++ b/dash/include/dash/Coevent.h
@@ -76,7 +76,7 @@ public:
 
   const_iterator begin() const noexcept {
     // TODO FIXME
-    //CoevenIter is not const correct, so we need a hack and unpack a nonconst
+    //CoeventIter is not const correct, so we need a hack and unpack a nonconst
     //pointer from a const iterator to make the comiler happy.
     //return const_iterator(static_cast<const_pointer>(_event_counts.begin()));
     auto dart_ptr = _event_counts.begin().dart_gptr();

--- a/dash/include/dash/Coevent.h
+++ b/dash/include/dash/Coevent.h
@@ -70,11 +70,11 @@ public:
       }
     }
 
-  iterator begin() noexcept {
+  iterator begin() DASH_NOEXCEPT {
     return iterator(static_cast<pointer>(_event_counts.begin()));
   }
 
-  const_iterator begin() const noexcept {
+  const_iterator begin() const DASH_NOEXCEPT {
     // TODO FIXME
     //CoeventIter is not const correct, so we need a hack and unpack a nonconst
     //pointer from a const iterator to make the comiler happy.

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -426,7 +426,7 @@ public:
   }
 
   constexpr auto get_unit() const noexcept {
-    return m_dart_pointer.unitid;
+    return team_unit_t{m_dart_pointer.unitid};
   }
 
   /**

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -425,6 +425,10 @@ public:
     m_dart_pointer.unitid = unit_id.id;
   }
 
+  constexpr auto get_unit() const noexcept {
+    return m_dart_pointer.unitid;
+  }
+
   /**
    * Check whether the global pointer is in the local
    * address space the pointer's associated unit.

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -98,7 +98,7 @@ public:
   /**
    * Constructor, specifies underlying global address.
    */
-  explicit constexpr GlobPtr(dart_gptr_t gptr)
+  explicit constexpr GlobPtr(dart_gptr_t gptr) DASH_NOEXCEPT
     : m_dart_pointer(gptr)
   {
   }
@@ -106,7 +106,7 @@ public:
   /**
    * Constructor for conversion of std::nullptr_t.
    */
-  explicit constexpr GlobPtr(std::nullptr_t)
+  explicit constexpr GlobPtr(std::nullptr_t) DASH_NOEXCEPT
     : m_dart_pointer(DART_GPTR_NULL)
   {
   }
@@ -143,7 +143,7 @@ public:
               typename dash::remove_atomic<value_type>::type>::value>
 
       ::type>
-  constexpr GlobPtr(const GlobPtr<From, GlobMemT> &other)
+  constexpr GlobPtr(const GlobPtr<From, GlobMemT> &other) DASH_NOEXCEPT
     : m_dart_pointer(other.m_dart_pointer)
   {
   }
@@ -151,19 +151,19 @@ public:
   /**
    * Move constructor.
    */
-  constexpr GlobPtr(self_t &&other) = default;
+  constexpr GlobPtr(self_t &&other) DASH_NOEXCEPT = default;
 
   /**
    * Move-assignment operator.
    */
-  self_t &operator=(self_t &&rhs) = default;
+  self_t &operator=(self_t &&rhs) DASH_NOEXCEPT = default;
 
   /**
    * Converts pointer to its referenced native pointer or
    * \c nullptr if the \c GlobPtr does not point to a local
    * address.
    */
-  explicit operator value_type *() const noexcept
+  explicit operator value_type *() const DASH_NOEXCEPT
   {
     return local();
   }
@@ -175,7 +175,7 @@ public:
    *           GlobPtr instance, or \c nullptr if the referenced element
    *           is not local to the calling unit.
    */
-  explicit operator value_type *() noexcept
+  explicit operator value_type *()
   {
     return local();
   }
@@ -183,7 +183,7 @@ public:
   /**
    * Converts pointer to its underlying global address.
    */
-  explicit constexpr operator dart_gptr_t() const noexcept
+  explicit constexpr operator dart_gptr_t() const DASH_NOEXCEPT
   {
     return m_dart_pointer;
   }
@@ -191,7 +191,7 @@ public:
   /**
    * The pointer's underlying global address.
    */
-  constexpr dart_gptr_t dart_gptr() const noexcept
+  constexpr dart_gptr_t dart_gptr() const DASH_NOEXCEPT
   {
     return m_dart_pointer;
   }
@@ -199,7 +199,7 @@ public:
   /**
    * Pointer offset difference operator.
    */
-  constexpr index_type operator-(const self_t &rhs) const noexcept
+  constexpr index_type operator-(const self_t &rhs) const DASH_NOEXCEPT
   {
     return dash::distance(rhs, *this);
   }
@@ -207,7 +207,7 @@ public:
   /**
    * Prefix increment operator.
    */
-  self_t &operator++()
+  self_t &operator++() DASH_NOEXCEPT
   {
     increment(1);
     return *this;
@@ -216,7 +216,7 @@ public:
   /**
    * Postfix increment operator.
    */
-  self_t operator++(int)
+  self_t operator++(int) DASH_NOEXCEPT
   {
     self_t res(*this);
     increment(1);
@@ -226,7 +226,7 @@ public:
   /**
    * Pointer increment operator.
    */
-  self_t operator+(index_type n) const
+  self_t operator+(index_type n) const DASH_NOEXCEPT
   {
     self_t res(*this);
     res += n;
@@ -236,7 +236,7 @@ public:
   /**
    * Pointer increment operator.
    */
-  self_t &operator+=(index_type n)
+  self_t &operator+=(index_type n) DASH_NOEXCEPT
   {
     if (n >= 0) {
       increment(n);
@@ -250,7 +250,7 @@ public:
   /**
    * Prefix decrement operator.
    */
-  self_t &operator--()
+  self_t &operator--() DASH_NOEXCEPT
   {
     decrement(1);
     return *this;
@@ -259,7 +259,7 @@ public:
   /**
    * Postfix decrement operator.
    */
-  self_t operator--(int)
+  self_t operator--(int) DASH_NOEXCEPT
   {
     self_t res(*this);
     decrement(1);
@@ -269,7 +269,7 @@ public:
   /**
    * Pointer decrement operator.
    */
-  self_t operator-(index_type n) const
+  self_t operator-(index_type n) const DASH_NOEXCEPT
   {
     self_t res(*this);
     res -= n;
@@ -279,7 +279,7 @@ public:
   /**
    * Pointer decrement operator.
    */
-  self_t &operator-=(index_type n)
+  self_t &operator-=(index_type n) DASH_NOEXCEPT
   {
     if (n >= 0) {
       decrement(n);
@@ -294,7 +294,7 @@ public:
    * Equality comparison operator.
    */
   // template <class GlobPtrT>
-  constexpr bool operator==(const GlobPtr &other) const noexcept
+  constexpr bool operator==(const GlobPtr &other) const DASH_NOEXCEPT
   {
     return DART_GPTR_EQUAL(
         static_cast<dart_gptr_t>(m_dart_pointer),
@@ -304,7 +304,7 @@ public:
   /**
    * Equality comparison operator.
    */
-  constexpr bool operator==(std::nullptr_t) const noexcept
+  constexpr bool operator==(std::nullptr_t) const DASH_NOEXCEPT
   {
     return DART_GPTR_ISNULL(static_cast<dart_gptr_t>(m_dart_pointer));
   }
@@ -313,7 +313,7 @@ public:
    * Inequality comparison operator.
    */
   template <class GlobPtrT>
-  constexpr bool operator!=(const GlobPtrT &other) const noexcept
+  constexpr bool operator!=(const GlobPtrT &other) const DASH_NOEXCEPT
   {
     return !(*this == other);
   }
@@ -322,7 +322,7 @@ public:
    * Less comparison operator.
    */
   template <class GlobPtrT>
-  constexpr bool operator<(const GlobPtrT &other) const noexcept
+  constexpr bool operator<(const GlobPtrT &other) const DASH_NOEXCEPT
   {
     return (other - *this) > 0;
   }
@@ -331,7 +331,7 @@ public:
    * Less-equal comparison operator.
    */
   template <class GlobPtrT>
-  constexpr bool operator<=(const GlobPtrT &other) const noexcept
+  constexpr bool operator<=(const GlobPtrT &other) const DASH_NOEXCEPT
   {
     return !(*this > other);
   }
@@ -340,7 +340,7 @@ public:
    * Greater comparison operator.
    */
   template <class GlobPtrT>
-  constexpr bool operator>(const GlobPtrT &other) const noexcept
+  constexpr bool operator>(const GlobPtrT &other) const DASH_NOEXCEPT
   {
     return (*this - other) > 0;
   }
@@ -349,7 +349,7 @@ public:
    * Greater-equal comparison operator.
    */
   template <class GlobPtrT>
-  constexpr bool operator>=(const GlobPtrT &other) const noexcept
+  constexpr bool operator>=(const GlobPtrT &other) const DASH_NOEXCEPT
   {
     return (*this - other) >= 0;
   }
@@ -357,7 +357,7 @@ public:
   /**
    * Subscript operator.
    */
-  constexpr GlobRef<const value_type> operator[](gptrdiff_t n) const
+  constexpr GlobRef<const value_type> operator[](gptrdiff_t n) const DASH_NOEXCEPT
   {
     return GlobRef<const value_type>(self_t((*this) + n));
   }
@@ -365,7 +365,7 @@ public:
   /**
    * Subscript assignment operator.
    */
-  GlobRef<value_type> operator[](gptrdiff_t n)
+  GlobRef<value_type> operator[](gptrdiff_t n) DASH_NOEXCEPT
   {
     return GlobRef<value_type>(self_t((*this) + n));
   }
@@ -373,7 +373,7 @@ public:
   /**
    * Dereference operator.
    */
-  GlobRef<value_type> operator*()
+  GlobRef<value_type> operator*() DASH_NOEXCEPT
   {
     return GlobRef<value_type>(*this);
   }
@@ -381,7 +381,7 @@ public:
   /**
    * Dereference operator.
    */
-  constexpr GlobRef<const value_type> operator*() const
+  constexpr GlobRef<const value_type> operator*() const DASH_NOEXCEPT
   {
     return GlobRef<const value_type>(*this);
   }
@@ -420,12 +420,12 @@ public:
   /**
    * Set the global pointer's associated unit.
    */
-  void set_unit(team_unit_t unit_id)
+  void set_unit(team_unit_t unit_id) DASH_NOEXCEPT
   {
     m_dart_pointer.unitid = unit_id.id;
   }
 
-  constexpr auto get_unit() const noexcept {
+  constexpr auto get_unit() const DASH_NOEXCEPT {
     return team_unit_t{m_dart_pointer.unitid};
   }
 
@@ -438,13 +438,13 @@ public:
     return dash::internal::is_local(m_dart_pointer);
   }
 
-  constexpr explicit operator bool() const noexcept
+  constexpr explicit operator bool() const DASH_NOEXCEPT
   {
     return !DART_GPTR_ISNULL(m_dart_pointer);
   }
 
 private:
-  void increment(size_type offs)
+  void increment(size_type offs) DASH_NOEXCEPT
   {
     if (offs == 0) {
       return;
@@ -471,7 +471,7 @@ private:
     m_dart_pointer = newPtr;
   }
 
-  void decrement(size_type offs)
+  void decrement(size_type offs) DASH_NOEXCEPT
   {
     if (offs == 0) {
       return;
@@ -582,7 +582,6 @@ DASH_CONSTEXPR inline typename std::enable_if<
         memory_space_contiguous>::value,
     T>::type *
 local_begin(GlobPtr<T, MemSpaceT> global_begin, dash::team_unit_t unit)
-    DASH_NOEXCEPT
 {
   // reset offset to 0
   auto dart_gptr                = static_cast<dart_gptr_t>(global_begin);

--- a/dash/include/dash/GlobRef.h
+++ b/dash/include/dash/GlobRef.h
@@ -66,7 +66,7 @@ public:
    * Constructor, creates an GlobRef object referencing an element in global
    * memory.
    */
-  explicit constexpr GlobRef(dart_gptr_t dart_gptr)
+  explicit constexpr GlobRef(dart_gptr_t dart_gptr) noexcept
   : _gptr(dart_gptr)
   {
   }
@@ -82,7 +82,7 @@ public:
   template <
       typename _T,
       long = internal::enable_implicit_copy_ctor<value_type, _T>::value>
-  constexpr GlobRef(const GlobRef<_T>& gref)
+  constexpr GlobRef(const GlobRef<_T>& gref) noexcept
     : GlobRef(gref.dart_gptr())
   {
   }
@@ -96,7 +96,7 @@ public:
   template <
       typename _T,
       int = internal::enable_explicit_copy_ctor<value_type, _T>::value>
-  explicit constexpr GlobRef(const GlobRef<_T>& gref)
+  explicit constexpr GlobRef(const GlobRef<_T>& gref) noexcept
     : GlobRef(gref.dart_gptr())
   {
   }
@@ -108,7 +108,7 @@ public:
   template <
       typename _T,
       long = internal::enable_implicit_copy_ctor<value_type, _T>::value>
-  constexpr GlobRef(const GlobAsyncRef<_T>& gref)
+  constexpr GlobRef(const GlobAsyncRef<_T>& gref) noexcept
     : _gptr(gref.dart_gptr())
   {
   }
@@ -116,7 +116,7 @@ public:
   template <
       typename _T,
       int = internal::enable_explicit_copy_ctor<value_type, _T>::value>
-  explicit constexpr GlobRef(const GlobAsyncRef<_T>& gref)
+  explicit constexpr GlobRef(const GlobAsyncRef<_T>& gref) noexcept
     : GlobRef(gref.dart_gptr())
   {
   }
@@ -124,7 +124,7 @@ public:
   /**
    * Move Constructor
    */
-  GlobRef(self_t&& other)
+  GlobRef(self_t&& other) noexcept
     :_gptr(std::move(other._gptr))
   {
     DASH_LOG_TRACE("GlobRef.GlobRef(GlobRef &&)", _gptr);
@@ -145,7 +145,7 @@ public:
   /**
    * Move Assignment: Redirects to Copy Assignment
    */
-  self_t& operator=(self_t&& other) {
+  self_t& operator=(self_t&& other) noexcept {
     DASH_LOG_TRACE("GlobRef.operator=(GlobRef &&)", _gptr);
     operator=(other);
     return *this;

--- a/dash/include/dash/Iterator.h
+++ b/dash/include/dash/Iterator.h
@@ -138,6 +138,23 @@ distance(
   return last - first;
 }
 
+template<
+  typename ElementType,
+  class    Pattern,
+  class    GlobMemType,
+  class    Pointer,
+  class    Reference >
+DASH_CONSTEXPR auto operator-(
+  /// Global pointer to the initial position in the global sequence
+  const GlobIter<ElementType, Pattern, GlobMemType, Pointer, Reference> &
+    lhs,
+  /// Global iterator to the final position in the global sequence
+  const GlobIter<ElementType, Pattern, GlobMemType, Pointer, Reference> &
+    rhs) DASH_NOEXCEPT
+{
+  return lhs.pos() - rhs.pos();
+}
+
 /**
  *
  * \ingroup     Algorithms

--- a/dash/include/dash/Shared.h
+++ b/dash/include/dash/Shared.h
@@ -8,6 +8,7 @@
 #include <dash/GlobRef.h>
 #include <dash/memory/MemorySpace.h>
 #include <dash/memory/UniquePtr.h>
+#include <dash/allocator/GlobalAllocator.h>
 
 #include <dash/iterator/GlobIter.h>
 

--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -321,6 +321,10 @@ public:
       DASH_LOG_TRACE_VAR("GlobIter.dart_gptr", idx);
       DASH_LOG_TRACE_VAR("GlobIter.dart_gptr", offset);
     }
+
+    if (offset == 1) {
+      return static_cast<dart_gptr_t>(_globmem->end());
+    }
     // Global index to local index and unit:
     local_pos_t local_pos = _pattern->local(idx);
     DASH_LOG_TRACE("GlobIter.dart_gptr",

--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -1,26 +1,14 @@
 #ifndef DASH__GLOB_ITER_H__INCLUDED
 #define DASH__GLOB_ITER_H__INCLUDED
 
-#include <dash/Pattern.h>
-#include <dash/GlobRef.h>
 #include <dash/GlobPtr.h>
+#include <dash/GlobRef.h>
+#include <dash/Pattern.h>
 
 #include <functional>
 #include <sstream>
 
 namespace dash {
-
-#ifndef DOXYGEN
-
-template<
-  typename ElementType,
-  class    PatternType,
-  class    GlobMemType,
-  class    PointerType,
-  class    ReferenceType >
-class GlobViewIter;
-
-#endif // DOXYGEN
 
 /**
  * \defgroup  DashGlobalIteratorConcept  Global Iterator Concept
@@ -31,13 +19,15 @@ class GlobViewIter;
  * \par Description
  *
  * \par Methods
- * Return Type             | Method                 | Parameters     | Description                                             |
- * ----------------------- | ---------------------- | -------------- | ------------------------------------------------------- |
- * <tt>dart_gptr_t</tt>    | <tt>dart_gptr</tt>     | &nbsp;         | DART global pointer on the iterator's current position. |
+ * Return Type             | Method                 | Parameters     |
+ * Description                                             |
+ * ----------------------- | ---------------------- | -------------- |
+ * ------------------------------------------------------- |
+ * <tt>dart_gptr_t</tt>    | <tt>dart_gptr</tt>     | &nbsp;         | DART
+ * global pointer on the iterator's current position. |
  *
  * \}
  */
-
 
 /**
  * Iterator on Partitioned Global Address Space.
@@ -58,144 +48,123 @@ class GlobIter : public std::iterator<
                      typename PatternType::index_type,
                      PointerType,
                      ReferenceType> {
-private:
+ private:
   typedef GlobIter<
-            ElementType,
-            PatternType,
-            GlobMemType,
-            PointerType,
-            ReferenceType>
-    self_t;
+      ElementType,
+      PatternType,
+      GlobMemType,
+      PointerType,
+      ReferenceType>
+      self_t;
 
-  typedef typename std::remove_const<ElementType>::type
-    nonconst_value_type;
+  typedef typename std::remove_const<ElementType>::type nonconst_value_type;
 
-public:
-  typedef          ElementType                         value_type;
+ public:
+  typedef ElementType value_type;
 
-  typedef          ReferenceType                        reference;
-  typedef typename ReferenceType::const_type      const_reference;
+  typedef ReferenceType                      reference;
+  typedef typename ReferenceType::const_type const_reference;
 
-  typedef          PointerType                            pointer;
-  typedef typename PointerType::const_type          const_pointer;
+  typedef PointerType                      pointer;
+  typedef typename PointerType::const_type const_pointer;
 
   typedef typename pointer::local_type local_type;
 
   typedef typename pointer::const_local_type const_local_type;
 
-  typedef          PatternType                       pattern_type;
-  typedef typename PatternType::index_type             index_type;
+  typedef PatternType                      pattern_type;
+  typedef typename PatternType::index_type index_type;
 
-private:
+ private:
   typedef GlobIter<
-            const ElementType,
-            PatternType,
-            GlobMemType,
-            const_pointer,
-            const_reference >
-    self_const_t;
+      const ElementType,
+      PatternType,
+      GlobMemType,
+      const_pointer,
+      const_reference>
+      self_const_t;
 
-public:
-  typedef std::integral_constant<bool, false>       has_view;
+ public:
+  typedef std::integral_constant<bool, false> has_view;
 
-public:
+ public:
   // For ostream output
-  template <
-    typename T_,
-    class    P_,
-    class    GM_,
-    class    Ptr_,
-    class    Ref_ >
-  friend std::ostream & operator<<(
-           std::ostream & os,
-           const GlobIter<T_, P_, GM_, Ptr_, Ref_> & it);
-
-  // For conversion to GlobViewIter
-  template<
-    typename T_,
-    class    P_,
-    class    GM_,
-    class    Ptr_,
-    class    Ref_ >
-  friend class GlobViewIter;
+  template <typename T_, class P_, class GM_, class Ptr_, class Ref_>
+  friend std::ostream& operator<<(
+      std::ostream& os, const GlobIter<T_, P_, GM_, Ptr_, Ref_>& it);
 
   // For comparison operators
-  template<
-    typename T_,
-    class    P_,
-    class    GM_,
-    class    Ptr_,
-    class    Ref_ >
+  template <typename T_, class P_, class GM_, class Ptr_, class Ref_>
   friend class GlobIter;
 
-private:
+ private:
   static const dim_t      NumDimensions = PatternType::ndim();
   static const MemArrange Arrangement   = PatternType::memory_order();
 
-protected:
+ protected:
   /// Global memory used to dereference iterated values.
-  GlobMemType          * _globmem         = nullptr;
+  GlobMemType* _globmem = nullptr;
   /// Pattern that specifies the iteration order (access pattern).
-  const PatternType    * _pattern         = nullptr;
+  const PatternType* _pattern = nullptr;
   /// Current position of the iterator in global canonical index space.
-  index_type             _idx             = 0;
+  index_type _idx = 0;
   /// Maximum position allowed for this iterator.
-  index_type             _max_idx         = 0;
-public:
+  index_type _max_idx = 0;
 
-  constexpr GlobIter() = default;
+ public:
+  DASH_CONSTEXPR GlobIter() = default;
 
   /**
    * Constructor, creates a global iterator on global memory following
    * the element order specified by the given pattern.
    */
-  constexpr GlobIter(
-    GlobMemType       * gmem,
-    const PatternType & pat,
-    index_type          position = 0)
-  : _globmem(gmem),
-    _pattern(&pat),
-    _idx(position),
-    _max_idx(std::max(index_type(pat.size()) - 1, index_type(0)))
-  { }
+  DASH_CONSTEXPR GlobIter(
+      GlobMemType*       gmem,
+      const PatternType& pat,
+      index_type         position = 0) DASH_NOEXCEPT
+    : _globmem(gmem),
+      _pattern(&pat),
+      _idx(position),
+      _max_idx(std::max(index_type(pat.size()) - 1, index_type(0)))
+  {
+  }
 
   /**
    * Copy constructor.
    */
-  template <
-    class    Ptr_,
-    class    Ref_ >
-  constexpr GlobIter(
-    const GlobIter<nonconst_value_type, PatternType, GlobMemType, Ptr_, Ref_> & other)
-  : _globmem(other._globmem)
-  , _pattern(other._pattern)
-  , _idx    (other._idx)
-  , _max_idx(other._max_idx)
-  { }
+  template <class Ptr_, class Ref_>
+  DASH_CONSTEXPR GlobIter(const GlobIter<
+                          nonconst_value_type,
+                          PatternType,
+                          GlobMemType,
+                          Ptr_,
+                          Ref_>& other) DASH_NOEXCEPT
+    : _globmem(other._globmem),
+      _pattern(other._pattern),
+      _idx(other._idx),
+      _max_idx(other._max_idx)
+  {
+  }
 
   /**
    * Move constructor.
    */
-  template <
-    class    Ptr_,
-    class    Ref_ >
-  constexpr GlobIter(
-    GlobIter<nonconst_value_type, PatternType, GlobMemType, Ptr_, Ref_> && other)
-  : _globmem(other._globmem)
-  , _pattern(other._pattern)
-  , _idx    (other._idx)
-  , _max_idx(other._max_idx)
-  { }
+  template <class Ptr_, class Ref_>
+  DASH_CONSTEXPR GlobIter(
+      GlobIter<nonconst_value_type, PatternType, GlobMemType, Ptr_, Ref_>&&
+          other) DASH_NOEXCEPT : _globmem(other._globmem),
+                                 _pattern(other._pattern),
+                                 _idx(other._idx),
+                                 _max_idx(other._max_idx)
+  {
+  }
 
   /**
    * Assignment operator.
    */
-  template <
-    typename T_,
-    class    Ptr_,
-    class    Ref_ >
-  self_t & operator=(
-    const GlobIter<T_, PatternType, GlobMemType, Ptr_, Ref_ > & other)
+  template <typename T_, class Ptr_, class Ref_>
+  self_t& operator=(const GlobIter<T_, PatternType, GlobMemType, Ptr_, Ref_>&
+                        other) DASH_NOEXCEPT
   {
     _globmem = other._globmem;
     _pattern = other._pattern;
@@ -207,12 +176,9 @@ public:
   /**
    * Move-assignment operator.
    */
-  template <
-    typename T_,
-    class    Ptr_,
-    class    Ref_ >
-  self_t & operator=(
-    GlobIter<T_, PatternType, GlobMemType, Ptr_, Ref_ > && other)
+  template <typename T_, class Ptr_, class Ref_>
+  self_t& operator=(GlobIter<T_, PatternType, GlobMemType, Ptr_, Ref_>&&
+                        other) DASH_NOEXCEPT
   {
     _globmem = other._globmem;
     _pattern = other._pattern;
@@ -237,7 +203,8 @@ public:
    *
    * \return  A global reference to the element at the iterator's position
    */
-  explicit operator const_pointer() const {
+  DASH_CONSTEXPR explicit operator const_pointer() const noexcept
+  {
     return const_pointer(this->dart_gptr());
   }
 
@@ -248,7 +215,8 @@ public:
    *
    * \return  A global reference to the element at the iterator's position
    */
-  explicit operator pointer() {
+  DASH_CONSTEXPR explicit operator pointer() DASH_NOEXCEPT
+  {
     return pointer(this->dart_gptr());
   }
 
@@ -258,7 +226,7 @@ public:
    * \return  A DART global pointer to the element at the iterator's
    *          position
    */
-  dart_gptr_t dart_gptr() const
+  DASH_CONSTEXPR dart_gptr_t dart_gptr() const DASH_NOEXCEPT
   {
     if (_globmem == nullptr) {
       return DART_GPTR_NULL;
@@ -270,16 +238,19 @@ public:
     }
 
     DASH_LOG_TRACE_VAR("GlobIter.dart_gptr()", _idx);
-    typedef typename pattern_type::local_index_t
-      local_pos_t;
+    typedef typename pattern_type::local_index_t local_pos_t;
 
     // Global index to local index and unit:
     local_pos_t local_pos = _pattern->local(_idx);
-    DASH_LOG_TRACE("GlobIter.dart_gptr",
-                   "unit:",        local_pos.unit,
-                   "local index:", local_pos.index);
+    DASH_LOG_TRACE(
+        "GlobIter.dart_gptr",
+        "unit:",
+        local_pos.unit,
+        "local index:",
+        local_pos.index);
     auto const dart_pointer = _get_pointer_at(local_pos);
-    DASH_ASSERT_MSG(!DART_GPTR_ISNULL(dart_pointer), "dart pointer must not be null");
+    DASH_ASSERT_MSG(
+        !DART_GPTR_ISNULL(dart_pointer), "dart pointer must not be null");
     return dart_pointer;
   }
 
@@ -288,7 +259,7 @@ public:
    *
    * \return  A global reference to the element at the iterator's position.
    */
-  inline reference operator*()
+  DASH_CONSTEXPR reference operator*() noexcept
   {
     return reference{this->dart_gptr()};
   }
@@ -298,7 +269,7 @@ public:
    *
    * \return  A global reference to the element at the iterator's position.
    */
-  inline const_reference operator*() const
+  DASH_CONSTEXPR const_reference operator*() const noexcept
   {
     return const_reference{this->dart_gptr()};
   }
@@ -307,9 +278,9 @@ public:
    * Subscript operator, returns global reference to element at given
    * global index.
    */
-  reference operator[](
-    /// The global position of the element
-    index_type g_index)
+  DASH_CONSTEXPR reference operator[](
+      /// The global position of the element
+      index_type g_index) noexcept
   {
     auto p = *this;
     p += g_index;
@@ -320,9 +291,9 @@ public:
    * Subscript operator, returns global reference to element at given
    * global index.
    */
-  const_reference operator[](
-    /// The global position of the element
-    index_type g_index) const
+  DASH_CONSTEXPR const_reference operator[](
+      /// The global position of the element
+      index_type g_index) const noexcept
   {
     auto p = *this;
     p += g_index;
@@ -333,7 +304,7 @@ public:
    * Checks whether the element referenced by this global iterator is in
    * the calling unit's local memory.
    */
-  constexpr bool is_local() const
+  DASH_CONSTEXPR bool is_local() const noexcept
   {
     return (_globmem->team().myid() == lpos().unit);
   }
@@ -341,9 +312,8 @@ public:
   /**
    * Convert global iterator to native pointer.
    */
-  local_type local() const
+  DASH_CONSTEXPR local_type local() const
   {
-
     auto local_pos = lpos();
 
     if (local_pos.unit != _pattern->team().myid()) {
@@ -361,11 +331,11 @@ public:
   /**
    * Unit and local offset at the iterator's position.
    */
-  auto lpos() const
+  DASH_CONSTEXPR auto lpos() const
   {
     DASH_LOG_TRACE_VAR("GlobIter.lpos()", _idx);
 
-    index_type idx = _idx;
+    index_type idx    = _idx;
     index_type offset = 0;
 
     // Convert iterator position (_idx) to local index and unit.
@@ -392,21 +362,15 @@ public:
   /**
    * Map iterator to global index domain.
    */
-  constexpr const self_t & global() const noexcept {
-    return *this;
-  }
-
-  /**
-   * Map iterator to global index domain.
-   */
-  self_t & global() {
+  DASH_CONSTEXPR const self_t& global() const DASH_NOEXCEPT
+  {
     return *this;
   }
 
   /**
    * Position of the iterator in global index space.
    */
-  constexpr index_type pos() const noexcept
+  DASH_CONSTEXPR index_type pos() const DASH_NOEXCEPT
   {
     return _idx;
   }
@@ -414,38 +378,25 @@ public:
   /**
    * Position of the iterator in global index range.
    */
-  constexpr index_type gpos() const noexcept
+  DASH_CONSTEXPR index_type gpos() const DASH_NOEXCEPT
   {
     return _idx;
   }
 
   /**
-   * Whether the iterator's position is relative to a view.
-   *
-   * TODO:
-   * should be iterator trait:
-   *   dash::iterator_traits<GlobIter<..>>::is_relative()::value
+   * The instance of \c GlobStaticMem used by this iterator to resolve
+   * addresses in global memory.
    */
-  constexpr bool is_relative() const noexcept
-  {
-    return false;
-  }
-
-
-  /**
-   * The instance of \c GlobStaticMem used by this iterator to resolve addresses
-   * in global memory.
-   */
-  constexpr const GlobMemType & globmem() const noexcept
+  DASH_CONSTEXPR const GlobMemType& globmem() const DASH_NOEXCEPT
   {
     return *_globmem;
   }
 
   /**
-   * The instance of \c GlobStaticMem used by this iterator to resolve addresses
-   * in global memory.
+   * The instance of \c GlobStaticMem used by this iterator to resolve
+   * addresses in global memory.
    */
-  inline GlobMemType & globmem()
+  inline GlobMemType& globmem()
   {
     return *_globmem;
   }
@@ -453,7 +404,7 @@ public:
   /**
    * Prefix increment operator.
    */
-  inline self_t & operator++()
+  DASH_CONSTEXPR self_t& operator++() DASH_NOEXCEPT
   {
     ++_idx;
     return *this;
@@ -462,7 +413,7 @@ public:
   /**
    * Postfix increment operator.
    */
-  inline self_t operator++(int)
+  DASH_CONSTEXPR self_t operator++(int) DASH_NOEXCEPT
   {
     self_t result = *this;
     ++_idx;
@@ -472,7 +423,7 @@ public:
   /**
    * Prefix decrement operator.
    */
-  inline self_t & operator--()
+  DASH_CONSTEXPR self_t& operator--() DASH_NOEXCEPT
   {
     --_idx;
     return *this;
@@ -481,113 +432,85 @@ public:
   /**
    * Postfix decrement operator.
    */
-  inline self_t operator--(int)
+  DASH_CONSTEXPR self_t operator--(int) DASH_NOEXCEPT
   {
     self_t result = *this;
     --_idx;
     return result;
   }
 
-  inline self_t & operator+=(index_type n)
+  DASH_CONSTEXPR self_t& operator+=(index_type n) DASH_NOEXCEPT
   {
     _idx += n;
     return *this;
   }
 
-  inline self_t & operator-=(index_type n)
+  DASH_CONSTEXPR self_t& operator-=(index_type n) DASH_NOEXCEPT
   {
     _idx -= n;
     return *this;
   }
 
-  constexpr self_t operator+(index_type n) const noexcept
+  DASH_CONSTEXPR self_t operator+(index_type n) const DASH_NOEXCEPT
   {
-    return self_t(
-      _globmem,
-      *_pattern,
-      _idx + static_cast<index_type>(n));
+    return self_t(_globmem, *_pattern, _idx + static_cast<index_type>(n));
   }
 
-  constexpr self_t operator-(index_type n) const noexcept
+  DASH_CONSTEXPR self_t operator-(index_type n) const DASH_NOEXCEPT
   {
-    return self_t(
-      _globmem,
-      *_pattern,
-      _idx - static_cast<index_type>(n));
+    return self_t(_globmem, *_pattern, _idx - static_cast<index_type>(n));
   }
 
   template <class GlobIterT>
-  constexpr auto operator+(
-    const GlobIterT & other) const noexcept
-    -> typename std::enable_if<
-         !std::is_integral<GlobIterT>::value,
-         index_type
-       >::type
-  {
-    return _idx + other._idx;
-  }
-
-  template <class GlobIterT>
-  constexpr auto operator-(
-    const GlobIterT & other) const noexcept
-    -> typename std::enable_if<
-         !std::is_integral<GlobIterT>::value,
-         index_type
-       >::type
-  {
-    return _idx - other._idx;
-  }
-
-  template <class GlobIterT>
-  constexpr bool operator<(const GlobIterT & other) const noexcept
+  DASH_CONSTEXPR bool operator<(const GlobIterT& other) const DASH_NOEXCEPT
   {
     return (_idx < other._idx);
   }
 
   template <class GlobIterT>
-  constexpr bool operator<=(const GlobIterT & other) const noexcept
+  DASH_CONSTEXPR bool operator<=(const GlobIterT& other) const DASH_NOEXCEPT
   {
     return (_idx <= other._idx);
   }
 
   template <class GlobIterT>
-  constexpr bool operator>(const GlobIterT & other) const noexcept
+  DASH_CONSTEXPR bool operator>(const GlobIterT& other) const DASH_NOEXCEPT
   {
     return (_idx > other._idx);
   }
 
   template <class GlobIterT>
-  constexpr bool operator>=(const GlobIterT & other) const noexcept
+  DASH_CONSTEXPR bool operator>=(const GlobIterT& other) const DASH_NOEXCEPT
   {
     return (_idx >= other._idx);
   }
 
   template <class GlobIterT>
-  constexpr bool operator==(const GlobIterT & other) const noexcept
+  DASH_CONSTEXPR bool operator==(const GlobIterT& other) const DASH_NOEXCEPT
   {
     return _idx == other._idx;
   }
 
   template <class GlobIterT>
-  constexpr bool operator!=(const GlobIterT & other) const noexcept
+  DASH_CONSTEXPR bool operator!=(const GlobIterT& other) const DASH_NOEXCEPT
   {
     return _idx != other._idx;
   }
 
-  constexpr const PatternType & pattern() const noexcept
+  DASH_CONSTEXPR const PatternType& pattern() const DASH_NOEXCEPT
   {
     return *_pattern;
   }
 
-  constexpr dash::Team & team() const noexcept
+  DASH_CONSTEXPR dash::Team& team() const DASH_NOEXCEPT
   {
     return _pattern->team();
   }
 
-private:
-
-  dart_gptr_t _get_pointer_at(typename pattern_type::local_index_t pos) const {
-
+ private:
+  DASH_CONSTEXPR dart_gptr_t
+                 _get_pointer_at(typename pattern_type::local_index_t pos) const
+  {
     auto dart_pointer = static_cast<dart_gptr_t>(_globmem->begin());
 
     DASH_ASSERT(pos.index >= 0);
@@ -599,28 +522,26 @@ private:
     return dart_pointer;
   }
 
-}; // class GlobIter
-
+};  // class GlobIter
 
 template <
-  typename ElementType,
-  class    Pattern,
-  class    GlobStaticMem,
-  class    Pointer,
-  class    Reference >
-std::ostream & operator<<(
-  std::ostream & os,
-  const dash::GlobIter<
-          ElementType, Pattern, GlobStaticMem, Pointer, Reference> & it)
+    typename ElementType,
+    class Pattern,
+    class GlobStaticMem,
+    class Pointer,
+    class Reference>
+std::ostream& operator<<(
+    std::ostream& os,
+    const dash::
+        GlobIter<ElementType, Pattern, GlobStaticMem, Pointer, Reference>& it)
 {
-  std::ostringstream ss;
+  std::ostringstream                              ss;
   dash::GlobPtr<const ElementType, GlobStaticMem> ptr(it.dart_gptr());
   ss << "dash::GlobIter<" << typeid(ElementType).name() << ">("
-     << "idx:"  << it._idx << ", "
+     << "idx:" << it._idx << ", "
      << "gptr:" << ptr << ")";
   return operator<<(os, ss.str());
 }
+}  // namespace dash
 
-} // namespace dash
-
-#endif // DASH__GLOB_ITER_H__INCLUDED
+#endif  // DASH__GLOB_ITER_H__INCLUDED

--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -100,9 +100,9 @@ class GlobIter {
 
  protected:
   /// Global memory used to dereference iterated values.
-  GlobMemType * _globmem = nullptr;
+  GlobMemType* _globmem = nullptr;
   /// Pattern that specifies the iteration order (access pattern).
-  PatternType const * _pattern = nullptr;
+  PatternType const* _pattern = nullptr;
   /// Current position of the iterator in global canonical index space.
   index_type _idx = 0;
   /// Maximum position allowed for this iterator.
@@ -116,8 +116,8 @@ class GlobIter {
    * the element order specified by the given pattern.
    */
   DASH_CONSTEXPR GlobIter(
-      GlobMemType *       gmem,
-      PatternType const & pat,
+      GlobMemType*       gmem,
+      PatternType const& pat,
       index_type         position = 0) DASH_NOEXCEPT
     : _globmem(gmem),
       _pattern(&pat),
@@ -131,19 +131,19 @@ class GlobIter {
       class PointerType_,
       class ReferenceType_,
       typename = typename std::enable_if<
-          // We always allow GlobPtr<T> -> GlobPtr<void> or the other way)
-          // or if From is assignable to To (value_type)
+          // Converstion works only if ElementType_ & is assignable to
+          // value_type &
           std::is_assignable<
               typename dash::remove_atomic<ElementType_>::type,
               typename dash::remove_atomic<value_type>::type>::value>
 
       ::type>
   DASH_CONSTEXPR GlobIter(const GlobIter<
-                     ElementType_,
-                     PatternType,
-                     GlobMemType,
-                     PointerType_,
-                     ReferenceType_>& other) DASH_NOEXCEPT
+                          ElementType_,
+                          PatternType,
+                          GlobMemType,
+                          PointerType_,
+                          ReferenceType_>& other) DASH_NOEXCEPT
     : _globmem(other._globmem),
       _pattern(other._pattern),
       _idx(other._idx),

--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -290,7 +290,7 @@ public:
    */
   inline reference operator*()
   {
-    return this->operator[](_idx);
+    return reference{this->dart_gptr()};
   }
 
   /**
@@ -300,7 +300,7 @@ public:
    */
   inline const_reference operator*() const
   {
-    return this->operator[](_idx);
+    return const_reference{this->dart_gptr()};
   }
 
   /**
@@ -311,16 +311,9 @@ public:
     /// The global position of the element
     index_type g_index)
   {
-    typedef typename pattern_type::local_index_t
-      local_pos_t;
-    // Global index to local index and unit:
-    local_pos_t local_pos = _pattern->local(g_index);
-    // Global reference to element at given position:
-    DASH_LOG_TRACE("GlobIter.[]",
-                   "(index:", g_index, ") ->",
-                   "(unit:", local_pos.unit, " index:", local_pos.index, " _idx: ", _idx, ")");
-    auto const dart_ptr = _get_pointer_at(local_pos);
-    return reference(dart_ptr);
+    auto p = *this;
+    p += g_index;
+    return reference(p.dart_gptr());
   }
 
   /**
@@ -331,16 +324,9 @@ public:
     /// The global position of the element
     index_type g_index) const
   {
-    typedef typename pattern_type::local_index_t
-      local_pos_t;
-    // Global index to local index and unit:
-    local_pos_t local_pos = _pattern->local(g_index);
-    // Global reference to element at given position:
-    DASH_LOG_TRACE("GlobIter.[]",
-                   "(index:", g_index, ") ->",
-                   "(unit:", local_pos.unit, " index:", local_pos.index, ")");
-    auto const dart_ptr = _get_pointer_at(local_pos);
-    return const_reference(dart_ptr);
+    auto p = *this;
+    p += g_index;
+    return const_reference(p.dart_gptr());
   }
 
   /**

--- a/dash/include/dash/iterator/internal/GlobPtrBase.h
+++ b/dash/include/dash/iterator/internal/GlobPtrBase.h
@@ -71,28 +71,28 @@ dart_gptr_t increment(
     dart_gptr_t dart_gptr,
     typename MemorySpaceT::size_type,
     MemorySpaceT const *mem_space,
-    memory_space_noncontiguous);
+    memory_space_noncontiguous) DASH_NOEXCEPT;
 
 template <class T, class MemorySpaceT>
 dart_gptr_t increment(
     dart_gptr_t dart_gptr,
     typename MemorySpaceT::size_type,
     MemorySpaceT const *mem_space,
-    memory_space_contiguous);
+    memory_space_contiguous) DASH_NOEXCEPT;
 
 template <class T, class MemorySpaceT>
 dart_gptr_t decrement(
     dart_gptr_t dart_gptr,
     typename MemorySpaceT::size_type,
     MemorySpaceT const *mem_space,
-    memory_space_contiguous);
+    memory_space_contiguous) DASH_NOEXCEPT;
 
 template <class T, class MemorySpaceT>
 dart_gptr_t decrement(
     dart_gptr_t dart_gptr,
     typename MemorySpaceT::size_type,
     MemorySpaceT const *mem_space,
-    memory_space_noncontiguous);
+    memory_space_noncontiguous) DASH_NOEXCEPT;
 
 template <class T, class MemSpaceT>
 inline dash::gptrdiff_t distance(
@@ -193,7 +193,7 @@ dart_gptr_t increment(
     dart_gptr_t dart_gptr,
     typename MemorySpaceT::size_type offs,
     MemorySpaceT const * /*mem_space*/,
-    memory_space_noncontiguous)
+    memory_space_noncontiguous) DASH_NOEXCEPT
 {
   dart_gptr.addr_or_offs.offset += offs * sizeof(T);
   return dart_gptr;
@@ -205,7 +205,7 @@ dart_gptr_t increment(
     dart_gptr_t                      gptr,
     typename MemorySpaceT::size_type offs,
     MemorySpaceT const *             mem_space,
-    memory_space_contiguous)
+    memory_space_contiguous) DASH_NOEXCEPT
 {
   using value_type = T;
 
@@ -281,7 +281,7 @@ dart_gptr_t decrement(
     dart_gptr_t gptr,
     typename MemorySpaceT::size_type offs,
     MemorySpaceT const *mem_space,
-    memory_space_noncontiguous)
+    memory_space_noncontiguous) DASH_NOEXCEPT
 {
   DASH_THROW(dash::exception::NotImplemented, "not implemented yet");
 }
@@ -291,7 +291,7 @@ dart_gptr_t decrement(
     dart_gptr_t gptr,
     typename MemorySpaceT::size_type offs,
     MemorySpaceT const *mem_space,
-    memory_space_contiguous)
+    memory_space_contiguous) DASH_NOEXCEPT
 {
   using value_type = T;
 

--- a/dash/include/dash/matrix/internal/Matrix-inl.h
+++ b/dash/include/dash/matrix/internal/Matrix-inl.h
@@ -143,7 +143,7 @@ Matrix<T, NumDim, IndexT, PatternT, LocalMemT>
   _team      = other._team;
   _size      = other._size;
   _lcapacity = other._lcapacity;
-  _begin     = other._begin;
+  _begin = iterator{&_glob_mem, _pattern, other._begin.pos()};
   _lbegin    = other._lbegin;
   _lend      = other._lend;
   _ref       = other._ref;

--- a/dash/include/dash/matrix/internal/Matrix-inl.h
+++ b/dash/include/dash/matrix/internal/Matrix-inl.h
@@ -462,7 +462,8 @@ constexpr typename Matrix<T, NumDim, IndexT, PatternT, LocalMemT>::const_iterato
 Matrix<T, NumDim, IndexT, PatternT, LocalMemT>
 ::begin() const noexcept
 {
-  return const_iterator(_begin);
+    return const_iterator(
+        const_cast<GlobMem_t *>(&_glob_mem), _pattern, _begin.pos());
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT, typename LocalMemT>

--- a/dash/include/dash/matrix/internal/Matrix-inl.h
+++ b/dash/include/dash/matrix/internal/Matrix-inl.h
@@ -479,7 +479,8 @@ constexpr typename Matrix<T, NumDim, IndexT, PatternT, LocalMemT>::const_iterato
 Matrix<T, NumDim, IndexT, PatternT, LocalMemT>
 ::end() const noexcept
 {
-  return const_iterator(_begin + _size);
+    return const_iterator(
+        const_cast<GlobMem_t *>(&_glob_mem), _pattern, _begin.pos() + _size);
 }
 
 template <typename T, dim_t NumDim, typename IndexT, class PatternT, typename LocalMemT>

--- a/dash/include/dash/memory/GlobStaticMem.h
+++ b/dash/include/dash/memory/GlobStaticMem.h
@@ -163,7 +163,7 @@ public:
   {
     auto soon_to_be_end = m_begin;
     // reset local offset to 0
-    soon_to_be_end.set_unit(dash::team_unit_t{m_team->size()});
+    soon_to_be_end.set_unit(dash::team_unit_t{static_cast<dart_team_unit_t>(m_team->size())});
 
     return void_pointer(soon_to_be_end);
   }

--- a/dash/test/algorithm/SortTest.cc
+++ b/dash/test/algorithm/SortTest.cc
@@ -67,9 +67,6 @@ TEST_F(SortTest, ArrayBlockedFullRange)
 
   array.barrier();
 
-  int wait = 0;
-  while(wait);
-
   perform_test(array.begin(), array.end());
 }
 

--- a/dash/test/algorithm/SortTest.cc
+++ b/dash/test/algorithm/SortTest.cc
@@ -67,6 +67,9 @@ TEST_F(SortTest, ArrayBlockedFullRange)
 
   array.barrier();
 
+  int wait = 0;
+  while(wait);
+
   perform_test(array.begin(), array.end());
 }
 


### PR DESCRIPTION
After move assignment and move construction in `dash::Array` we should also unregister the dealloc functions in the original team. Otherwise, we get segmentation faults during `dash::finalize`.