### PR TITLE
Add Boost as a dependency

### DIFF
--- a/CMakeExt/Boost.cmake
+++ b/CMakeExt/Boost.cmake
@@ -1,0 +1,5 @@
+find_package(Boost REQUIRED COMPONENTS
+        ## If you need to link a boost library, add it below. For example:
+        # chrono
+        ## will link boost_chrono for you and also add it as a dependency.
+        )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ endif()
 
 # Load build modules to locate libraries after environment setup
 # has been loaded:
+include(${CMAKE_SOURCE_DIR}/CMakeExt/Boost.cmake)
 include(${CMAKE_SOURCE_DIR}/CMakeExt/MPI.cmake)
 include(${CMAKE_SOURCE_DIR}/CMakeExt/PAPI.cmake)
 include(${CMAKE_SOURCE_DIR}/CMakeExt/Hwloc.cmake)

--- a/dash/CMakeLists.txt
+++ b/dash/CMakeLists.txt
@@ -231,6 +231,10 @@ if (ENABLE_SCALAPACK)
          ${SCALAPACK_LIBRARIES})
   endif()
 endif()
+set (ADDITIONAL_INCLUDES ${ADDITIONAL_INCLUDES}
+  ${Boost_INCLUDE_DIRS})
+set (ADDITIONAL_LIBRARIES ${ADDITIONAL_LIBRARIES}
+        ${Boost_LIBRARIES})
 
 if (HAVE_STD_TRIVIALLY_COPYABLE)
   set (ADDITIONAL_COMPILE_FLAGS
@@ -351,6 +355,11 @@ foreach (dart_variant ${DART_IMPLEMENTATIONS_LIST})
   if(ENABLE_COMPTIME_RED)
       #cotire(${DASH_LIBRARY})
   endif()
+
+  include_directories(${Boost_INCLUDE_DIR})
+  target_link_libraries(
+    ${DASH_LIBRARY}
+    ${Boost_LIBRARIES})
 
   include_directories(
     ${ADDITIONAL_INCLUDES}


### PR DESCRIPTION
We could eliminate much of our code if we just used Boost, e.g. much of the iterators and const-correctnes stuff @rkowalewski is currently working on. This PR adds the dependency to DASH.

So far this will only add the include directory to the library target as well
as to the compiler wrapper.

If at some point some Boost module must be linked, it should be added to
Boost.cmake.

How can I add Boost to our CI Docker images?