### PR TITLE
Set default window type to non-shared static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ option(ENABLE_ASSERTIONS
 option(ENABLE_UNIFIED_MEMORY_MODEL
        "Specify whether to assume unified memory model" on)
 option(ENABLE_SHARED_WINDOWS
-       "Specify whether shared memory features are enabled" on)
+       "Specify whether shared memory features are enabled" off)
 option(ENABLE_DYNAMIC_WINDOWS
-       "Specify whether to use dynamic MPI windows for collective allocation" on)
+       "Specify whether to use dynamic MPI windows for collective allocation" off)
 option(ENABLE_DEFAULT_INDEX_TYPE_LONG
        "Specify whether to use int64_t as default index type" on)
 option(ENABLE_LIBNUMA

--- a/build.analyze.sh
+++ b/build.analyze.sh
@@ -76,6 +76,15 @@ fi
 #                    -DGTEST_INCLUDE_PATH=${HOME}/gtest/include \
 #
 
+# The MPI backend offers support for employing shared memory windows in combination
+# with dynamic windows, which may improve on-node communication performance.
+# This feature can be enabled by setting
+#                        -DENABLE_SHARED_WINDOWS=ON \
+#                        -DENABLE_DYNAMIC_WINDOWS=ON \
+# below. However, we have experienced issues with some MPI implementations if used
+# in combination with -DENABLE_THREADSUPPORT=ON. It might also have a negative effect
+# on inter-node communication performance on some architectures.
+
 # To build with MKL support, set environment variables MKLROOT and INTELROOT.
 #
 
@@ -103,8 +112,8 @@ mkdir -p $BUILD_DIR/$REPORT_DIR
                         -DENABLE_LT_OPTIMIZATION=OFF \
                         -DENABLE_ASSERTIONS=ON \
                         \
-                        -DENABLE_SHARED_WINDOWS=ON \
-                        -DENABLE_UNIFIED_MEMORY_MODEL=ON \
+                        -DENABLE_SHARED_WINDOWS=OFF \
+                        -DENABLE_UNIFIED_MEMORY_MODEL=OFF \
                         -DENABLE_DYNAMIC_WINDOWS=ON \
                         -DENABLE_DEFAULT_INDEX_TYPE_LONG=ON \
                         \

--- a/build.cov.sh
+++ b/build.cov.sh
@@ -64,8 +64,8 @@ rm -Rf $BUILD_DIR/*
                         -DENABLE_LT_OPTIMIZATION=OFF \
                         -DENABLE_ASSERTIONS=ON \
                         \
-                        -DENABLE_SHARED_WINDOWS=ON \
-                        -DENABLE_DYNAMIC_WINDOWS=ON \
+                        -DENABLE_SHARED_WINDOWS=OFF \
+                        -DENABLE_DYNAMIC_WINDOWS=OFF \
                         -DENABLE_UNIFIED_MEMORY_MODEL=ON \
                         -DENABLE_DEFAULT_INDEX_TYPE_LONG=ON \
                         \

--- a/build.cov.sh
+++ b/build.cov.sh
@@ -41,6 +41,15 @@ fi
 #                    -DGTEST_INCLUDE_PATH=${HOME}/gtest/include \
 #
 
+# The MPI backend offers support for employing shared memory windows in combination
+# with dynamic windows, which may improve on-node communication performance.
+# This feature can be enabled by setting
+#                        -DENABLE_SHARED_WINDOWS=ON \
+#                        -DENABLE_DYNAMIC_WINDOWS=ON \
+# below. However, we have experienced issues with some MPI implementations if used
+# in combination with -DENABLE_THREADSUPPORT=ON. It might also have a negative effect
+# on inter-node communication performance on some architectures.
+
 # To build with MKL support, set environment variables MKLROOT and INTELROOT.
 #
 

--- a/build.debug.sh
+++ b/build.debug.sh
@@ -66,8 +66,8 @@ rm -Rf $BUILD_DIR/*
                         -DENABLE_LT_OPTIMIZATION=OFF \
                         -DENABLE_ASSERTIONS=ON \
                         \
-                        -DENABLE_SHARED_WINDOWS=ON \
-                        -DENABLE_DYNAMIC_WINDOWS=ON \
+                        -DENABLE_SHARED_WINDOWS=OFF \
+                        -DENABLE_DYNAMIC_WINDOWS=OFF \
                         -DENABLE_UNIFIED_MEMORY_MODEL=ON \
                         -DENABLE_DEFAULT_INDEX_TYPE_LONG=ON \
                         \

--- a/build.debug.sh
+++ b/build.debug.sh
@@ -41,6 +41,15 @@ fi
 #                    -DGTEST_INCLUDE_PATH=${HOME}/gtest/include \
 #
 
+# The MPI backend offers support for employing shared memory windows in combination
+# with dynamic windows, which may improve on-node communication performance.
+# This feature can be enabled by setting
+#                        -DENABLE_SHARED_WINDOWS=ON \
+#                        -DENABLE_DYNAMIC_WINDOWS=ON \
+# below. However, we have experienced issues with some MPI implementations if used
+# in combination with -DENABLE_THREADSUPPORT=ON. It might also have a negative effect
+# on inter-node communication performance on some architectures.
+
 # To build with MKL support, set environment variables MKLROOT and INTELROOT.
 #
 

--- a/build.dev.sh
+++ b/build.dev.sh
@@ -44,6 +44,15 @@ fi
 # To build with MKL support, set environment variables MKLROOT and INTELROOT.
 #
 
+# The MPI backend offers support for employing shared memory windows in combination
+# with dynamic windows, which may improve on-node communication performance.
+# This feature can be enabled by setting
+#                        -DENABLE_SHARED_WINDOWS=ON \
+#                        -DENABLE_DYNAMIC_WINDOWS=ON \
+# below. However, we have experienced issues with some MPI implementations if used
+# in combination with -DENABLE_THREADSUPPORT=ON. It might also have a negative effect
+# on inter-node communication performance on some architectures.
+
 # To enable IPM runtime support, use:
 #
 #                    -DIPM_PREFIX=<IPM install path> \

--- a/build.dev.sh
+++ b/build.dev.sh
@@ -66,8 +66,8 @@ rm -Rf $BUILD_DIR/*
                         -DENABLE_LT_OPTIMIZATION=OFF \
                         -DENABLE_ASSERTIONS=ON \
                         \
-                        -DENABLE_SHARED_WINDOWS=ON \
-                        -DENABLE_DYNAMIC_WINDOWS=ON \
+                        -DENABLE_SHARED_WINDOWS=OFF \
+                        -DENABLE_DYNAMIC_WINDOWS=OFF \
                         -DENABLE_UNIFIED_MEMORY_MODEL=ON \
                         -DENABLE_DEFAULT_INDEX_TYPE_LONG=ON \
                         \

--- a/build.mic.sh
+++ b/build.mic.sh
@@ -55,8 +55,8 @@ rm -Rf $BUILD_DIR/*
                         -DENABLE_EXT_COMPILER_WARNINGS=OFF \
                         -DENABLE_ASSERTIONS=OFF \
                         \
-                        -DENABLE_SHARED_WINDOWS=ON \
-                        -DENABLE_DYNAMIC_WINDOWS=ON \
+                        -DENABLE_SHARED_WINDOWS=OFF \
+                        -DENABLE_DYNAMIC_WINDOWS=OFF \
                         -DENABLE_UNIFIED_MEMORY_MODEL=ON \
                         -DENABLE_DEFAULT_INDEX_TYPE_LONG=ON \
                         \

--- a/build.minimal.sh
+++ b/build.minimal.sh
@@ -39,6 +39,16 @@ fi
 #                    -DGTEST_LIBRARY_PATH=${HOME}/gtest \
 #                    -DGTEST_INCLUDE_PATH=${HOME}/gtest/include \
 #
+# The MPI backend offers support for employing shared memory windows in combination
+# with dynamic windows, which may improve on-node communication performance.
+# This feature can be enabled by setting
+#                        -DENABLE_SHARED_WINDOWS=ON \
+#                        -DENABLE_DYNAMIC_WINDOWS=ON \
+# below. However, we have experienced issues with some MPI implementations if used
+# in combination with -DENABLE_THREADSUPPORT=ON. It might also have a negative effect
+# on inter-node communication performance on some architectures.
+#
+#
 # To build with MKL support, set environment variables MKLROOT and INTELROOT.
 #
 # To enable IPM runtime support, use:

--- a/build.nasty.sh
+++ b/build.nasty.sh
@@ -41,6 +41,15 @@ fi
 #                    -DGTEST_INCLUDE_PATH=${HOME}/gtest/include \
 #
 
+# The MPI backend offers support for employing shared memory windows in combination
+# with dynamic windows, which may improve on-node communication performance.
+# This feature can be enabled by setting
+#                        -DENABLE_SHARED_WINDOWS=ON \
+#                        -DENABLE_DYNAMIC_WINDOWS=ON \
+# below. However, we have experienced issues with some MPI implementations if used
+# in combination with -DENABLE_THREADSUPPORT=ON. It might also have a negative effect
+# on inter-node communication performance on some architectures.
+
 # To build with MKL support, set environment variables MKLROOT and INTELROOT.
 #
 

--- a/build.sh
+++ b/build.sh
@@ -66,8 +66,8 @@ rm -Rf $BUILD_DIR/*
                         -DENABLE_LT_OPTIMIZATION=OFF \
                         -DENABLE_ASSERTIONS=ON \
                         \
-                        -DENABLE_SHARED_WINDOWS=ON \
-                        -DENABLE_DYNAMIC_WINDOWS=ON \
+                        -DENABLE_SHARED_WINDOWS=OFF \
+                        -DENABLE_DYNAMIC_WINDOWS=OFF \
                         -DENABLE_UNIFIED_MEMORY_MODEL=ON \
                         -DENABLE_DEFAULT_INDEX_TYPE_LONG=ON \
                         \

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,15 @@ fi
 #                    -DGTEST_INCLUDE_PATH=${HOME}/gtest/include \
 #
 
+# The MPI backend offers support for employing shared memory windows in combination
+# with dynamic windows, which may improve on-node communication performance.
+# This feature can be enabled by setting
+#                        -DENABLE_SHARED_WINDOWS=ON \
+#                        -DENABLE_DYNAMIC_WINDOWS=ON \
+# below. However, we have experienced issues with some MPI implementations if used
+# in combination with -DENABLE_THREADSUPPORT=ON. It might also have a negative effect
+# on inter-node communication performance on some architectures.
+
 # To build with MKL support, set environment variables MKLROOT and INTELROOT.
 #
 


### PR DESCRIPTION
This PR changes the build scripts and CMakeList to configure DART to use regular windows instead of dynamic + shared memory windows in `dart_team_memalloc_aligned`.

Background: 
The use  of dynamic windows causes all sorts of troubles:

1) It prevents the use of RDMA capabilities on any decent hardware.
2) Open MPI chokes if `MPI_THREAD_MULTIPLE` is enabled and no RDMA-capable network is found (thanks to @bertwesarg for bringing this back up) because the shared-memory component does not support dynamic windows (how could it?) and the `pt2pt` component lacks support for `MPI_THREAD_MULTIPLE` (not sure this will ever be fixed). Hence, DASH won't even work on a single node.

The MPI implementation will likely short-cut through shared memory for on-node communication so the benefit of doing it ourselves really seems marginal. On the other hand, changing the default avoids some bad surprises.