### PR TITLE
Correctly determine the number of units per node

### DIFF
--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -575,8 +575,6 @@ dart_ret_t dart__base__host_topology__create(
   /* Number of units mapped to current host: */
   int    num_host_units = 0;
   for (size_t u = 0; u < num_units; ++u) {
-    ++num_host_units;
-    if (u == last_host_idx) { continue; }
     /* copies next differing host name to the left, like:
      *
      *     [ a a a a b b b c c c ]  last_host_index++ = 1
@@ -596,8 +594,9 @@ dart_ret_t dart__base__host_topology__create(
       }
       num_host_units = 0;
     }
+    ++num_host_units;
   }
-  if (max_host_units == 0) {
+  if (max_host_units < num_host_units) {
     /* All units mapped to same host: */
     max_host_units = num_host_units;
   }

--- a/dart-impl/base/src/internal/host_topology.c
+++ b/dart-impl/base/src/internal/host_topology.c
@@ -588,7 +588,9 @@ dart_ret_t dart__base__host_topology__create(
      */
     if (strcmp(hostnames[u], hostnames[last_host_idx]) != 0) {
       ++last_host_idx;
-      strncpy(hostnames[last_host_idx], hostnames[u], max_host_len);
+      if (last_host_idx != u) {
+        strncpy(hostnames[last_host_idx], hostnames[u], max_host_len);
+      }
       if (num_host_units > max_host_units) {
         max_host_units = num_host_units;
       }


### PR DESCRIPTION
Fixes some edge cases where nodes contain different numbers of units, e.g., one on the first node and N-1 on the second node.