### PR TITLE
Fix UnorderedMap deallocation

### DIFF
--- a/dash/include/dash/map/UnorderedMap.h
+++ b/dash/include/dash/map/UnorderedMap.h
@@ -349,7 +349,7 @@ public:
     // Assure all units are synchronized before deallocation, otherwise
     // other units might still be working on the map:
     if (dash::is_initialized()) {
-      barrier();
+      _team->barrier();
     }
     // Remove this function from team deallocator map to avoid
     // double-free:
@@ -362,7 +362,6 @@ public:
       _globmem = nullptr;
     }
     _local_cumul_sizes    = std::vector<size_type>(_team->size(), 0);
-    _local_sizes.local[0] = 0;
     _remote_size          = 0;
     _begin                = iterator();
     _end                  = _begin;

--- a/dash/test/container/MatrixTest.cc
+++ b/dash/test/container/MatrixTest.cc
@@ -15,6 +15,11 @@
 #include <iostream>
 #include <iomanip>
 
+TEST_F(MatrixTest, Declaration)
+{
+  dash::Matrix<int, 2> matrix;
+}
+
 
 TEST_F(MatrixTest, OddSize)
 {

--- a/dash/test/container/UnorderedMapTest.cc
+++ b/dash/test/container/UnorderedMapTest.cc
@@ -8,6 +8,11 @@
 #include <vector>
 #include <algorithm>
 
+TEST_F(UnorderedMapTest, Declaration)
+{
+  dash::UnorderedMap<int, int> map;
+}
+
 TEST_F(UnorderedMapTest, Initialization)
 {
   typedef int                                  key_t;


### PR DESCRIPTION
We cannot access member DASH containers while deallocating dash::UnorderedMap because they will likely have been destroyed by them team owning them before the UnorderedMap deallocator gets called.

Fixes #517 