### PR TITLE
GlobIter: fix edge-case of empty container

### DIFF
--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -60,7 +60,7 @@ class GlobIter {
   typedef typename pointer::const_local_type const_local_type;
 
   typedef PatternType                      pattern_type;
-  typedef typename PatternType::index_type index_type;
+  typedef typename std::make_signed<typename PatternType::index_type>::type index_type;
 
  private:
   typedef GlobIter<
@@ -122,7 +122,7 @@ class GlobIter {
     : _globmem(gmem),
       _pattern(&pat),
       _idx(position),
-      _max_idx(std::max(index_type(pat.size()) - 1, index_type(0)))
+      _max_idx(index_type(pat.size()) - 1)
   {
   }
 

--- a/dash/test/container/ArrayTest.cc
+++ b/dash/test/container/ArrayTest.cc
@@ -21,6 +21,18 @@ TEST_F(ArrayTest, Declaration)
   dash::Array<int> arr;
 }
 
+
+TEST_F(ArrayTest, Empty)
+{
+  dash::Array<int> arr{0};
+
+  auto begin = arr.begin();
+  auto end   = arr.end();
+  auto gptr  = begin.dart_gptr();
+
+  ASSERT_EQ_U(begin, end);
+}
+
 TEST_F(ArrayTest, Initialization)
 {
   dash::Array<int> array_local(19 * dash::size(), dash::BLOCKED);


### PR DESCRIPTION
Member `_max_idx` should be allowed to be -1 for empty containers, hence the signed index type.