### PR TITLE
TilePattern: Fix coordinate <-> index conversion

### DIFF
--- a/dash/include/dash/Cartesian.h
+++ b/dash/include/dash/Cartesian.h
@@ -698,6 +698,8 @@ public:
     }
     // Tiles in at least one dimension
     // TODO
+    DASH_THROW(dash::exception::NotImplemented,
+               "CartesianIndexSpace::resize(IndexType) not implemented for tiles!");
   }
 
   /**
@@ -737,6 +739,8 @@ public:
     }
     // Tiles in at least one dimension
     // TODO
+    DASH_THROW(dash::exception::NotImplemented,
+               "CartesianIndexSpace::at(IndexType) not implemented for tiles!");
   }
 
   /**
@@ -758,11 +762,6 @@ public:
     for (auto d = 0; d < NumDimensions; ++d) {
       coords[d] = point[d] + viewspec[d].offset;
     }
-    if (!_distspec.is_tiled()) {
-      // Default case, no tiles
-      return parent_t::at(coords);
-    }
-    // Tiles in at least one dimension
     return at(coords);
   }
 
@@ -778,6 +777,8 @@ public:
     }
     // Tiles in at least one dimension
     // TODO
+    DASH_THROW(dash::exception::NotImplemented,
+               "CartesianIndexSpace::coords(IndexType) not implemented for tiles!");
   }
 
 private:

--- a/dash/include/dash/Pattern.h
+++ b/dash/include/dash/Pattern.h
@@ -564,21 +564,6 @@ public:
   const std::array<size_type, NumDimensions> & extents() const;
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  const MemoryLayout_t & memory_layout() const;
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  const LocalMemoryLayout_t & local_memory_layout() const;
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -594,6 +579,16 @@ public:
    */
   std::array<index_type, NumDimensions> coords(
     index_type index) const;
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  std::array<index_type, NumDimensions> coords(
+    index_type         index,
+    const ViewSpec_t & viewspec) const;
 
   /**
    * Memory order followed by the pattern.

--- a/dash/include/dash/halo/Halo.h
+++ b/dash/include/dash/halo/Halo.h
@@ -953,7 +953,7 @@ public:
    * \see DashGlobalIteratorConcept
    */
   pattern_index_t gpos() const {
-    return _pattern->at(glob_coords(_idx));
+    return _pattern->global_at(glob_coords(_idx));
   }
 
   std::array<pattern_index_t, NumDimensions> gcoords() const {

--- a/dash/include/dash/halo/Halo.h
+++ b/dash/include/dash/halo/Halo.h
@@ -953,7 +953,7 @@ public:
    * \see DashGlobalIteratorConcept
    */
   pattern_index_t gpos() const {
-    return _pattern->memory_layout().at(glob_coords(_idx));
+    return _pattern->at(glob_coords(_idx));
   }
 
   std::array<pattern_index_t, NumDimensions> gcoords() const {
@@ -1084,7 +1084,7 @@ private:
 
   std::array<pattern_index_t, NumDimensions> glob_coords(
     pattern_index_t idx) const {
-    return _pattern->memory_layout().coords(idx, _region_view);
+    return _pattern->coords(idx, _region_view);
   }
 
 private:

--- a/dash/include/dash/iterator/GlobViewIter.h
+++ b/dash/include/dash/iterator/GlobViewIter.h
@@ -655,7 +655,7 @@ public:
       auto g_coords = coords(idx);
       DASH_LOG_TRACE_VAR("GlobViewIter.gpos", _idx);
       DASH_LOG_TRACE_VAR("GlobViewIter.gpos", g_coords);
-      auto g_idx    = _pattern->memory_layout().at(g_coords);
+      auto g_idx    = _pattern->global_at(g_coords);
       DASH_LOG_TRACE_VAR("GlobViewIter.gpos", g_idx);
       g_idx += offset;
       DASH_LOG_TRACE_VAR("GlobViewIter.gpos >", g_idx);
@@ -718,7 +718,7 @@ public:
     if (_viewspec != nullptr) {
       return *_viewspec;
     }
-    return ViewSpecType(_pattern->memory_layout().extents());
+    return ViewSpecType(_pattern->extents());
   }
 
   /**
@@ -1004,7 +1004,7 @@ private:
         glob_coords[d]  += dim_offset;
       }
     } else {
-      glob_coords = _pattern->memory_layout().coords(glob_index);
+      glob_coords = _pattern->coords(glob_index);
     }
     DASH_LOG_TRACE_VAR("GlobViewIter.coords >", glob_coords);
     return glob_coords;

--- a/dash/include/dash/matrix/internal/MatrixRefView-inl.h
+++ b/dash/include/dash/matrix/internal/MatrixRefView-inl.h
@@ -49,9 +49,8 @@ MatrixRefView<T, NumDim, PatternT, LocalMemT>
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference()", _coord);
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference",   _viewspec);
   const auto & pattern       = _mat->pattern();
-  const auto & memory_layout = pattern.memory_layout();
   // MatrixRef coordinate and viewspec to global linear index:
-  const auto & global_index  = memory_layout.at(_coord, _viewspec);
+  const auto & global_index  = pattern.global_at(_coord, _viewspec);
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference", global_index);
   const auto & global_begin  = _mat->begin();
   // Global reference at global linear index:
@@ -68,9 +67,8 @@ MatrixRefView<T, NumDim, PatternT, LocalMemT>
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference()", _coord);
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference",   _viewspec);
   const auto & pattern       = _mat->pattern();
-  const auto & memory_layout = pattern.memory_layout();
   // MatrixRef coordinate and viewspec to global linear index:
-  const auto & global_index  = memory_layout.at(_coord, _viewspec);
+  const auto & global_index  = pattern.global_at(_coord, _viewspec);
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference", global_index);
   auto         global_begin  = _mat->begin();
   // Global reference at global linear index:
@@ -91,9 +89,8 @@ MatrixRefView<T, NumDim, PatternT, LocalMemT>
   }
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference()", coords);
   const auto & pattern       = _mat->pattern();
-  const auto & memory_layout = pattern.memory_layout();
   // MatrixRef coordinate and viewspec to global linear index:
-  const auto & global_index  = memory_layout.at(coords, _viewspec);
+  const auto & global_index  = pattern.global_at(coords, _viewspec);
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference", global_index);
   const auto & global_begin  = _mat->begin();
   // Global reference at global linear index:
@@ -114,9 +111,8 @@ MatrixRefView<T, NumDim, PatternT, LocalMemT>
   }
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference()", coords);
   const auto & pattern       = _mat->pattern();
-  const auto & memory_layout = pattern.memory_layout();
   // MatrixRef coordinate and viewspec to global linear index:
-  const auto & global_index  = memory_layout.at(coords, _viewspec);
+  const auto & global_index  = pattern.global_at(coords, _viewspec);
   DASH_LOG_TRACE_VAR("MatrixRefView.global_reference", global_index);
   auto         global_begin  = _mat->begin();
   // Global reference at global linear index:

--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -1278,27 +1278,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  constexpr const MemoryLayout_t & memory_layout() const noexcept
-  {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  constexpr const LocalMemoryLayout_t & local_memory_layout() const noexcept
-  {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1319,6 +1298,21 @@ public:
     IndexType index) const noexcept
   {
     return _memory_layout.coords(index);
+  }
+
+  /**
+   * Convert given global linear offset (index) and viewspec to global cartesian
+   * coordinates.
+   *
+   * \see DashPatternConcept
+   */
+  constexpr std::array<IndexType, NumDimensions> coords(
+    /// Global index (offset) to convert
+    IndexType          index,
+    /// View specification (offsets) to apply on \c coords
+    const ViewSpec_t & viewspec) const noexcept
+  {
+    return _memory_layout.coords(index, viewspec);
   }
 
   /**

--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -436,7 +436,7 @@ public:
     // Apply viewspec offsets to coordinates:
     std::array<IndexType, NumDimensions> vs_coords;
     for (auto d = 0; d < NumDimensions; ++d) {
-      vs_coords[d] = coords[d] + viewspec[d].offset;
+      vs_coords[d] = coords[d] + viewspec.offset(0);
     }
     return unit_at(vs_coords);
   }
@@ -937,7 +937,7 @@ public:
     DASH_LOG_TRACE_VAR("BlockPattern.has_local_elements()", dim_offset);
     DASH_LOG_TRACE_VAR("BlockPattern.has_local_elements()", unit);
     // Apply viewspec offset in dimension to given position
-    dim_offset += viewspec[dim].offset;
+    dim_offset += viewspec.offset(0);
     // Offset to block offset
     IndexType block_coord_d    = dim_offset / _blocksize_spec.extent(dim);
     DASH_LOG_TRACE_VAR("BlockPattern.has_local_elements", block_coord_d);

--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -937,7 +937,7 @@ public:
     DASH_LOG_TRACE_VAR("BlockPattern.has_local_elements()", dim_offset);
     DASH_LOG_TRACE_VAR("BlockPattern.has_local_elements()", unit);
     // Apply viewspec offset in dimension to given position
-    dim_offset += viewspec.offset(0);
+    dim_offset += viewspec.offset(dim);
     // Offset to block offset
     IndexType block_coord_d    = dim_offset / _blocksize_spec.extent(dim);
     DASH_LOG_TRACE_VAR("BlockPattern.has_local_elements", block_coord_d);

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -688,6 +688,32 @@ public:
     return global(unit, l_coords)[0];
   }
 
+  /**
+   * Convert given global coordinates and viewspec to linear global offset
+   * (index).
+   *
+   * \see DashPatternConcept
+   */
+  constexpr IndexType global_at(
+    /// Point in local memory
+    const std::array<IndexType, NumDimensions> & global_coords,
+    /// View specification (offsets) to apply on \c coords
+    const ViewSpec_t & viewspec) const {
+    return global_coords[0] + viewspec.offset(0);
+  }
+
+  /**
+   * Convert given global coordinates to linear global offset (index).
+   *
+   * \see DashPatternConcept
+   */
+  constexpr IndexType global_at(
+    /// Point in local memory
+    const std::array<IndexType, NumDimensions> & global_coords) const {
+    return global_coords[0];
+  }
+
+
   ////////////////////////////////////////////////////////////////////////////
   /// at
   ////////////////////////////////////////////////////////////////////////////
@@ -1022,25 +1048,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  constexpr const MemoryLayout_t & memory_layout() const {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  constexpr const LocalMemoryLayout_t & local_memory_layout() const {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1059,6 +1066,18 @@ public:
   constexpr std::array<IndexType, NumDimensions> coords(
     IndexType index) const {
     return std::array<IndexType, 1> {{ index }};
+  }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  constexpr std::array<IndexType, NumDimensions> coords(
+    IndexType          index,
+    const ViewSpec_t & viewspec) const {
+    return std::array<IndexType, 1> {{ index + viewspec.offset(0) }};
   }
 
   /**

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -381,7 +381,7 @@ public:
     const std::array<IndexType, NumDimensions> & coords,
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t & viewspec) const {
-    return team_unit_t (((coords[0] + viewspec[0].offset) / _blocksize)
+    return team_unit_t (((coords[0] + viewspec.offset(0)) / _blocksize)
                         % _nunits);
   }
 
@@ -406,7 +406,7 @@ public:
     /// View to apply global position
     const ViewSpec_t & viewspec
   ) const {
-    return team_unit_t(((global_pos + viewspec[0].offset) / _blocksize)
+    return team_unit_t(((global_pos + viewspec.offset(0)) / _blocksize)
                        % _nunits);
   }
 
@@ -550,7 +550,7 @@ public:
     const std::array<IndexType, NumDimensions> & local_coords,
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t & viewspec) const {
-    return local_coords[0] + viewspec[0].offset;
+    return local_coords[0] + viewspec.offset(0);
   }
 
   /**
@@ -743,7 +743,7 @@ public:
     const ViewSpec_t & viewspec) const {
     return local_coords(
              std::array<IndexType, 1> {{
-               g_coords[0] + viewspec[0].offset
+               g_coords[0] + viewspec.offset(0)
              }}
            )[0];
   }

--- a/dash/include/dash/pattern/CSRPattern.h
+++ b/dash/include/dash/pattern/CSRPattern.h
@@ -1079,27 +1079,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  constexpr const MemoryLayout_t & memory_layout() const noexcept
-  {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  constexpr const LocalMemoryLayout_t & local_memory_layout() const noexcept
-  {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1121,6 +1100,19 @@ public:
   {
     return std::array<IndexType, 1> {{ index }};
   }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  std::array<IndexType, NumDimensions> coords(
+    IndexType          index,
+    const ViewSpec_t & viewspec) const {
+    return std::array<IndexType, 1> {{ index + viewspec.offset(0) }};
+  }
+
 
   /**
    * Memory order followed by the pattern.

--- a/dash/include/dash/pattern/CSRPattern.h
+++ b/dash/include/dash/pattern/CSRPattern.h
@@ -477,7 +477,7 @@ public:
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t                           & viewspec) const
   {
-    return unit_at(coords[0] + viewspec[0].offset);
+    return unit_at(coords[0] + viewspec.offset(0));
   }
 
   /**
@@ -502,7 +502,7 @@ public:
     /// View to apply global position
     const ViewSpec_t & viewspec) const
   {
-    return unit_at(global_pos + viewspec[0].offset);
+    return unit_at(global_pos + viewspec.offset(0));
   }
 
   /**
@@ -620,7 +620,7 @@ public:
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t & viewspec) const noexcept
   {
-    return local_coords[0] + viewspec[0].offset;
+    return local_coords[0] + viewspec.offset(0);
   }
 
   /**
@@ -817,7 +817,7 @@ public:
     const ViewSpec_t & viewspec) const
   {
     auto vs_coords = g_coords;
-    vs_coords[0] += viewspec[0].offset;
+    vs_coords[0] += viewspec.offset(0);
     return local_coords(vs_coords)[0];
   }
 

--- a/dash/include/dash/pattern/DynamicPattern.h
+++ b/dash/include/dash/pattern/DynamicPattern.h
@@ -505,7 +505,7 @@ public:
   {
     DASH_LOG_TRACE_VAR("DynamicPattern.unit_at()", coords);
     // Apply viewspec offsets to coordinates:
-    team_unit_t unit_id(((coords[0] + viewspec[0].offset) / _blocksize)
+    team_unit_t unit_id(((coords[0] + viewspec.offset(0)) / _blocksize)
                           % _nunits);
     DASH_LOG_TRACE_VAR("DynamicPattern.unit_at >", unit_id);
     return unit_id;
@@ -545,7 +545,7 @@ public:
     DASH_LOG_TRACE_VAR("DynamicPattern.unit_at()", global_pos);
     DASH_LOG_TRACE_VAR("DynamicPattern.unit_at()", viewspec);
     // Apply viewspec offsets to coordinates:
-    auto g_coord         = global_pos + viewspec[0].offset;
+    auto g_coord         = global_pos + viewspec.offset(0);
     for (team_unit_t unit_idx{0}; unit_idx < _nunits - 1; ++unit_idx) {
       if (_block_offsets[unit_idx+1] >= static_cast<size_type>(g_coord)) {
         DASH_LOG_TRACE_VAR("DynamicPattern.unit_at >", unit_idx);
@@ -653,7 +653,7 @@ public:
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t & viewspec) const
   {
-    return local_coords[0] + viewspec[0].offset;
+    return local_coords[0] + viewspec.offset(0);
   }
 
   /**
@@ -897,7 +897,7 @@ public:
     const ViewSpec_t & viewspec) const
   {
     auto vs_coords = g_coords;
-    vs_coords[0] += viewspec[0].offset;
+    vs_coords[0] += viewspec.offset(0);
     return local_coords(vs_coords)[0];
   }
 

--- a/dash/include/dash/pattern/DynamicPattern.h
+++ b/dash/include/dash/pattern/DynamicPattern.h
@@ -1198,27 +1198,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  const MemoryLayout_t & memory_layout() const
-  {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  const LocalMemoryLayout_t & local_memory_layout() const
-  {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1240,6 +1219,20 @@ public:
   {
     return std::array<IndexType, 1> { index };
   }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  std::array<IndexType, NumDimensions> coords(
+    IndexType          index,
+    const ViewSpec_t & viewspec) const
+  {
+    return std::array<IndexType, 1> { index + viewspec.offset(0) };
+  }
+
 
   /**
    * Memory order followed by the pattern.

--- a/dash/include/dash/pattern/LoadBalancePattern.h
+++ b/dash/include/dash/pattern/LoadBalancePattern.h
@@ -1031,27 +1031,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  const MemoryLayout_t & memory_layout() const
-  {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  const LocalMemoryLayout_t & local_memory_layout() const
-  {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1072,6 +1051,19 @@ public:
     IndexType index) const
   {
     return std::array<IndexType, 1> {{ index }};
+  }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  std::array<IndexType, NumDimensions> coords(
+    IndexType          index,
+    const ViewSpec_t & viewspec) const
+  {
+    return std::array<IndexType, 1> {{ index + viewspec.offset(0) }};
   }
 
   /**

--- a/dash/include/dash/pattern/LoadBalancePattern.h
+++ b/dash/include/dash/pattern/LoadBalancePattern.h
@@ -431,7 +431,7 @@ public:
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t                           & viewspec) const
   {
-    return unit_at(coords[0] + viewspec[0].offset);
+    return unit_at(coords[0] + viewspec.offset(0));
   }
 
   /**
@@ -456,7 +456,7 @@ public:
     /// View to apply global position
     const ViewSpec_t & viewspec) const
   {
-    return unit_at(global_pos + viewspec[0].offset);
+    return unit_at(global_pos + viewspec.offset(0));
   }
 
   /**
@@ -561,7 +561,7 @@ public:
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t & viewspec) const
   {
-    return local_coords[0] + viewspec[0].offset;
+    return local_coords[0] + viewspec.offset(0);
   }
 
   /**
@@ -760,7 +760,7 @@ public:
     const ViewSpec_t & viewspec) const
   {
     auto vs_coords = g_coords;
-    vs_coords[0] += viewspec[0].offset;
+    vs_coords[0] += viewspec.offset(0);
     return local_coords(vs_coords)[0];
   }
 

--- a/dash/include/dash/pattern/SeqTilePattern.h
+++ b/dash/include/dash/pattern/SeqTilePattern.h
@@ -1091,7 +1091,7 @@ public:
     DASH_LOG_TRACE_VAR("SeqTilePattern.has_local_elements()", unit);
     DASH_LOG_TRACE_VAR("SeqTilePattern.has_local_elements()", viewspec);
     // Apply viewspec offset in dimension to given position
-    dim_offset += viewspec[dim].offset;
+    dim_offset += viewspec.offset(dim);
     // Offset to block offset
     IndexType block_coord_d    = dim_offset / _blocksize_spec.extent(dim);
     DASH_LOG_TRACE_VAR("SeqTilePattern.has_local_elements", block_coord_d);

--- a/dash/include/dash/pattern/SeqTilePattern.h
+++ b/dash/include/dash/pattern/SeqTilePattern.h
@@ -1398,25 +1398,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  const MemoryLayout_t & memory_layout() const {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  const LocalMemoryLayout_t & local_memory_layout() const {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1435,6 +1416,18 @@ public:
   std::array<IndexType, NumDimensions> coords(
     IndexType index) const {
     return _memory_layout.coords(index);
+  }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  std::array<IndexType, NumDimensions> coords(
+    IndexType          index,
+    const ViewSpec_t & viewspec) const {
+    return _memory_layout.coords(index, viewspec);
   }
 
   /**

--- a/dash/include/dash/pattern/ShiftTilePattern.h
+++ b/dash/include/dash/pattern/ShiftTilePattern.h
@@ -1067,7 +1067,7 @@ public:
     DASH_LOG_TRACE_VAR("ShiftTilePattern.has_local_elements()", unit);
     DASH_LOG_TRACE_VAR("ShiftTilePattern.has_local_elements()", viewspec);
     // Apply viewspec offset in dimension to given position
-    dim_offset += viewspec[dim].offset;
+    dim_offset += viewspec.offset(dim);
     // Offset to block offset
     IndexType block_coord_d    = dim_offset / _blocksize_spec.extent(dim);
     DASH_LOG_TRACE_VAR("ShiftTilePattern.has_local_elements", block_coord_d);

--- a/dash/include/dash/pattern/ShiftTilePattern.h
+++ b/dash/include/dash/pattern/ShiftTilePattern.h
@@ -1376,25 +1376,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  const MemoryLayout_t & memory_layout() const {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  const LocalMemoryLayout_t & local_memory_layout() const {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1413,6 +1394,18 @@ public:
   std::array<IndexType, NumDimensions> coords(
     IndexType index) const {
     return _memory_layout.coords(index);
+  }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  std::array<IndexType, NumDimensions> coords(
+    IndexType          index,
+    const ViewSpec_t & viewspec) const {
+    return _memory_layout.coords(index, viewspec);
   }
 
   /**

--- a/dash/include/dash/pattern/ShiftTilePattern1D.h
+++ b/dash/include/dash/pattern/ShiftTilePattern1D.h
@@ -407,7 +407,7 @@ public:
     const ViewSpec_t & viewspec) const {
     DASH_LOG_TRACE_VAR("ShiftTilePattern<1>.unit_at()", coords);
     // Apply viewspec offsets to coordinates:
-    team_unit_t unit_id(((coords[0] + viewspec[0].offset) / _blocksize)
+    team_unit_t unit_id(((coords[0] + viewspec.offset(0)) / _blocksize)
                           % _nunits);
     DASH_LOG_TRACE_VAR("ShiftTilePattern<1>.unit_at >", unit_id);
     return unit_id;
@@ -439,7 +439,7 @@ public:
   ) const {
     DASH_LOG_TRACE_VAR("ShiftTilePattern<1>.unit_at()", global_pos);
     // Apply viewspec offsets to coordinates:
-    team_unit_t unit_id(((global_pos + viewspec[0].offset) / _blocksize)
+    team_unit_t unit_id(((global_pos + viewspec.offset(0)) / _blocksize)
                           % _nunits);
     DASH_LOG_TRACE_VAR("ShiftTilePattern<1>.unit_at >", unit_id);
     return unit_id;
@@ -533,7 +533,7 @@ public:
     const std::array<IndexType, NumDimensions> & local_coords,
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t & viewspec) const {
-    return local_coords[0] + viewspec[0].offset;
+    return local_coords[0] + viewspec.offset(0);
   }
 
   /**
@@ -719,7 +719,7 @@ public:
     const std::array<IndexType, NumDimensions> & global_coords,
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t & viewspec) const {
-    return global_coords[0] + viewspec[0].offset;
+    return global_coords[0] + viewspec.offset(0);
   }
 
   /**
@@ -761,7 +761,7 @@ public:
     const std::array<IndexType, NumDimensions> & g_coords,
     const ViewSpec_t & viewspec) const {
     auto vs_coords = g_coords;
-    vs_coords[0] += viewspec[0].offset;
+    vs_coords[0] += viewspec.offset(0);
     return local_coords(vs_coords)[0];
   }
 

--- a/dash/include/dash/pattern/ShiftTilePattern1D.h
+++ b/dash/include/dash/pattern/ShiftTilePattern1D.h
@@ -708,6 +708,31 @@ public:
     return g_index;
   }
 
+  /**
+   * Convert given global coordinates and viewspec to linear global offset
+   * (index).
+   *
+   * \see DashPatternConcept
+   */
+  constexpr IndexType global_at(
+    /// Point in local memory
+    const std::array<IndexType, NumDimensions> & global_coords,
+    /// View specification (offsets) to apply on \c coords
+    const ViewSpec_t & viewspec) const {
+    return global_coords[0] + viewspec[0].offset;
+  }
+
+  /**
+   * Convert given global coordinates to linear global offset (index).
+   *
+   * \see DashPatternConcept
+   */
+  constexpr IndexType global_at(
+    /// Point in local memory
+    const std::array<IndexType, NumDimensions> & global_coords) const {
+    return global_coords[0];
+  }
+
   ////////////////////////////////////////////////////////////////////////////
   /// at
   ////////////////////////////////////////////////////////////////////////////
@@ -1008,25 +1033,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  const MemoryLayout_t & memory_layout() const {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  const LocalMemoryLayout_t & local_memory_layout() const {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1045,6 +1051,18 @@ public:
   std::array<IndexType, NumDimensions> coords(
     IndexType index) const {
     return std::array<IndexType, 1> {{ index }};
+  }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  std::array<IndexType, NumDimensions> coords(
+    IndexType          index,
+    const ViewSpec_t & viewspec) const {
+    return std::array<IndexType, 1> {{ index + viewspec.offset(0) }};
   }
 
   /**

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -876,7 +876,7 @@ public:
     // Coordinates of the block containing the element:
     std::array<IndexType, NumDimensions> block_coords{};
     for (auto d = 0; d < NumDimensions; ++d) {
-      auto vs_coord     = global_coords[d] + viewspec.offset(d);
+      auto vs_coord     = view_coords[d] + viewspec.offset(d);
       phase_coords[d]   = vs_coord % _blocksize_spec.extent(d);
       block_coords[d]   = vs_coord / _blocksize_spec.extent(d);
     }
@@ -916,6 +916,7 @@ public:
     std::array<IndexType, NumDimensions> phase_coords;
     // Coordinates of the block containing the element:
     std::array<IndexType, NumDimensions> block_coords;
+
     for (auto d = 0; d < NumDimensions; ++d) {
       auto vs_coord     = global_coords[d];
       phase_coords[d]   = vs_coord % _blocksize_spec.extent(d);
@@ -1059,7 +1060,7 @@ public:
     DASH_LOG_TRACE_VAR("TilePattern.has_local_elements()", unit);
     DASH_LOG_TRACE_VAR("TilePattern.has_local_elements()", viewspec);
     // Apply viewspec offset in dimension to given position
-    dim_offset += viewspec[dim].offset;
+    dim_offset += viewspec.offset(dim);
     // Offset to block offset
     IndexType block_coord_d    = dim_offset / _blocksize_spec.extent(dim);
     DASH_LOG_TRACE_VAR("TilePattern.has_local_elements", block_coord_d);

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -823,7 +823,7 @@ public:
     }
     std::array<IndexType, NumDimensions> g_coords =
       global(_myid, l_coords);
-    auto offset = _memory_layout.at(g_coords);
+    auto offset = global_at(g_coords);
     DASH_LOG_TRACE_VAR("TilePattern.global >", offset);
     return offset;
   }

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -876,7 +876,7 @@ public:
     // Coordinates of the block containing the element:
     std::array<IndexType, NumDimensions> block_coords{};
     for (auto d = 0; d < NumDimensions; ++d) {
-      auto vs_coord     = view_coords[d] + viewspec.offset(d);
+      auto vs_coord     = global_coords[d] + viewspec.offset(d);
       phase_coords[d]   = vs_coord % _blocksize_spec.extent(d);
       block_coords[d]   = vs_coord / _blocksize_spec.extent(d);
     }

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -1417,25 +1417,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  constexpr const MemoryLayout_t & memory_layout() const {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  constexpr const LocalMemoryLayout_t & local_memory_layout() const {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -1452,8 +1433,39 @@ public:
    * \see DashPatternConcept
    */
   constexpr std::array<IndexType, NumDimensions> coords(
+    /// Global index (offset) to convert
     IndexType index) const {
-    return _memory_layout.coords(index);
+
+    ::std::array<IndexType, NumDimensions> pos{};
+    auto block_coords = _blockspec.coords(index / _blocksize_spec.size());
+    auto phase_coords = _blocksize_spec.coords(index % _blocksize_spec.size());
+    for (auto d = 0; d < NumDimensions; ++d) {
+      pos[d] = block_coords[d]*_blocksize_spec.extent(d) + phase_coords[d];
+    }
+    return pos;
+  }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates.
+   *
+   * \see DashPatternConcept
+   */
+  constexpr std::array<IndexType, NumDimensions> coords(
+    /// Global index (offset) to convert
+    IndexType index,
+    /// View specification (offsets) to apply on \c coords
+    const ViewSpec_t & viewspec) const {
+
+    ::std::array<IndexType, NumDimensions> pos;
+    auto block_coords = _blockspec.coords(index / _blocksize_spec.size(),
+                                          viewspec);
+    auto phase_coords = _blocksize_spec.coords(index % _blocksize_spec.size(),
+                                               viewspec);
+    for (auto d = 0; d < NumDimensions; ++d) {
+      pos[d] = block_coords[d]*_blocksize_spec.extent(d) + phase_coords[d];
+    }
+    return pos;
   }
 
   /**

--- a/dash/include/dash/pattern/TilePattern1D.h
+++ b/dash/include/dash/pattern/TilePattern1D.h
@@ -372,7 +372,7 @@ public:
     const ViewSpec_t & viewspec) const {
     DASH_LOG_TRACE_VAR("TilePattern<1>.unit_at()", coords);
     // Apply viewspec offsets to coordinates:
-    team_unit_t unit_id(((coords[0] + viewspec[0].offset) / _blocksize)
+    team_unit_t unit_id(((coords[0] + viewspec.offset(0)) / _blocksize)
                           % _nunits);
     DASH_LOG_TRACE_VAR("TilePattern<1>.unit_at >", unit_id);
     return unit_id;
@@ -404,7 +404,7 @@ public:
   ) const {
     DASH_LOG_TRACE_VAR("TilePattern<1>.unit_at()", global_pos);
     // Apply viewspec offsets to coordinates:
-    team_unit_t unit_id(((global_pos + viewspec[0].offset) / _blocksize)
+    team_unit_t unit_id(((global_pos + viewspec.offset(0)) / _blocksize)
                           % _nunits);
     DASH_LOG_TRACE_VAR("TilePattern<1>.unit_at >", unit_id);
     return unit_id;
@@ -485,7 +485,7 @@ public:
     const std::array<IndexType, NumDimensions> & local_coords,
     /// View specification (offsets) to apply on \c coords
     const ViewSpec_t & viewspec) const {
-    return local_coords[0] + viewspec[0].offset;
+    return local_coords[0] + viewspec.offset(0);
   }
 
   /**
@@ -712,7 +712,7 @@ public:
     const std::array<IndexType, NumDimensions> & g_coords,
     const ViewSpec_t & viewspec) const {
     auto vs_coords = g_coords;
-    vs_coords[0] += viewspec[0].offset;
+    vs_coords[0] += viewspec.offset(0);
     return local_coords(vs_coords)[0];
   }
 

--- a/dash/include/dash/pattern/TilePattern1D.h
+++ b/dash/include/dash/pattern/TilePattern1D.h
@@ -659,6 +659,31 @@ public:
     return global(unit, l_coords[0]);
   }
 
+  /**
+   * Convert given global coordinates and viewspec to linear global offset
+   * (index).
+   *
+   * \see DashPatternConcept
+   */
+  constexpr IndexType global_at(
+    /// Point in local memory
+    const std::array<IndexType, NumDimensions> & global_coords,
+    /// View specification (offsets) to apply on \c coords
+    const ViewSpec_t & viewspec) const {
+    return global_coords[0] + viewspec.offset(0);
+  }
+
+  /**
+   * Convert given global coordinates to linear global offset (index).
+   *
+   * \see DashPatternConcept
+   */
+  constexpr IndexType global_at(
+    /// Point in local memory
+    const std::array<IndexType, NumDimensions> & global_coords) const {
+    return global_coords[0];
+  }
+
   ////////////////////////////////////////////////////////////////////////////
   /// at
   ////////////////////////////////////////////////////////////////////////////
@@ -961,25 +986,6 @@ public:
   }
 
   /**
-   * Cartesian index space representing the underlying memory model of the
-   * pattern.
-   *
-   * \see DashPatternConcept
-   */
-  constexpr const MemoryLayout_t & memory_layout() const {
-    return _memory_layout;
-  }
-
-  /**
-   * Cartesian index space representing the underlying local memory model
-   * of this pattern for the calling unit.
-   * Not part of DASH Pattern concept.
-   */
-  constexpr const LocalMemoryLayout_t & local_memory_layout() const {
-    return _local_memory_layout;
-  }
-
-  /**
    * Cartesian arrangement of the Team containing the units to which this
    * pattern's elements are mapped.
    *
@@ -998,6 +1004,18 @@ public:
   std::array<IndexType, NumDimensions> coords(
     IndexType index) const {
     return std::array<IndexType, 1> {{ index }};
+  }
+
+  /**
+   * Convert given global linear offset (index) to global cartesian
+   * coordinates using viewspec.
+   *
+   * \see DashPatternConcept
+   */
+  std::array<IndexType, NumDimensions> coords(
+    IndexType          index,
+    const ViewSpec_t & viewspec) const {
+    return std::array<IndexType, 1> {{ index + viewspec.offset(0) }};
   }
 
   /**

--- a/dash/test/container/MatrixTest.cc
+++ b/dash/test/container/MatrixTest.cc
@@ -487,7 +487,7 @@ TEST_F(MatrixTest, Sub2DimDefault)
       auto l_coords   = pattern.local_coords(g_coords);
       auto unit_id    = pattern.unit_at(g_coords);
       auto local_idx  = pattern.local_at(l_coords);
-      auto global_idx = pattern.memory_layout().at(g_coords);
+      auto global_idx = pattern.global_at(g_coords);
       auto exp_value  = ((unit_id + 1) * 1000) + local_idx;
       bool is_local   = unit_id == pattern.team().myid();
       element_t value = column[row];


### PR DESCRIPTION
The conversion between coordinates and indices should not be done through directly throught the `CartesianIndexSpace` because that has no notion of tiles. 

To make things consistent, this PR removes the exposure of the `[local_]memory_layout` in the patterns and adds a missing `coords` member that takes a viewspec. All conversion should be done through the patterns as the results might differ from the conversion the `memory_layout` provides for some pattern types.

Fixes #620 