### PR TITLE
locality: Avoid `Conditional jump or move depends on uninitialised value`

### DIFF
--- a/dart-impl/base/src/internal/domain_locality.c
+++ b/dart-impl/base/src/internal/domain_locality.c
@@ -130,7 +130,7 @@ dart_ret_t dart__base__locality__domain__destruct(
     domain->unit_ids = NULL;
   }
   if (NULL != domain->aliases) {
-//  free(domain->aliases);
+    free(domain->aliases);
     domain->aliases  = NULL;
   }
   domain->num_domains = 0;

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -132,25 +132,19 @@ dart_ret_t dart__base__locality__create(
     "dash__base__locality__create(): "
     "locality data of team is already initialized");
 
-  dart_domain_locality_t * team_global_domain =
-    malloc(sizeof(dart_domain_locality_t));
+  dart_domain_locality_t * team_global_domain = NULL;
+  DART_ASSERT_RETURNS(dart__base__locality__create_domain(&team_global_domain), DART_OK);
   dart__base__locality__global_domain_[team] =
     team_global_domain;
 
   /* Initialize the global domain as the root entry in the locality
    * hierarchy:
    */
-  team_global_domain->scope          = DART_LOCALITY_SCOPE_GLOBAL;
-  team_global_domain->level          = 0;
-  team_global_domain->relative_index = 0;
-  team_global_domain->team           = team;
-  team_global_domain->parent         = NULL;
-  team_global_domain->num_domains    = 0;
-  team_global_domain->children       = NULL;
-  team_global_domain->num_units      = 0;
-  team_global_domain->host[0]        = '\0';
-  team_global_domain->domain_tag[0]  = '.';
-  team_global_domain->domain_tag[1]  = '\0';
+  team_global_domain->scope         = DART_LOCALITY_SCOPE_GLOBAL;
+  team_global_domain->team          = team;
+  team_global_domain->num_units     = 0;
+  team_global_domain->domain_tag[0] = '.';
+  team_global_domain->domain_tag[1] = '\0';
 
   size_t num_units = 0;
   DART_ASSERT_RETURNS(dart_team_size(team, &num_units), DART_OK);


### PR DESCRIPTION

```
Conditional jump or move depends on uninitialised value(s)
   at 0x145430: dart__base__locality__domain__destruct (domain_locality.c:133)
   by 0x14850C: dart__base__locality__delete (locality.c:227)
   by 0x148621: dart__base__locality__finalize (locality.c:85)
   by 0x1410D7: dart__mpi__locality_finalize (dart_locality_priv.c:37)
   by 0x140AA6: dart_exit (dart_initialization.c:292)
   by 0x13089A: dash::finalize() (Init.cc:96)
 Uninitialised value was created by a heap allocation
   at 0x4C2FB0F: malloc (vg_replace_malloc.c:299)
   by 0x148375: dart__base__locality__create (locality.c:135)
   by 0x141097: dart__mpi__locality_init (dart_locality_priv.c:22)
   by 0x1408A5: do_init (dart_initialization.c:205)
   by 0x140902: dart_init (dart_initialization.c:235)
   by 0x13036E: dash::init(int*, char***) (Init.cc:49)
```