### PR TITLE
Fix invocation of MPI_Win_get_attr

### DIFF
--- a/dart-impl/mpi/src/dart_globmem.c
+++ b/dart-impl/mpi/src/dart_globmem.c
@@ -171,13 +171,13 @@ dart_ret_t dart_memfree (dart_gptr_t gptr)
  */
 void dart__mpi__check_memory_model(dart_segment_info_t *segment)
 {
-  int mem_model, flag;
+  int *mem_model, flag;
   MPI_Win_get_attr(segment->win, MPI_WIN_MODEL, &mem_model, &flag);
 
   DART_ASSERT_MSG(flag != 0, "Failed to query window memory model!");
 
   segment->sync_needed = false;
-  if (mem_model != MPI_WIN_UNIFIED) {
+  if (*mem_model != MPI_WIN_UNIFIED) {
     static bool warning_printed = false;
     if (!warning_printed) {
       dart_global_unit_t myid;


### PR DESCRIPTION
`MPI_Win_get_attr` expects an `int**` behind the `void*` for `MPI_WIN_MODEL`. What a stupid interface which gives out a pointer to an integer instead of the integer itself?!

Thanks to @dhinf for reinserting this into my attention stream...