### PR TITLE
Rewrite dash::copy

### DIFF
--- a/dash/examples/bench.15.copy/main.cpp
+++ b/dash/examples/bench.15.copy/main.cpp
@@ -1,0 +1,223 @@
+/**
+ * Measures the performance of different
+ * for_each implementations on dash containers
+ */
+
+#include <libdash.h>
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <cmath>
+#ifdef MPI_IMPL_ID
+#include <mpi.h>
+#endif
+
+using std::cout;
+using std::endl;
+using std::setw;
+using std::setprecision;
+
+typedef dash::util::Timer<
+          dash::util::TimeMeasure::Clock
+        > Timer;
+
+typedef typename dash::util::BenchmarkParams::config_params_type
+  bench_cfg_params;
+
+using TeamSpecT = dash::TeamSpec<2>;
+using ValueT    = double;
+using MatrixT   = dash::NArray<ValueT, 2>;
+using PatternT  = typename MatrixT::pattern_type;
+using SizeSpecT = dash::SizeSpec<2>;
+using DistSpecT = dash::DistributionSpec<2>;
+
+typedef struct benchmark_params_t {
+
+  benchmark_params_t()
+  { }
+  int    reps        = 100;
+  int    rounds      = 10;
+  size_t matrix_ext  = 1024;
+  size_t tile_ext    = 64;
+} benchmark_params;
+
+typedef struct measurement_t {
+  std::string testcase;
+  double      time_total_s;
+} measurement;
+
+#ifdef HAVE_ASSERT
+#include <cassert>
+#define ASSERT_EQ(_e, _a) do {  \
+  assert((_e) == (_a));         \
+} while (0)
+#else
+#define ASSERT_EQ(_e, _a) do {  \
+  dash__unused(_e);             \
+  dash__unused(_a);             \
+} while (0)
+#endif
+
+void print_measurement_header();
+void print_measurement_record(
+  const bench_cfg_params & cfg_params,
+  std::string              name,
+  double                   time_in_us,
+  const benchmark_params & params);
+
+benchmark_params parse_args(int argc, char * argv[]);
+
+void print_params(
+  const dash::util::BenchmarkParams & bench_cfg,
+  const benchmark_params            & params);
+
+template<bool UseHandles>
+double evaluate(
+  int reps, MatrixT& matrix, ValueT *buffer,
+  benchmark_params params);
+
+int main(int argc, char** argv)
+{
+  dash::init(&argc, &argv);
+
+  Timer::Calibrate(0);
+
+  dash::util::BenchmarkParams bench_params("bench.15.copy");
+  bench_params.print_header();
+  bench_params.print_pinning();
+
+  benchmark_params params = parse_args(argc, argv);
+  auto bench_cfg = bench_params.config();
+
+  size_t matrix_ext = params.matrix_ext;
+  size_t tile_ext   = params.tile_ext;
+
+
+  auto& team_all = dash::Team::All();
+  TeamSpecT team_all_spec(team_all.size(), 1);
+  team_all_spec.balance_extents();
+
+  auto size_spec = SizeSpecT(matrix_ext, matrix_ext);
+  auto dist_spec = DistSpecT(dash::TILE(tile_ext), dash::TILE(tile_ext));
+
+  MatrixT matrix(size_spec, dist_spec, team_all, team_all_spec);
+
+  print_params(bench_params, params);
+  print_measurement_header();
+
+  int          round = 0;
+
+  ValueT *buffer = new ValueT[matrix.size()];
+
+  while(round < params.rounds) {
+    double res;
+    res = evaluate<true>(params.reps, matrix, buffer, params);
+    print_measurement_record(bench_cfg, "copy_with_handle", res, params);
+
+    res = evaluate<false>(params.reps, matrix, buffer, params);
+    print_measurement_record(bench_cfg, "copy_without_handle", res, params);
+    round++;
+  }
+
+  if (dash::myid() == 0) {
+    cout << "Benchmark finished" << endl;
+  }
+
+  dash::finalize();
+  return 0;
+}
+
+template<bool UseHandles>
+double evaluate(
+  int reps, MatrixT& matrix, ValueT *buffer,
+  benchmark_params params)
+{
+  measurement mes;
+
+  auto r = dash::myid();
+
+  auto begin = matrix.begin();
+  auto end   = matrix.end();
+
+  float lmin = r;
+  float lmax = 1000 - r;
+
+  auto ts_tot_start = Timer::Now();
+
+  for (int i = 0; i < reps; i++) {
+    dash::copy<ValueT, decltype(begin), UseHandles>(begin, end, buffer);
+  }
+
+  return Timer::ElapsedSince(ts_tot_start) / (double)reps / 1E6;
+}
+
+void print_measurement_header()
+{
+  if (dash::myid() == 0) {
+    cout << std::right
+         << std::setw( 5) << "units"      << ","
+         << std::setw( 9) << "mpi.impl"   << ","
+         << std::setw(30) << "impl"       << ","
+         << std::setw( 8) << "total.s"
+         << endl;
+  }
+}
+
+void print_measurement_record(
+  const bench_cfg_params & cfg_params,
+  std::string              name,
+  double                   time_in_us,
+  const benchmark_params & params)
+{
+  if (dash::myid() == 0) {
+    std::string mpi_impl = dash__toxstr(MPI_IMPL_ID);
+    cout << std::right
+         << std::setw(5) << dash::size() << ","
+         << std::setw(9) << mpi_impl     << ","
+         << std::fixed << setprecision(2) << setw(30) << name << ","
+         << std::fixed << setprecision(8) << setw(12) << time_in_us
+         << endl;
+  }
+}
+
+benchmark_params parse_args(int argc, char * argv[])
+{
+  benchmark_params params;
+
+  for (auto i = 1; i < argc; i += 2) {
+    std::string flag = argv[i];
+    if (flag == "-r") {
+      params.reps = atoi(argv[i+1]);
+    }
+    if (flag == "-n") {
+      params.rounds = atoi(argv[i+1]);
+    }
+    if (flag == "-t") {
+      params.tile_ext = atoi(argv[i+1]);
+    }
+    if (flag == "-s") {
+      params.matrix_ext = atoi(argv[i+1]);
+    }
+  }
+  return params;
+}
+
+void print_params(
+  const dash::util::BenchmarkParams & bench_cfg,
+  const benchmark_params            & params)
+{
+  if (dash::myid() != 0) {
+    return;
+  }
+
+  bench_cfg.print_section_start("Runtime arguments");
+  bench_cfg.print_param("-r", "repetitions per round", params.reps);
+  bench_cfg.print_param("-n", "rounds",                params.rounds);
+  bench_cfg.print_param("-s",
+                        "matrix size (number of double elements per dimension)",
+                        params.reps);
+  bench_cfg.print_param("-t",
+                        "tile size (number of double elements per dimension)",
+                        params.rounds);
+  bench_cfg.print_section_end();
+}

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -68,6 +68,8 @@ public:
 
   typedef GlobMemT memory_type;
 
+  typedef std::integral_constant<bool, false> has_view;
+
   /**
    * Rebind to a different type of pointer
    */

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -68,8 +68,6 @@ public:
 
   typedef GlobMemT memory_type;
 
-  typedef std::integral_constant<bool, false> has_view;
-
   /**
    * Rebind to a different type of pointer
    */

--- a/dash/include/dash/algorithm/Copy.h
+++ b/dash/include/dash/algorithm/Copy.h
@@ -168,8 +168,10 @@ ValueType * copy_impl(
 
     // handle local data locally
     if (cur_in.is_local()) {
-      // if the chunk is less than a cache line don't bother post-poning it
-      if (l2_line_size > num_copy_elem*sizeof(ValueType)) {
+      // if the chunk is less than a cache line or if it is the only transfer
+      // don't bother post-poning it
+      if (num_copy_elem == num_elem_total ||
+          l2_line_size > num_copy_elem*sizeof(ValueType)) {
         std::memcpy(dest_ptr, cur_in.local(), num_copy_elem*sizeof(ValueType));
       } else {
         // larger chunks are handled later to allow overlap
@@ -264,10 +266,12 @@ GlobOutputIt copy_impl(
 
     // handle local data locally
     if (cur_out_first.is_local()) {
-      // if the chunk is less than a cache line don't bother post-poning it
       nonconst_value_type* dest_ptr =
                         const_cast<nonconst_value_type*>(cur_out_first.local());
-      if (l2_line_size > num_copy_elem*sizeof(ValueType)) {
+      // if the chunk is less than a cache line or if it is the only transfer
+      // don't bother post-poning it
+      if (num_elem_total == num_copy_elem ||
+          l2_line_size > num_copy_elem*sizeof(ValueType)) {
         std::memcpy(dest_ptr, src_ptr, num_copy_elem*sizeof(ValueType));
       } else {
         // larger chunks are handled later to allow overlap

--- a/dash/include/dash/algorithm/Copy.h
+++ b/dash/include/dash/algorithm/Copy.h
@@ -105,9 +105,9 @@ namespace internal {
 
 template<typename ValueType>
 struct local_copy_chunk {
-  ValueType *src;
-  ValueType *dest;
-  size_t     size;
+  const ValueType *src;
+        ValueType *dest;
+  const size_t     size;
 };
 
 template<typename ValueType>

--- a/dash/include/dash/algorithm/Copy.h
+++ b/dash/include/dash/algorithm/Copy.h
@@ -106,7 +106,7 @@ void
 do_local_copies(std::vector<local_copy_chunk<ValueType>>& chunks)
 {
   for (auto& chunk : chunks) {
-    std::memcpy(chunk.dest, chunk.src, chunk.size*sizeof(ValueType));
+    std::copy(chunk.src, chunk.src + chunk.size, chunk.dest);
   }
 }
 
@@ -170,9 +170,10 @@ ValueType * copy_impl(
     if (cur_in.is_local()) {
       // if the chunk is less than a cache line or if it is the only transfer
       // don't bother post-poning it
+      auto src_ptr = cur_in.local();
       if (num_copy_elem == num_elem_total ||
           l2_line_size > num_copy_elem*sizeof(ValueType)) {
-        std::memcpy(dest_ptr, cur_in.local(), num_copy_elem*sizeof(ValueType));
+        std::copy(src_ptr, src_ptr + num_copy_elem, dest_ptr);
       } else {
         // larger chunks are handled later to allow overlap
         local_chunks.push_back({cur_in.local(), dest_ptr, num_copy_elem});
@@ -272,7 +273,7 @@ GlobOutputIt copy_impl(
       // don't bother post-poning it
       if (num_elem_total == num_copy_elem ||
           l2_line_size > num_copy_elem*sizeof(ValueType)) {
-        std::memcpy(dest_ptr, src_ptr, num_copy_elem*sizeof(ValueType));
+        std::copy(src_ptr, src_ptr + num_copy_elem, dest_ptr);
       } else {
         // larger chunks are handled later to allow overlap
         local_chunks.push_back({src_ptr, dest_ptr, num_copy_elem});

--- a/dash/include/dash/algorithm/Copy.h
+++ b/dash/include/dash/algorithm/Copy.h
@@ -387,8 +387,7 @@ dash::Future<ValueType *> copy_async(
     [=](ValueType ** out) mutable {
       int32_t flag;
       DASH_ASSERT_RETURNS(
-        DART_OK,
-        dart_testall_local(handles->data(), handles->size(), &flag));
+        dart_testall_local(handles->data(), handles->size(), &flag), DART_OK);
       if (flag) {
         handles->clear();
         *out = out_last;
@@ -399,8 +398,7 @@ dash::Future<ValueType *> copy_async(
     [=]() mutable {
       for (auto& handle : *handles) {
         DASH_ASSERT_RETURNS(
-          DART_OK,
-          dart_handle_free(&handle));
+          dart_handle_free(&handle), DART_OK);
       }
     }
   );
@@ -523,8 +521,7 @@ dash::Future<GlobOutputIt> copy_async(
     [=](GlobOutputIt *out) mutable {
       int32_t flag;
       DASH_ASSERT_RETURNS(
-        DART_OK,
-        dart_testall(handles->data(), handles->size(), &flag));
+        dart_testall(handles->data(), handles->size(), &flag), DART_OK);
       if (flag) {
         handles->clear();
         *out = out_last;
@@ -535,8 +532,7 @@ dash::Future<GlobOutputIt> copy_async(
     [=]() mutable {
       for (auto& handle : *handles) {
         DASH_ASSERT_RETURNS(
-          DART_OK,
-          dart_handle_free(&handle));
+          dart_handle_free(&handle), DART_OK);
       }
     }
   );

--- a/dash/include/dash/algorithm/Copy.h
+++ b/dash/include/dash/algorithm/Copy.h
@@ -454,7 +454,7 @@ ValueType * copy(
                                          out_first,
                                          nullptr);
     DASH_LOG_TRACE("dash::copy", "Waiting for remote transfers to complete");
-    dart_flush_local(in_first.dart_gptr());
+    dart_flush_local_all(in_first.dart_gptr());
   }
 
   DASH_LOG_TRACE("dash::copy >", "finished,",
@@ -578,7 +578,7 @@ GlobOutputIt copy(
                                          out_first,
                                          nullptr);
     DASH_LOG_TRACE("dash::copy", "Waiting for remote transfers to complete");
-    dart_flush(out_first.dart_gptr());
+    dart_flush_all(out_first.dart_gptr());
   }
   return out_last;
 }

--- a/dash/include/dash/algorithm/Copy.h
+++ b/dash/include/dash/algorithm/Copy.h
@@ -418,7 +418,7 @@ dash::Future<ValueType *> copy_async(
 template <
   typename ValueType,
   class    GlobInputIt,
-  bool     UseHandles = true >
+  bool     UseHandles = false >
 ValueType * copy(
   GlobInputIt   in_first,
   GlobInputIt   in_last,
@@ -551,7 +551,7 @@ dash::Future<GlobOutputIt> copy_async(
 template <
   typename ValueType,
   typename GlobOutputIt,
-  bool     UseHandles = true >
+  bool     UseHandles = false >
 GlobOutputIt copy(
   ValueType    * in_first,
   ValueType    * in_last,

--- a/dash/include/dash/iterator/GlobIter.h
+++ b/dash/include/dash/iterator/GlobIter.h
@@ -48,6 +48,7 @@ class GlobIter {
   using iterator_category = std::random_access_iterator_tag;
   using value_type        = ElementType;
   using difference_type   = typename PatternType::index_type;
+  using size_type         = typename PatternType::size_type;
   using pointer           = PointerType;
   using reference         = ReferenceType;
 

--- a/dash/include/dash/iterator/GlobViewIter.h
+++ b/dash/include/dash/iterator/GlobViewIter.h
@@ -92,6 +92,7 @@ public:
 
   typedef          PatternType                       pattern_type;
   typedef typename PatternType::index_type             index_type;
+  typedef typename PatternType::size_type               size_type;
 
 private:
   typedef GlobViewIter<

--- a/dash/include/dash/iterator/GlobViewIter.h
+++ b/dash/include/dash/iterator/GlobViewIter.h
@@ -1080,7 +1080,7 @@ std::ostream & operator<<(
           ElementType, Pattern, GlobStaticMem, Pointer, Reference> & it)
 {
   std::ostringstream ss;
-  Pointer ptr(it.globmem(), it.dart_gptr());
+  Pointer ptr(it.dart_gptr());
   ss << "dash::GlobViewIter<" << typeid(ElementType).name() << ">("
      << "idx:"  << it._idx << ", "
      << "gptr:" << ptr << ")";

--- a/dash/include/dash/iterator/internal/ContiguousRange.h
+++ b/dash/include/dash/iterator/internal/ContiguousRange.h
@@ -1,0 +1,404 @@
+#ifndef DASH__ITERATOR_INTERNAL_CONTIGUOUSRANGE_H__
+#define DASH__ITERATOR_INTERNAL_CONTIGUOUSRANGE_H__
+
+#include <dash/GlobPtr.h>
+#include <dash/internal/Macro.h>
+#include <dash/Exception.h>
+
+namespace dash {
+namespace internal {
+
+/**
+ * Iterator used to find consecutive memory ranges across a global memory range.
+ */
+template<typename IteratorT, bool HasView = IteratorT::has_view::value>
+struct ContiguousRangeIterator {
+
+public:
+  /// Iterator Traits
+  using iterator_category = std::forward_iterator_tag;
+  using pattern_type = typename IteratorT::pattern_type;
+  using index_type   = typename pattern_type::index_type;
+  using size_type    = typename pattern_type::size_type;
+  using value_type   = std::pair<IteratorT, size_type>;
+
+  using Self_t = ContiguousRangeIterator<IteratorT, HasView>;
+
+  DASH_CONSTEXPR ContiguousRangeIterator() = default;
+
+  ContiguousRangeIterator(IteratorT begin, IteratorT end)
+  : m_pos(begin),
+    m_end(end),
+    m_num_copy_elems(next_range().second)
+  { }
+
+  Self_t&
+  operator++() {
+    auto range = next_range();
+    m_pos            = range.first;
+    m_num_copy_elems = range.second;
+    return *this;
+  }
+
+  std::pair<IteratorT, size_type>
+  operator*() {
+    return std::make_pair(m_pos, m_num_copy_elems);
+  }
+
+  DASH_CONSTEXPR bool operator<(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos < other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator<=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos <= other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator>(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos > other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator>=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos >= other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator==(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return m_pos == other.m_pos;
+  }
+
+  DASH_CONSTEXPR bool operator!=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return m_pos != other.m_pos;
+  }
+
+
+private:
+
+  std::pair<IteratorT, size_type>
+  next_range() const {
+    auto cur_first = m_pos + m_num_copy_elems;
+    auto cur_last  = cur_first;
+    size_type num_copy_elem = 0;
+
+    const auto& pattern = cur_last.pattern();
+
+    // unit and local index of first element in current range segment:
+    auto local_pos      = pattern.local(static_cast<index_type>(
+                                            m_pos.pos()));
+    auto last_local_pos = local_pos;
+    do {
+      ++cur_last;
+      ++num_copy_elem;
+      auto pos = pattern.local(static_cast<index_type>(
+                                            cur_last.pos()));
+      if (m_end == cur_last ||
+          pos.unit  != local_pos.unit ||
+          pos.index != (last_local_pos.index + 1)) {
+        break;
+      }
+      last_local_pos = pos;
+    } while (1);
+
+    return std::make_pair(cur_last, num_copy_elem);
+  }
+
+
+private:
+
+  /// Start of the current contiguous range
+  IteratorT m_pos;
+  /// End position of the total range
+  const IteratorT m_end;
+  /// Number of elements in current contiguous range
+  size_type m_num_copy_elems = 0;
+};
+
+
+/**
+ * Specialization for non-view iterators.
+ */
+template<typename IteratorT>
+struct ContiguousRangeIterator<IteratorT, false> {
+
+public:
+  /// Iterator Traits
+  using iterator_category = std::forward_iterator_tag;
+  using pattern_type = typename IteratorT::pattern_type;
+  using index_type   = typename pattern_type::index_type;
+  using size_type    = typename pattern_type::size_type;
+  using value_type   = std::pair<IteratorT, size_type>;
+
+  using Self_t = ContiguousRangeIterator<IteratorT, false>;
+
+  DASH_CONSTEXPR ContiguousRangeIterator() = default;
+
+  ContiguousRangeIterator(IteratorT begin, IteratorT end)
+  : m_pos(begin),
+    m_end(end),
+    m_num_copy_elems(next_range().second)
+  { }
+
+  Self_t&
+  operator++() {
+    auto range = next_range();
+    m_pos            = range.first;
+    m_num_copy_elems = range.second;
+    return *this;
+  }
+
+  std::pair<IteratorT, size_type>
+  operator*() noexcept {
+    return std::make_pair(m_pos, m_num_copy_elems);
+  }
+
+  DASH_CONSTEXPR bool operator<(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos < other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator<=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos <= other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator>(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos > other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator>=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos >= other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator==(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return m_pos == other.m_pos;
+  }
+
+  DASH_CONSTEXPR bool operator!=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return m_pos != other.m_pos;
+  }
+
+private:
+
+  std::pair<IteratorT, size_type>
+  next_range() const {
+    auto cur_first = m_pos + m_num_copy_elems;
+    auto cur_last  = cur_first;
+    size_type num_copy_elem = 0;
+    constexpr const int ndim = pattern_type::ndim();
+    const auto& pattern = m_pos.pattern();
+    const int fast_dim = (pattern.memory_order() == dash::ROW_MAJOR) ? ndim - 1 : 0;
+    const size_type blocksize_d = pattern.blocksize(fast_dim);
+
+
+    auto lpos = m_pos.lpos();
+
+    do {
+
+      size_type blocksize = blocksize_d;
+
+      /* Determine coords and offset in first block */
+      auto global_coords = pattern.coords(cur_last.gpos());
+
+      // check in which block we currently are
+      auto block_coord_d   = global_coords[fast_dim] / blocksize;
+      auto phase_d         = global_coords[fast_dim] % blocksize;
+
+      // check for underful blocks at the end of the dimension
+      if (block_coord_d == (pattern.blockspec().extent(fast_dim) - 1)) {
+        blocksize = pattern.extent(fast_dim) - (block_coord_d * blocksize_d);
+      }
+
+      // the number of elements to copy is the blocksize minus the offset in the block
+      size_type num_copy_block_elem = blocksize - phase_d;
+
+      // don't try to copy too many elements
+      size_type elems_left = dash::distance(cur_last, m_end);
+      if (num_copy_block_elem > elems_left) {
+        num_copy_block_elem = elems_left;
+        // nothing more to do here
+        num_copy_elem += num_copy_block_elem;
+        break;
+      }
+
+      cur_last      += num_copy_block_elem;
+      auto next_lpos = cur_last.lpos();
+
+      num_copy_elem += num_copy_block_elem;
+      // check whether the contiguous range is over at the end of the block
+      if (cur_last == m_end ||
+          next_lpos.unit != lpos.unit ||
+          next_lpos.index != (lpos.index + 1)) {
+        break;
+      }
+
+    } while (1);
+
+    return std::make_pair(cur_first, num_copy_elem);
+  }
+
+
+private:
+
+  /// Start of the current contiguous range
+  IteratorT m_pos;
+  /// End position of the total range
+  const IteratorT m_end;
+  /// Number of elements in current contiguous range
+  size_type m_num_copy_elems = 0;
+};
+
+
+/**
+ * Specialization for non-view iterators.
+ */
+template<typename ValueType, typename GlobMemT>
+struct ContiguousRangeIterator<dash::GlobPtr<ValueType, GlobMemT>, false> {
+
+public:
+  /// Iterator Traits
+  using iterator_category = std::forward_iterator_tag;
+  using pointer_type = typename dash::GlobPtr<ValueType, GlobMemT>;
+  using index_type   = typename pointer_type::index_type;
+  using size_type    = typename pointer_type::size_type;
+  using value_type   = std::pair<pointer_type, size_type>;
+
+  using Self_t = ContiguousRangeIterator<pointer_type, false>;
+
+  DASH_CONSTEXPR ContiguousRangeIterator() = default;
+
+  ContiguousRangeIterator(pointer_type begin, pointer_type end)
+  : m_pos(begin),
+    m_end(end),
+    m_num_copy_elems(next_range().second)
+  { }
+
+  Self_t&
+  operator++() {
+    auto range = next_range();
+    m_pos            = range.first;
+    m_num_copy_elems = range.second;
+    return *this;
+  }
+
+  std::pair<pointer_type, size_type>
+  operator*() noexcept {
+    return std::make_pair(m_pos, m_num_copy_elems);
+  }
+
+  DASH_CONSTEXPR bool operator<(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos < other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator<=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos <= other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator>(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos > other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator>=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return (m_pos >= other.m_pos);
+  }
+
+  DASH_CONSTEXPR bool operator==(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return m_pos == other.m_pos;
+  }
+
+  DASH_CONSTEXPR bool operator!=(const Self_t& other) const DASH_NOEXCEPT
+  {
+    return m_pos != other.m_pos;
+  }
+
+private:
+
+  std::pair<pointer_type, size_type>
+  next_range() const {
+    auto cur_first = m_pos + m_num_copy_elems;
+    auto cur_last  = cur_first;
+    size_type num_copy_elem = 0;
+
+    dart_gptr_t gptr = m_pos.dart_gptr();
+
+
+    auto& reg = dash::internal::MemorySpaceRegistry::GetInstance();
+    auto const * mem_space = static_cast<const GlobMemT *>(reg.lookup(gptr));
+
+    if (mem_space == nullptr) {
+      // TODO: how to handle this?
+    }
+
+    // treat offsets and sizes in Bytes, convert as late as possible
+    size_type offs = gptr.addr_or_offs.offset;
+    dash::team_unit_t current_uid{gptr.unitid};
+    size_type size_at_unit = mem_space->capacity(current_uid);
+    DASH_ASSERT_LT(offs*sizeof(value_type), size_at_unit,
+                   "Global pointer points beyond local unit!");
+
+    size_type size_left_at_unit = size_at_unit - offs;
+    size_type elems_left = dash::distance(m_pos, m_end);
+
+
+    // check if there is enough space at the current unit
+    if (elems_left*sizeof(value_type) <= size_left_at_unit) {
+      num_copy_elem = elems_left;
+    } else {
+      // go to end of current unit
+      num_copy_elem = size_left_at_unit / sizeof(value_type);
+    }
+    return std::make_pair(cur_first, num_copy_elem);
+  }
+
+
+private:
+
+  /// Start of the current contiguous range
+  pointer_type m_pos;
+  /// End position of the total range
+  const pointer_type m_end;
+  /// Number of elements in current contiguous range
+  size_type m_num_copy_elems = 0;
+};
+
+
+template<typename IteratorT>
+struct ContiguousRangeSet {
+
+  using iterator_type = ContiguousRangeIterator<IteratorT>;
+
+  ContiguousRangeSet(IteratorT begin, IteratorT end)
+  : m_range_begin(begin), m_range_end(end), m_end(end, end)
+  { }
+
+  iterator_type begin() const {
+    return iterator_type(m_range_begin, m_range_end);
+  }
+
+  iterator_type end() const {
+    return m_end;
+  }
+
+private:
+  const IteratorT m_range_begin;
+  const IteratorT m_range_end;
+
+  const iterator_type m_end;
+};
+
+} // namespace internal
+} // namespace dash
+
+#endif // DASH__ITERATOR_INTERNAL_CONTIGUOUSRANGE_H__

--- a/dash/include/dash/iterator/internal/GlobPtrBase.h
+++ b/dash/include/dash/iterator/internal/GlobPtrBase.h
@@ -208,11 +208,12 @@ dart_gptr_t increment(
     memory_space_contiguous) DASH_NOEXCEPT
 {
   using value_type = T;
-
+  if (mem_space == nullptr) {
+    return gptr;
+  }
   auto const gend = static_cast<dart_gptr_t>(mem_space->end());
 
-  if (mem_space == nullptr ||
-      distance<T>(gptr, gend, mem_space, memory_space_contiguous{}) <= 0) {
+  if (distance<T>(gptr, gend, mem_space, memory_space_contiguous{}) <= 0) {
     return gptr;
   }
 

--- a/dash/test/algorithm/CopyTest.cc
+++ b/dash/test/algorithm/CopyTest.cc
@@ -1019,3 +1019,24 @@ TEST_F(CopyTest, MatrixToSmallerTeam)
 
   }
 }
+
+TEST_F(CopyTest, InputOutputTypeTest)
+{
+  /* signed/unsigned and const conversion is permitted */
+  ASSERT_TRUE_U((dash::internal::is_dash_copyable<int, int>::value));
+  ASSERT_TRUE_U((dash::internal::is_dash_copyable<const int, int>::value));
+  ASSERT_TRUE_U((dash::internal::is_dash_copyable<const int, unsigned int>::value));
+  ASSERT_TRUE_U((dash::internal::is_dash_copyable<float, float>::value));
+  /* size conversion is not permitted */
+  ASSERT_FALSE_U((dash::internal::is_dash_copyable<uint64_t, uint32_t>::value));
+  ASSERT_FALSE_U((dash::internal::is_dash_copyable<float, double>::value));
+
+  struct point_t {
+    int a;
+    int b;
+  };
+  /* no conversion between arithmetic types and non-arithmetic types */
+  ASSERT_FALSE_U((dash::internal::is_dash_copyable<point_t, uint64_t>::value));
+  ASSERT_TRUE_U((dash::internal::is_dash_copyable<const point_t, point_t>::value));
+
+}

--- a/dash/test/pattern/CSRPatternTest.cc
+++ b/dash/test/pattern/CSRPatternTest.cc
@@ -87,7 +87,6 @@ TEST_F(CSRPatternTest, CopyGlobalToLocal) {
     local_sizes.push_back(tmp);
     sum += tmp;
   }
-  auto max_local_size = local_sizes.back();
 
   DASH_LOG_DEBUG_VAR("CSRPatternTest.InitArray", local_sizes);
 


### PR DESCRIPTION
This PR addresses #657  and #656 by making `dash::copy` adhere to the iteration space of the iterators passed. This requires splitting up the copy into transfers to/from contiguous global memory regions. 

Copying should now be correct for both global-to-local and local-to-global. Larger (>1 cache line size, maybe better be a pagesize?) local copies are deferred until all remote transfers are kicked off in an attempt to overlap remote and local copies.

~For `GlobIter` and `GlobPtr` the detection of contiguous memory regions is fairly straightforward, for `GlobViewIter` (or any view-based iterator)  finding boundaries of contiguous regions is in O(n). Ideas on how to improve that are welcome (@fuchsto @dhinf @rkowalewski can the viewspec be used for that?)~
All iterators (except for `GlobPtr`) make use of views to find contiguous memory boundaries,