### PR TITLE
Fix silent memory corruption in DART locality

### DIFF
--- a/dart-impl/base/include/dash/dart/base/macro.h
+++ b/dart-impl/base/include/dash/dart/base/macro.h
@@ -41,4 +41,14 @@
 #define DART_INTERNAL
 #endif
 
+/* Static Assertion Macro */
+#if __STDC_VERSION__ == 201112L
+#define _STATIC_ASSERT(COND,MSG) _Static_assert(COND, MSG)
+#else
+#define _STATIC_ASSERT(COND,MSG) typedef char static_assertion[(!!(COND))*2-1]
+#endif
+#define DART_STATIC_ASSERT(x)           _STATIC_ASSERT(x,dart__toxstr(x))
+#define DART_STATIC_ASSERT_MSG(x, msg)  _STATIC_ASSERT(x, msg)
+
+
 #endif /* DART__BASE__MACRO_H_ */

--- a/dart-impl/base/include/dash/dart/base/macro.h
+++ b/dart-impl/base/include/dash/dart/base/macro.h
@@ -42,7 +42,7 @@
 #endif
 
 /* Static Assertion Macro */
-#if __STDC_VERSION__ == 201112L
+#if __STDC_VERSION__ >= 201112L
 #define _STATIC_ASSERT(COND,MSG) _Static_assert(COND, MSG)
 #else
 #define _STATIC_ASSERT(COND,MSG) typedef char static_assertion[(!!(COND))*2-1]

--- a/dart-impl/base/src/locality.c
+++ b/dart-impl/base/src/locality.c
@@ -121,7 +121,6 @@ dart_ret_t dart__base__locality__finalize()
   free(dart__base__locality__unit_mapping_);
   dart__base__locality__unit_mapping_  = NULL;
 
-  dart_barrier(DART_TEAM_ALL);
   return DART_OK;
 }
 


### PR DESCRIPTION
This PR enables the creation of more than 32 teams without silently corrupting memory through oob writes (apparently people need that, who would have thought...) by allocating sufficient space for all possible teams (that's currently 768kB of mostly wasted memory). Since the locality stuff is being overhauled anyway there is no sense in creating a more  sophisticated solution atm.

Fixes #661 