### PR TITLE
Leave context empty in single-argument DASH_LOG_* macros calls

### DIFF
--- a/dash/include/dash/Mutex.h
+++ b/dash/include/dash/Mutex.h
@@ -39,6 +39,7 @@ private:
 
         if (ret != DART_OK) {
           DASH_LOG_ERROR(
+              "dash::Mutex::operator()",
               "Failed to destroy DART lock! "
               "(dart_team_lock_destroy failed)");
         }

--- a/dash/include/dash/Shared.h
+++ b/dash/include/dash/Shared.h
@@ -182,7 +182,7 @@ public:
     // If our Shared has already a non-null pointer let us return it. The user
     // has first to deallocate it.
     if (m_glob_pointer) {
-      DASH_LOG_ERROR("Shared scalar is already initialized");
+      DASH_LOG_ERROR("dash::Shared::init", "Shared scalar is already initialized");
       return false;
     }
 

--- a/dash/include/dash/Team.h
+++ b/dash/include/dash/Team.h
@@ -183,7 +183,7 @@ public:
 
     if (_group != DART_GROUP_NULL) {
       if (DART_OK != dart_group_destroy(&_group)) {
-        DASH_LOG_ERROR("Failed to destroy DART group!");
+        DASH_LOG_ERROR("dash::Team d'tor", "Failed to destroy DART group!");
       }
     }
 
@@ -202,7 +202,7 @@ public:
         DART_TEAM_ALL  != _dartid) {
       if (DART_OK != dart_team_destroy(&_dartid))
       {
-        DASH_LOG_ERROR("Failed to destroy DART group!");
+        DASH_LOG_ERROR("dash::Team d'tor", "Failed to destroy DART group!");
       }
     }
   }
@@ -630,6 +630,12 @@ private:
 bool operator==(
   const Team::Deallocator & lhs,
   const Team::Deallocator & rhs);
+
+class TeamPtr {
+
+  std::shared_ptr<Team*> _teamptr;
+
+}; // class TeamPtr
 
 }  // namespace dash
 

--- a/dash/include/dash/algorithm/Reduce.h
+++ b/dash/include/dash/algorithm/Reduce.h
@@ -120,7 +120,7 @@ reduce(
     g_result.valid = true;
   }
   if (!g_result.valid) {
-    DASH_LOG_ERROR("Found invalid reduction value!");
+    DASH_LOG_ERROR("dash::reduce()", "Found invalid reduction value!");
   }
   auto result = g_result.value;
 

--- a/dash/include/dash/internal/Logging.h
+++ b/dash/include/dash/internal/Logging.h
@@ -40,17 +40,17 @@
 //
 // Always log error and warning messages:
 //
-#define DASH_LOG_ERROR(context, ...) \
+#define DASH_LOG_ERROR(...) \
   dash::internal::logging::LogWrapper(\
-    "ERROR", __FILE__, __LINE__, context, __VA_ARGS__)
+    "ERROR", __FILE__, __LINE__, __VA_ARGS__)
 
 #define DASH_LOG_ERROR_VAR(context, var) \
   dash::internal::logging::LogVarWrapper(\
     "ERROR", __FILE__, __LINE__, context, #var, (var))
 
-#define DASH_LOG_WARN(context, ...) \
+#define DASH_LOG_WARN(...) \
   dash::internal::logging::LogWrapper(\
-    "WARN ", __FILE__, __LINE__, context, __VA_ARGS__)
+    "WARN ", __FILE__, __LINE__, __VA_ARGS__)
 
 #define DASH_LOG_WARN_VAR(context, var) \
   dash::internal::logging::LogVarWrapper(\
@@ -60,9 +60,9 @@
 // Debug and trace log messages:
 //
 #if defined(DASH_ENABLE_LOGGING)
-#  define DASH_LOG_DEBUG(context, ...) \
+#  define DASH_LOG_DEBUG(...) \
      dash::internal::logging::LogWrapper(\
-       "DEBUG", __FILE__, __LINE__, context, __VA_ARGS__)
+       "DEBUG", __FILE__, __LINE__, __VA_ARGS__)
 
 #  define DASH_LOG_DEBUG_VAR(context, var) \
      dash::internal::logging::LogVarWrapper(\
@@ -70,9 +70,9 @@
 
 #  if defined(DASH_ENABLE_TRACE_LOGGING)
 
-#    define DASH_LOG_TRACE(context, ...) \
+#    define DASH_LOG_TRACE(...) \
        dash::internal::logging::LogWrapper(\
-         "TRACE", __FILE__, __LINE__, context, __VA_ARGS__)
+         "TRACE", __FILE__, __LINE__, __VA_ARGS__)
 
 #    define DASH_LOG_TRACE_VAR(context, var) \
        dash::internal::logging::LogVarWrapper(\

--- a/dash/include/dash/internal/Logging.h
+++ b/dash/include/dash/internal/Logging.h
@@ -40,17 +40,17 @@
 //
 // Always log error and warning messages:
 //
-#define DASH_LOG_ERROR(...) \
+#define DASH_LOG_ERROR(context, ...) \
   dash::internal::logging::LogWrapper(\
-    "ERROR", __FILE__, __LINE__, __VA_ARGS__)
+    "ERROR", __FILE__, __LINE__, context, __VA_ARGS__)
 
 #define DASH_LOG_ERROR_VAR(context, var) \
   dash::internal::logging::LogVarWrapper(\
     "ERROR", __FILE__, __LINE__, context, #var, (var))
 
-#define DASH_LOG_WARN(...) \
+#define DASH_LOG_WARN(context, ...) \
   dash::internal::logging::LogWrapper(\
-    "WARN ", __FILE__, __LINE__, __VA_ARGS__)
+    "WARN ", __FILE__, __LINE__, context, __VA_ARGS__)
 
 #define DASH_LOG_WARN_VAR(context, var) \
   dash::internal::logging::LogVarWrapper(\
@@ -60,9 +60,9 @@
 // Debug and trace log messages:
 //
 #if defined(DASH_ENABLE_LOGGING)
-#  define DASH_LOG_DEBUG(...) \
+#  define DASH_LOG_DEBUG(context, ...) \
      dash::internal::logging::LogWrapper(\
-       "DEBUG", __FILE__, __LINE__, __VA_ARGS__)
+       "DEBUG", __FILE__, __LINE__, context, __VA_ARGS__)
 
 #  define DASH_LOG_DEBUG_VAR(context, var) \
      dash::internal::logging::LogVarWrapper(\
@@ -70,9 +70,9 @@
 
 #  if defined(DASH_ENABLE_TRACE_LOGGING)
 
-#    define DASH_LOG_TRACE(...) \
+#    define DASH_LOG_TRACE(context, ...) \
        dash::internal::logging::LogWrapper(\
-         "TRACE", __FILE__, __LINE__, __VA_ARGS__)
+         "TRACE", __FILE__, __LINE__, context, __VA_ARGS__)
 
 #    define DASH_LOG_TRACE_VAR(context, var) \
        dash::internal::logging::LogVarWrapper(\

--- a/dash/src/Logging.cc
+++ b/dash/src/Logging.cc
@@ -49,10 +49,15 @@ void Log_Recursive(
   const char* context_tag,
   std::ostringstream & msg)
 {
-  std::istringstream ss(msg.str());
-  std::string item;
-  while (std::getline(ss, item)) {
-    Log_Line(level, file, line, context_tag, item);
+  std::string msg_str = msg.str();
+  if (msg_str.empty()) {
+    Log_Line(level, file, line, "", context_tag);
+  } else {
+    std::istringstream ss(msg_str);
+    std::string item;
+    while (std::getline(ss, item)) {
+      Log_Line(level, file, line, context_tag, item);
+    }
   }
   (DASH_LOG_OUTPUT_TARGET).flush();
 }

--- a/dash/src/Mutex.cc
+++ b/dash/src/Mutex.cc
@@ -11,7 +11,9 @@ Mutex::Mutex(Team& team)
 
 bool Mutex::init() {
   if (dart_lock_initialized(_mutex.get())) {
-    DASH_LOG_ERROR("DART lock is already initialized");
+    DASH_LOG_ERROR(
+        "dash::Mutex::init()",
+        "DART lock is already initialized");
     return false;
   }
   if (*_team != dash::Team::Null() && dash::is_initialized()) {
@@ -20,6 +22,7 @@ bool Mutex::init() {
 
     if (ret != DART_OK) {
         DASH_LOG_ERROR(
+            "dash::Mutex::init()",
             "Failed to initialize DART lock! "
             "(dart_team_lock_init failed)");
         return false;


### PR DESCRIPTION
Otherwise messages without a context won't be printed...