### PR TITLE
avoid non-standard `__attribute__`, instead use C++ `alignas`

### DIFF
--- a/dash/include/cpp17/polymorphic_allocator.h
+++ b/dash/include/cpp17/polymorphic_allocator.h
@@ -141,16 +141,16 @@ struct aligned_chunk<8> {
   long long x;
 };
 template <>
-struct aligned_chunk<16> {
-  __attribute__((aligned(16))) char x;
+struct alignas(16) aligned_chunk<16> {
+  char x;
 };
 template <>
-struct aligned_chunk<32> {
-  __attribute__((aligned(32))) char x;
+struct alignas(16) aligned_chunk<32> {
+  char x;
 };
 template <>
-struct aligned_chunk<64> {
-  __attribute__((aligned(64))) char x;
+struct alignas(16) aligned_chunk<64> {
+  char x;
 };
 
 // Adaptor to make a polymorphic allocator resource type from an STL allocator


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/language/alignas

Fixes #665