### PR TITLE
Move 'make sure dynamic windows are enabled` define into .c file

### DIFF
--- a/dart-if/include/dash/dart/if/dart_globmem.h
+++ b/dart-if/include/dash/dart/if/dart_globmem.h
@@ -16,12 +16,6 @@
 #include <dash/dart/if/dart_types.h>
 #include <dash/dart/if/dart_team_group.h>
 
-// make sure dynamic windows are enabled if shared windows are not disabled
-#if !defined(DART_MPI_DISABLE_SHARED_WINDOWS) && \
-    !defined(DART_MPI_ENABLE_DYNAMIC_WINDOWS)
-#define DART_MPI_ENABLE_DYNAMIC_WINDOWS
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/dart-impl/mpi/src/dart_globmem.c
+++ b/dart-impl/mpi/src/dart_globmem.c
@@ -29,6 +29,12 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+// make sure dynamic windows are enabled if shared windows are not disabled
+#if !defined(DART_MPI_DISABLE_SHARED_WINDOWS) && \
+    !defined(DART_MPI_ENABLE_DYNAMIC_WINDOWS)
+#define DART_MPI_ENABLE_DYNAMIC_WINDOWS
+#endif
+
 /**
  * TODO: add this window to the team_data for DART_TEAM_ALL as segment 0.
  */


### PR DESCRIPTION
The `DART_MPI_ENABLE_DYNAMIC_WINDOWS` is only used inside the .c file,
so why adding the fallback into the .h file. Worth, the header is
installed and used by the header-lib part of DASH
`dash/include/dash/iterator/internal/GlobPtrBase.h`. Thus it gives the
impression, that you could change the value of
`DART_MPI_ENABLE_DYNAMIC_WINDOWS` after the installation of DASH.