### PR TITLE
Fix compilation issues #682 hwloc 2.x and likwid

### DIFF
--- a/dart-if/include/dash/dart/if/dart_types.h
+++ b/dart-if/include/dash/dart/if/dart_types.h
@@ -376,6 +376,8 @@ typedef struct
 
     int   numa_id;
 
+    int   num_sockets;
+
     /** The unit's affine core, unique identifier within a processing
      *  module. */
     int   core_id;

--- a/dart-impl/base/src/hwinfo.c
+++ b/dart-impl/base/src/hwinfo.c
@@ -316,13 +316,21 @@ dart_ret_t dart_hwinfo(
   if(hw.system_memory_bytes < 0) {
     hwloc_obj_t obj;
     obj = hwloc_get_obj_by_type(topology, HWLOC_OBJ_MACHINE, 0);
+#if HWLOC_API_VERSION < 0x00020000
     hw.system_memory_bytes = obj->memory.total_memory / BYTES_PER_MB;
+#else
+    hw.system_memory_bytes = obj->total_memory / BYTES_PER_MB;
+#endif
   }
   if(hw.numa_memory_bytes < 0) {
     hwloc_obj_t obj;
     obj = hwloc_get_obj_by_type(topology, DART__HWLOC_OBJ_NUMANODE, 0);
     if(obj != NULL) {
+#if HWLOC_API_VERSION < 0x00020000
       hw.numa_memory_bytes = obj->memory.total_memory / BYTES_PER_MB;
+#else
+      hw.numa_memory_bytes = obj->total_memory / BYTES_PER_MB;
+#endif
     } else {
       /* No NUMA domain: */
       hw.numa_memory_bytes = hw.system_memory_bytes;

--- a/dart-impl/base/src/hwinfo.c
+++ b/dart-impl/base/src/hwinfo.c
@@ -289,7 +289,13 @@ dart_ret_t dart_hwinfo(
     }
   }
   if (hw.num_sockets < 0) {
-    int n_sockets = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PACKAGE);
+    int n_sockets = hwloc_get_nbobjs_by_type(topology, 
+#if HWLOC_API_VERSION > 0x00011000
+                 HWLOC_OBJ_PACKAGE
+#else
+                 HWLOC_OBJ_SOCKET
+#endif
+    );
     if (n_sockets > 0) {
       hw.num_sockets = n_sockets;
     }

--- a/dart-impl/base/src/hwinfo.c
+++ b/dart-impl/base/src/hwinfo.c
@@ -363,7 +363,10 @@ dart_ret_t dart_hwinfo(
       hw.max_cpu_mhz = info->clock;
     }
     if (hw.num_numa < 0) {
-      hw.num_numa    = hw.num_sockets;
+      hw.num_numa    = likwid_getNumberOfNodes();
+    }
+    if (hw.num_sockets < 0) {
+      hw.num_sockets = topo->numSockets;
     }
     if (hw.num_cores < 0) {
       hw.num_cores   = topo->numCoresPerSocket * hw.num_sockets;


### PR DESCRIPTION
This PR proposes portability fixes referent to issue #682. Tested sucessful combinations are:
- hwloc 1.11 + likwid 4.3.2
- hwloc 2.0

I think other versions should also work.