### PR TITLE
Add local_blockspec() call to 1D TilePattern specialization

### DIFF
--- a/dash/include/dash/Pattern.h
+++ b/dash/include/dash/Pattern.h
@@ -48,7 +48,8 @@ namespace dash {
  * <tt>index</tt>           | <tt>global</tt>            | <tt>unit u, index li</tt>       | Local offset <i>li</i> of unit <i>u</i> to global index                                                    |
  * <tt>index</tt>           | <tt>global</tt>            | <tt>index li</tt>               | Local offset <i>li</i> of active unit to global index                                                      |
  * <b>blocks</b>            | &nbsp;                     | &nbsp;                          | &nbsp;                                                                                                     |
- * <tt>size[d]</tt>         | <tt>blockspec</tt>         | &nbsp;                          | Number of blocks in all dimensions.                                                                        |
+ * <tt>size[d]</tt>         | <tt>blockspec</tt>         | &nbsp;                          | Number of blocks in all dimensions.                                          |
+ * <tt>size[d]</tt>         | <tt>local_blockspec</tt>   | &nbsp;                          | Number of local blocks in all dimensions.                                                                          |
  * <tt>index</tt>           | <tt>block_at</tt>          | <tt>index[d] gp</tt>            | Global index of block at global coordinates <i>gp</i>                                                      |
  * <tt>viewspec</tt>        | <tt>block</tt>             | <tt>index gbi</tt>              | Offset and extent in global cartesian space of block at global block index <i>gbi</i>                      |
  * <tt>viewspec</tt>        | <tt>local_block</tt>       | <tt>index lbi</tt>              | Offset and extent in global cartesian space of block at local block index <i>lbi</i>                       |

--- a/dash/include/dash/pattern/ShiftTilePattern1D.h
+++ b/dash/include/dash/pattern/ShiftTilePattern1D.h
@@ -916,9 +916,9 @@ public:
   }
 
   /**
-   * Cartesian arrangement of pattern blocks.
+   * Cartesian arrangement of local pattern blocks.
    */
-  const BlockSpec_t & local_blockspec() const
+  const BlockSpec_t local_blockspec() const
   {
     return BlockSpec_t(_nlblocks);
   }

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -1295,7 +1295,7 @@ public:
   }
 
   /**
-   * Cartesian arrangement of pattern blocks.
+   * Cartesian arrangement of local pattern blocks.
    */
   constexpr const BlockSpec_t & local_blockspec() const
   {

--- a/dash/include/dash/pattern/TilePattern1D.h
+++ b/dash/include/dash/pattern/TilePattern1D.h
@@ -796,9 +796,15 @@ public:
    * Cartesian arrangement of pattern blocks.
    */
   constexpr BlockSpec_t blockspec() const {
-    return BlockSpec_t({ dash::math::div_ceil(_size, _blocksize) });
+    return BlockSpec_t({ _nblocks });
   }
 
+  /**
+   * Cartesian arrangement of local pattern blocks.
+   */
+  constexpr BlockSpec_t local_blockspec() const {
+    return BlockSpec_t({ _nlblocks });
+  }
   /**
    * Index of block at given global coordinates.
    *


### PR DESCRIPTION
This is needed for the HDF5 integration to work correctly.

See #692 