### PR TITLE
Test cases for StoreHDF5 read and write for issue #692

### DIFF
--- a/dart-impl/base/src/hwinfo.c
+++ b/dart-impl/base/src/hwinfo.c
@@ -11,7 +11,7 @@
 
 #define CPUID(INFO, LEAF, SUBLEAF) __cpuid_count(LEAF, SUBLEAF, INFO[0], INFO[1], INFO[2], INFO[3])
 
-static int osx_sched_getcpu() {                              
+static int osx_sched_getcpu() {
   uint32_t CPUInfo[4]; 
   int cpuid;                          
   CPUID(CPUInfo, 1, 0);                          
@@ -400,17 +400,17 @@ dart_ret_t dart_hwinfo(
   }
 #endif /* DART_ENABLE_PAPI */
 
-if (hw.cpu_id < 0) {
-  #ifdef DART__PLATFORM__LINUX
+  if (hw.cpu_id < 0) {
+#ifdef DART__PLATFORM__LINUX
     hw.cpu_id = sched_getcpu();
-  #elif defined(DART__PLATFORM__OSX)
+#elif defined(DART__PLATFORM__OSX)
     hw.cpu_id = osx_sched_getcpu();
-  #else
+#else
     DART_LOG_ERROR("dart_hwinfo: "
-                "HWLOC or PAPI required if not running on a Linux or OSX platform");
+                   "HWLOC or PAPI required if not running on a Linux or OSX platform");
     return DART_ERR_OTHER;
-  #endif
-}
+#endif
+  }
 
 #ifdef DART__ARCH__IS_MIC
   /*

--- a/dash/test/io/HDF5MatrixTest.cc
+++ b/dash/test/io/HDF5MatrixTest.cc
@@ -515,43 +515,6 @@ TEST_F(HDF5MatrixTest, GroupTest) {
   verify_matrix(matrix_c, secret[2]);
 }
 
-TEST_F(HDF5MatrixTest, ReadAndWriteDashMatrix1D) {
-  auto numunits = dash::Team::All().size();
-
-  // Add some randomness to the data
-  std::srand(time(NULL));
-  int local_secret = std::rand() % 1000;
-  int myid = dash::myid();
-
-  typedef dash::Matrix<value_t, 1> matrix_t;
-
-  int extend = 1000;  
-  auto size_spec = dash::SizeSpec<1>(extend);
-
-  DASH_LOG_DEBUG("Pattern", pattern1d);
-  {
-    matrix_t mat1(size_spec);
-    dash::barrier();
-    LOG_MESSAGE("Matrix created");
-
-    fill_matrix(mat1, local_secret);
-    dash::barrier();
-    DASH_LOG_DEBUG("BEGIN STORE HDF");
-
-    StoreHDF::write(mat1, _filename, _dataset);
-
-    DASH_LOG_DEBUG("END STORE HDF");
-    dash::barrier();
-  }
-
-  matrix_t mat1_verified(size_spec);
-  dash::barrier();
-  StoreHDF::read(mat1_verified, _filename, _dataset);
-  dash::barrier();
-
-  verify_matrix(mat1_verified, local_secret);
-}
-
 TEST_F(HDF5MatrixTest, ReadAndWriteDashMatrix2D) {
   auto numunits = dash::Team::All().size();
 

--- a/dash/test/io/HDF5MatrixTest.cc
+++ b/dash/test/io/HDF5MatrixTest.cc
@@ -563,9 +563,6 @@ TEST_F(HDF5MatrixTest, ReadAndWriteDashMatrix2D) {
   typedef dash::TilePattern<2, dash::ROW_MAJOR, long> pattern_t;
   typedef dash::Matrix<value_t, 2, typename pattern_t::index_type, pattern_t> matrix_t;
 
-  typedef dash::TilePattern<2, dash::ROW_MAJOR, unsigned long> upattern_t;
-  typedef dash::Matrix<value_t, 2, typename upattern_t::index_type, upattern_t> umatrix_t;
-
   //test default type
   dash::TeamSpec<2, pattern_t::index_type> team_spec(numunits, 1);
   team_spec.balance_extents();
@@ -599,10 +596,25 @@ TEST_F(HDF5MatrixTest, ReadAndWriteDashMatrix2D) {
   dash::barrier();
 
   verify_matrix(mat1_verified, local_secret);
+}
+
+TEST_F(HDF5MatrixTest, ReadAndWriteDashMatrix2DUnsigned) {
+  typedef dash::TilePattern<2, dash::ROW_MAJOR, unsigned long> upattern_t;
+  typedef dash::Matrix<value_t, 2, typename upattern_t::index_type, upattern_t> umatrix_t;
+
+  auto numunits = dash::Team::All().size();
+
+  // Add some randomness to the data
+  std::srand(time(NULL));
+  int local_secret = std::rand() % 1000;
+  int myid = dash::myid();
 
   //test unsigned type
   dash::TeamSpec<2, upattern_t::index_type> uteam_spec(numunits, 1); //here signifies the inflexibity of type acceptance
   uteam_spec.balance_extents();
+
+  auto extend_x = 2 * 2 * uteam_spec.extent(0);
+  auto extend_y = 2 * 5 * uteam_spec.extent(1);
 
   upattern_t upattern(dash::SizeSpec<2, upattern_t::size_type>(extend_x, extend_y),
                       dash::DistributionSpec<2>(dash::TILE(2), dash::TILE(5)),


### PR DESCRIPTION
This PR proposes test cases for StoreHDF5::read and StoreHDF5::write with dash::Matrix. Test cases consist of 1D and 2D matrices with the default and unsigned index type.