### PR TITLE
Pattern tests and patches

### DIFF
--- a/dash/include/dash/pattern/BlockPattern.h
+++ b/dash/include/dash/pattern/BlockPattern.h
@@ -83,12 +83,6 @@ private:
     BlockSpec_t;
   typedef CartesianIndexSpace<NumDimensions, Arrangement, IndexType>
     BlockSizeSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -107,15 +101,19 @@ public:
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 private:
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
   /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
   /// dimensions
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team *                _team            = nullptr;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// Total amount of units to which this pattern's elements are mapped
   SizeType                    _nunits          = 0;
   /// The global layout of the pattern's elements in memory respective to
@@ -223,12 +221,12 @@ public:
    */
   BlockPattern(
       /// Pattern size (extent, number of elements) in every dimension
-      const SizeSpec_t &sizespec,
+      const size_spec &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
       /// all dimensions.
-      DistributionSpec_t dist,
+      distribution_spec dist,
       /// Cartesian arrangement of units within the team
-      const TeamSpec_t &teamspec,
+      const team_spec &teamspec,
       /// Team containing units to which this pattern maps its elements
       dash::Team &team = dash::Team::All())
     : _distspec(std::move(dist))
@@ -285,11 +283,11 @@ public:
    */
   BlockPattern(
       /// Pattern size (extent, number of elements) in every dimension
-      const SizeSpec_t &sizespec,
+      const size_spec &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
       /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
       /// dimensions
-      DistributionSpec_t dist = DistributionSpec_t(),
+      distribution_spec dist = distribution_spec(),
       /// Team containing units to which this pattern maps its elements
       Team &team = dash::Team::All())
     : _distspec(std::move(dist))
@@ -1251,7 +1249,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  constexpr const DistributionSpec_t & distspec() const noexcept
+  constexpr const distribution_spec & distspec() const noexcept
   {
     return _distspec;
   }
@@ -1261,9 +1259,9 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr SizeSpec_t sizespec() const noexcept
+  constexpr size_spec sizespec() const noexcept
   {
-    return SizeSpec_t(_memory_layout.extents());
+    return size_spec(_memory_layout.extents());
   }
 
   /**
@@ -1283,7 +1281,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr const TeamSpec_t & teamspec() const noexcept
+  constexpr const team_spec & teamspec() const noexcept
   {
     return _teamspec;
   }
@@ -1379,9 +1377,9 @@ private:
    * distribution spec.
    */
   BlockSizeSpec_t initialize_blocksizespec(
-    const SizeSpec_t         & sizespec,
-    const DistributionSpec_t & distspec,
-    const TeamSpec_t         & teamspec) const
+    const size_spec          & sizespec,
+    const distribution_spec  & distspec,
+    const team_spec          & teamspec) const
   {
     DASH_LOG_TRACE_VAR("BlockPattern.init_blocksizespec", teamspec.size());
     if (teamspec.size() == 0) {
@@ -1404,8 +1402,8 @@ private:
    * spec.
    */
   BlockSpec_t initialize_blockspec(
-    const SizeSpec_t         & sizespec,
-    const DistributionSpec_t & distspec,
+    const size_spec          & sizespec,
+    const distribution_spec  & distspec,
     const BlockSizeSpec_t    & blocksizespec) const
   {
     if (blocksizespec.size() == 0) {

--- a/dash/include/dash/pattern/BlockPattern1D.h
+++ b/dash/include/dash/pattern/BlockPattern1D.h
@@ -77,12 +77,6 @@ private:
     LocalMemoryLayout_t;
   typedef CartesianSpace<NumDimensions, SizeType>
     BlockSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -101,6 +95,10 @@ public:
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 private:
   /// Extent of the linear pattern.
   SizeType                    _size            = 0;
@@ -108,11 +106,11 @@ private:
   MemoryLayout_t              _memory_layout;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE) of
   /// all dimensions. Defaults to BLOCKED.
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team *                _team            = nullptr;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// Total amount of units to which this pattern's elements are mapped
   SizeType                    _nunits          = 0;
   /// Maximum extents of a block in this pattern
@@ -194,11 +192,11 @@ public:
    */
   BlockPattern(
     /// Pattern size (extent, number of elements) in every dimension
-    const SizeSpec_t         sizespec,
+    const size_spec          sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE).
-    const DistributionSpec_t dist,
+    const distribution_spec  dist,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t         teamspec,
+    const team_spec          teamspec,
     /// Team containing units to which this pattern maps its elements
     dash::Team &             team     = dash::Team::All())
   : _size(sizespec.size()),
@@ -255,10 +253,10 @@ public:
    */
   BlockPattern(
     /// Pattern size (extent, number of elements) in every dimension
-    const SizeSpec_t         sizespec,
+    const size_spec         sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE).
     /// Defaults to BLOCKED.
-    const DistributionSpec_t dist = DistributionSpec_t(),
+    const distribution_spec dist = distribution_spec(),
     /// Team containing units to which this pattern maps its elements
     Team &                   team = dash::Team::All())
   : _size(sizespec.size()),
@@ -1025,7 +1023,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  constexpr const DistributionSpec_t & distspec() const noexcept {
+  constexpr const distribution_spec & distspec() const noexcept {
     return _distspec;
   }
 
@@ -1034,8 +1032,8 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr SizeSpec_t sizespec() const {
-    return SizeSpec_t(std::array<SizeType, 1> {{ _size }});
+  constexpr size_spec sizespec() const {
+    return size_spec(std::array<SizeType, 1> {{ _size }});
   }
 
   /**
@@ -1053,7 +1051,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr const TeamSpec_t & teamspec() const {
+  constexpr const team_spec & teamspec() const {
     return _teamspec;
   }
 
@@ -1141,7 +1139,7 @@ private:
    */
   SizeType initialize_blocksize(
     SizeType                   size,
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     SizeType                   nunits) const {
     DASH_LOG_TRACE_VAR("BlockPattern<1>.init_blocksize", nunits);
     if (nunits == 0) {

--- a/dash/include/dash/pattern/CSRPattern.h
+++ b/dash/include/dash/pattern/CSRPattern.h
@@ -97,12 +97,6 @@ private:
     LocalMemoryLayout_t;
   typedef CartesianSpace<NumDimensions, SizeType>
     BlockSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -121,6 +115,10 @@ public:
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 private:
   /// Extent of the linear pattern.
   SizeType                    _size            = 0;
@@ -134,11 +132,11 @@ private:
   BlockSpec_t                 _blockspec;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE) of
   /// all dimensions. Defaults to BLOCKED.
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team *                _team            = nullptr;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// Total amount of units to which this pattern's elements are mapped
   SizeType                    _nunits          = 0;
   /// Actual number of local elements of the active unit.
@@ -187,11 +185,11 @@ public:
    */
   CSRPattern(
     /// Size spec of the pattern.
-    const SizeSpec_t         & sizespec,
+    const size_spec          & sizespec,
     /// Distribution spec.
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t         & teamspec,
+    const team_spec          & teamspec,
     /// Team containing units to which this pattern maps its elements.
     Team                     & team = dash::Team::All())
   : _size(sizespec.size()),
@@ -204,7 +202,7 @@ public:
     _memory_layout(std::array<SizeType, 1> {{ _size }}),
     _blockspec(initialize_blockspec(
         _local_sizes)),
-    _distspec(DistributionSpec_t()),
+    _distspec(distribution_spec()),
     _team(&team),
     _teamspec(
       teamspec,
@@ -234,9 +232,9 @@ public:
    */
   CSRPattern(
     /// Size spec of the pattern.
-    const SizeSpec_t         & sizespec,
+    const size_spec          & sizespec,
     /// Distribution spec.
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     /// Team containing units to which this pattern maps its elements.
     Team                     & team = dash::Team::All())
   : _size(sizespec.size()),
@@ -249,7 +247,7 @@ public:
     _memory_layout(std::array<SizeType, 1> {{ _size }}),
     _blockspec(initialize_blockspec(
         _local_sizes)),
-    _distspec(DistributionSpec_t()),
+    _distspec(distribution_spec()),
     _team(&team),
     _teamspec(_distspec, *_team),
     _nunits(_team->size()),
@@ -307,7 +305,7 @@ public:
     /// Number of local elements for every unit in the active team.
     const std::vector<size_type>          & local_sizes,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t                      & teamspec,
+    const team_spec                       & teamspec,
     /// Team containing units to which this pattern maps its elements
     dash::Team                            & team     = dash::Team::All())
   : _size(initialize_size(
@@ -318,7 +316,7 @@ public:
     _memory_layout(std::array<SizeType, 1> {{ _size }}),
     _blockspec(initialize_blockspec(
         _local_sizes)),
-    _distspec(DistributionSpec_t()),
+    _distspec(distribution_spec()),
     _team(&team),
     _teamspec(
         teamspec,
@@ -362,7 +360,7 @@ public:
     _blockspec(
       initialize_blockspec(
         _local_sizes)),
-    _distspec(DistributionSpec_t()),
+    _distspec(distribution_spec()),
     _team(&team),
     _teamspec(_distspec, *_team),
     _nunits(_team->size()),
@@ -1052,7 +1050,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  constexpr const DistributionSpec_t & distspec() const noexcept
+  constexpr const distribution_spec & distspec() const noexcept
   {
     return _distspec;
   }
@@ -1062,9 +1060,9 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr SizeSpec_t sizespec() const noexcept
+  constexpr size_spec sizespec() const noexcept
   {
-    return SizeSpec_t(std::array<SizeType, 1> {{ _size }});
+    return size_spec(std::array<SizeType, 1> {{ _size }});
   }
 
   /**
@@ -1084,7 +1082,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr const TeamSpec_t & teamspec() const noexcept
+  constexpr const team_spec & teamspec() const noexcept
   {
     return _teamspec;
   }
@@ -1181,7 +1179,7 @@ private:
    */
   std::vector<size_type> initialize_local_sizes(
     size_type                  total_size,
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     const dash::Team         & team) const
   {
     DASH_LOG_TRACE_VAR("CSRPattern.init_local_sizes()", total_size);

--- a/dash/include/dash/pattern/DynamicPattern.h
+++ b/dash/include/dash/pattern/DynamicPattern.h
@@ -93,12 +93,6 @@ private:
     LocalMemoryLayout_t;
   typedef CartesianSpace<NumDimensions, SizeType>
     BlockSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -116,6 +110,10 @@ public:
     team_unit_t                            unit;
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
+
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
 
 public:
   /**
@@ -153,11 +151,11 @@ public:
    */
   DynamicPattern(
     /// Size spec of the pattern.
-    const SizeSpec_t         & sizespec,
+    const size_spec          & sizespec,
     /// Distribution spec.
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t         & teamspec,
+    const team_spec          & teamspec,
     /// Team containing units to which this pattern maps its elements.
     Team                     & team = dash::Team::All())
   : _size(sizespec.size()),
@@ -171,7 +169,7 @@ public:
     _blockspec(initialize_blockspec(
         _size,
         _local_sizes)),
-    _distspec(DistributionSpec_t()),
+    _distspec(distribution_spec()),
     _team(&team),
     _myid(_team->myid()),
     _teamspec(
@@ -205,9 +203,9 @@ public:
    */
   DynamicPattern(
     /// Size spec of the pattern.
-    const SizeSpec_t         & sizespec,
+    const size_spec          & sizespec,
     /// Distribution spec.
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     /// Team containing units to which this pattern maps its elements.
     Team                     & team = dash::Team::All())
   : _size(sizespec.size()),
@@ -221,7 +219,7 @@ public:
     _blockspec(initialize_blockspec(
         _size,
         _local_sizes)),
-    _distspec(DistributionSpec_t()),
+    _distspec(distribution_spec()),
     _team(&team),
     _myid(_team->myid()),
     _teamspec(_distspec, *_team),
@@ -283,7 +281,7 @@ public:
     /// Number of local elements for every unit in the active team.
     const std::vector<size_type> & local_sizes,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t             & teamspec,
+    const team_spec              & teamspec,
     /// Team containing units to which this pattern maps its elements
     dash::Team                   & team     = dash::Team::All())
   : _size(initialize_size(
@@ -295,7 +293,7 @@ public:
     _blockspec(initialize_blockspec(
         _size,
         _local_sizes)),
-    _distspec(DistributionSpec_t()),
+    _distspec(distribution_spec()),
     _team(&team),
     _myid(_team->myid()),
     _teamspec(
@@ -341,7 +339,7 @@ public:
     _blockspec(initialize_blockspec(
         _size,
         _local_sizes)),
-    _distspec(DistributionSpec_t()),
+    _distspec(distribution_spec()),
     _team(&team),
     _myid(_team->myid()),
     _teamspec(_distspec, *_team),
@@ -1172,7 +1170,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  const DistributionSpec_t & distspec() const
+  const distribution_spec & distspec() const
   {
     return _distspec;
   }
@@ -1182,9 +1180,9 @@ public:
    *
    * \see DashPatternConcept
    */
-  SizeSpec_t sizespec() const
+  size_spec sizespec() const
   {
-    return SizeSpec_t(std::array<SizeType, 1> { _size });
+    return size_spec(std::array<SizeType, 1> { _size });
   }
 
   /**
@@ -1203,7 +1201,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  const TeamSpec_t & teamspec() const
+  const team_spec & teamspec() const
   {
     return _teamspec;
   }
@@ -1310,7 +1308,7 @@ private:
    */
   std::vector<size_type> initialize_local_sizes(
     size_type                  total_size,
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     const dash::Team         & team) const
   {
     DASH_LOG_TRACE_VAR("DynamicPattern.init_local_sizes()", total_size);
@@ -1396,7 +1394,7 @@ private:
    */
   SizeType initialize_blocksize(
     SizeType                   size,
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     SizeType                   nunits) const
   {
     DASH_LOG_TRACE_VAR("DynamicPattern.init_blocksize", nunits);
@@ -1413,7 +1411,7 @@ private:
   SizeType initialize_num_local_blocks(
     SizeType                   num_blocks,
     SizeType                   blocksize,
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     SizeType                   nunits,
     SizeType                   local_size) const
   {
@@ -1500,13 +1498,13 @@ private:
   BlockSpec_t                 _blockspec;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE) of
   /// all dimensions. Defaults to BLOCKED.
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team *                _team            = nullptr;
   /// The active unit's id.
   team_unit_t                 _myid;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// Total amount of units to which this pattern's elements are mapped
   SizeType                    _nunits          = 0;
   /// Maximum extents of a block in this pattern

--- a/dash/include/dash/pattern/LoadBalancePattern.h
+++ b/dash/include/dash/pattern/LoadBalancePattern.h
@@ -258,12 +258,6 @@ private:
     LocalMemoryLayout_t;
   typedef CartesianSpace<NumDimensions, SizeType>
     BlockSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -286,13 +280,17 @@ public:
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 public:
   /**
    * Constructor.
    */
   LoadBalancePattern(
     /// Size spec of the pattern.
-    const SizeSpec_t     & sizespec,
+    const size_spec      & sizespec,
     /// Locality hierarchy of the team.
     TeamLocality_t       & team_loc)
   : _size(sizespec.size()),
@@ -345,7 +343,7 @@ public:
    */
   LoadBalancePattern(
     /// Size spec of the pattern.
-    const SizeSpec_t     & sizespec,
+    const size_spec      & sizespec,
     /// Team containing units to which this pattern maps its elements.
     dash::Team           & team = dash::Team::All())
   : LoadBalancePattern(sizespec, TeamLocality_t(team))
@@ -1005,7 +1003,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  const DistributionSpec_t & distspec() const
+  const distribution_spec & distspec() const
   {
     return _distspec;
   }
@@ -1015,9 +1013,9 @@ public:
    *
    * \see DashPatternConcept
    */
-  SizeSpec_t sizespec() const
+  size_spec sizespec() const
   {
-    return SizeSpec_t(std::array<SizeType, 1> {{ _size }});
+    return size_spec(std::array<SizeType, 1> {{ _size }});
   }
 
   /**
@@ -1036,7 +1034,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  const TeamSpec_t & teamspec() const
+  const team_spec & teamspec() const
   {
     return _teamspec;
   }
@@ -1290,13 +1288,13 @@ private:
   /// Number of blocks in all dimensions
   BlockSpec_t                 _blockspec;
   /// Distribution types of all dimensions.
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team *                _team            = nullptr;
   /// The active unit's id.
   team_unit_t                 _myid;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// Total amount of units to which this pattern's elements are mapped
   SizeType                    _nunits          = 0;
   /// Actual number of local elements of the active unit.

--- a/dash/include/dash/pattern/SeqTilePattern.h
+++ b/dash/include/dash/pattern/SeqTilePattern.h
@@ -95,12 +95,6 @@ private:
     BlockSpec_t;
   typedef CartesianIndexSpace<NumDimensions, Arrangement, SizeType>
     BlockSizeSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -119,17 +113,21 @@ public:
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 private:
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
   /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
   /// dimensions
-  DistributionSpec_t          _distspec;
+  distribution_spec          _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team                * _team            = nullptr;
   /// The active unit's id.
   team_unit_t                 _myid;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// The global layout of the pattern's elements in memory respective to
   /// memory order. Also specifies the extents of the pattern space.
   MemoryLayout_t              _memory_layout;
@@ -238,13 +236,13 @@ public:
    */
   SeqTilePattern(
       /// SeqTilePattern size (extent, number of elements) in every dimension
-      const SizeSpec_t &sizespec,
+      const size_spec  &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
       /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
       /// dimensions
-      DistributionSpec_t dist,
+      distribution_spec dist,
       /// Cartesian arrangement of units within the team
-      const TeamSpec_t &teamspec,
+      const team_spec  &teamspec,
       /// Team containing units to which this pattern maps its elements
       dash::Team &team = dash::Team::All())
     : _distspec(std::move(dist))
@@ -299,11 +297,11 @@ public:
    */
   SeqTilePattern(
     /// SeqTilePattern size (extent, number of elements) in every dimension
-    const SizeSpec_t         & sizespec,
+    const size_spec          & sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
     /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
     /// dimensions
-    const DistributionSpec_t & dist = DistributionSpec_t(),
+    const distribution_spec  & dist = distribution_spec(),
     /// Team containing units to which this pattern maps its elements
     Team                     & team = dash::Team::All())
   : _distspec(dist),
@@ -1375,7 +1373,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  const DistributionSpec_t & distspec() const {
+  const distribution_spec & distspec() const {
     return _distspec;
   }
 
@@ -1384,8 +1382,8 @@ public:
    *
    * \see DashPatternConcept
    */
-  SizeSpec_t sizespec() const {
-    return SizeSpec_t(_memory_layout.extents());
+  size_spec sizespec() const {
+    return size_spec(_memory_layout.extents());
   }
 
   /**
@@ -1403,7 +1401,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  const TeamSpec_t & teamspec() const {
+  const team_spec & teamspec() const {
     return _teamspec;
   }
 
@@ -1475,9 +1473,9 @@ private:
    * distribution spec.
    */
   BlockSizeSpec_t initialize_blocksizespec(
-    const SizeSpec_t         & sizespec,
-    const DistributionSpec_t & distspec,
-    const TeamSpec_t         & teamspec) const {
+    const size_spec          & sizespec,
+    const distribution_spec  & distspec,
+    const team_spec          & teamspec) const {
     DASH_LOG_TRACE("SeqTilePattern.init_blocksizespec()");
     // Extents of a single block:
     std::array<SizeType, NumDimensions> s_blocks{};
@@ -1500,9 +1498,9 @@ private:
    * spec.
    */
   BlockSpec_t initialize_blockspec(
-    const SizeSpec_t         & sizespec,
+    const size_spec          & sizespec,
     const BlockSizeSpec_t    & blocksizespec,
-    const TeamSpec_t         & teamspec) const
+    const team_spec          & teamspec) const
   {
     DASH_LOG_TRACE("SeqTilePattern.init_blockspec()",
                    "pattern size:", sizespec.extents(),

--- a/dash/include/dash/pattern/ShiftTilePattern.h
+++ b/dash/include/dash/pattern/ShiftTilePattern.h
@@ -89,12 +89,6 @@ private:
     BlockSpec_t;
   typedef CartesianIndexSpace<NumDimensions, Arrangement, SizeType>
     BlockSizeSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -113,15 +107,19 @@ public:
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 private:
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
   /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
   /// dimensions
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team                * _team            = nullptr;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// The global layout of the pattern's elements in memory respective to
   /// memory order. Also specifies the extents of the pattern space.
   MemoryLayout_t              _memory_layout;
@@ -236,12 +234,12 @@ public:
   ShiftTilePattern(
       /// ShiftTilePattern size (extent, number of elements) in every
       /// dimension
-      const SizeSpec_t &sizespec,
+      const size_spec  &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
       /// all dimensions.
-      DistributionSpec_t dist,
+      distribution_spec dist,
       /// Cartesian arrangement of units within the team
-      TeamSpec_t teamspec,
+      team_spec teamspec,
       /// Team containing units to which this pattern maps its elements
       dash::Team &team = dash::Team::All())
     : _distspec(std::move(dist))
@@ -306,11 +304,11 @@ public:
   ShiftTilePattern(
       /// ShiftTilePattern size (extent, number of elements) in every
       /// dimension
-      const SizeSpec_t &sizespec,
+      const size_spec &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
       /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
       /// dimensions
-      DistributionSpec_t dist = DistributionSpec_t(),
+      distribution_spec dist = distribution_spec(),
       /// Team containing units to which this pattern maps its elements
       Team &team = dash::Team::All())
     : _distspec(std::move(dist))
@@ -1353,7 +1351,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  inline const DistributionSpec_t & distspec() const {
+  inline const distribution_spec & distspec() const {
     return _distspec;
   }
 
@@ -1362,8 +1360,8 @@ public:
    *
    * \see DashPatternConcept
    */
-  SizeSpec_t sizespec() const {
-    return SizeSpec_t(_memory_layout.extents());
+  size_spec sizespec() const {
+    return size_spec(_memory_layout.extents());
   }
 
   /**
@@ -1381,7 +1379,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  const TeamSpec_t & teamspec() const {
+  const team_spec & teamspec() const {
     return _teamspec;
   }
 
@@ -1472,9 +1470,9 @@ private:
    * distribution spec.
    */
   BlockSizeSpec_t initialize_blocksizespec(
-    const SizeSpec_t         & sizespec,
-    const DistributionSpec_t & distspec,
-    const TeamSpec_t         & teamspec) const {
+    const size_spec          & sizespec,
+    const distribution_spec  & distspec,
+    const team_spec          & teamspec) const {
     DASH_LOG_TRACE("ShiftTilePattern.init_blocksizespec()");
     // Extents of a single block:
     std::array<SizeType, NumDimensions> s_blocks{};
@@ -1497,9 +1495,9 @@ private:
    * spec.
    */
   BlockSpec_t initialize_blockspec(
-    const SizeSpec_t         & sizespec,
+    const size_spec          & sizespec,
     const BlockSizeSpec_t    & blocksizespec,
-    const TeamSpec_t         & teamspec) const
+    const team_spec          & teamspec) const
   {
     DASH_LOG_TRACE("ShiftTilePattern.init_blockspec()",
                    "pattern size:", sizespec.extents(),
@@ -1583,7 +1581,7 @@ private:
    * Return major dimension with tiled distribution, i.e. lowest tiled
    * dimension.
    */
-  dim_t initialize_major_tiled_dim(const DistributionSpec_t & ds)
+  dim_t initialize_major_tiled_dim(const distribution_spec & ds)
   {
     DASH_LOG_TRACE("ShiftTilePattern.init_major_tiled_dim()");
     if (Arrangement == dash::COL_MAJOR) {

--- a/dash/include/dash/pattern/ShiftTilePattern1D.h
+++ b/dash/include/dash/pattern/ShiftTilePattern1D.h
@@ -81,12 +81,6 @@ private:
     LocalMemoryLayout_t;
   typedef CartesianSpace<NumDimensions, SizeType>
     BlockSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -105,6 +99,10 @@ public:
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 private:
   /// Extent of the linear pattern.
   SizeType                    _size;
@@ -112,11 +110,11 @@ private:
   MemoryLayout_t              _memory_layout;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE) of
   /// all dimensions. Defaults to BLOCKED.
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team *                _team            = nullptr;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// Total amount of units to which this pattern's elements are mapped
   SizeType                    _nunits          = 0;
   /// Maximum extents of a block in this pattern
@@ -199,11 +197,11 @@ public:
    */
   ShiftTilePattern(
       /// Pattern size (extent, number of elements) in every dimension
-      const SizeSpec_t &sizespec,
+      const size_spec  &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE).
-      DistributionSpec_t dist,
+      distribution_spec dist,
       /// Cartesian arrangement of units within the team
-      const TeamSpec_t &teamspec,
+      const team_spec  &teamspec,
       /// Team containing units to which this pattern maps its elements
       dash::Team &team = dash::Team::All())
     : _size(sizespec.size())
@@ -251,12 +249,12 @@ public:
    */
   ShiftTilePattern(
     /// Pattern size (extent, number of elements) in every dimension
-    const SizeSpec_t &         sizespec,
+    const size_spec &         sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE).
     /// Defaults to BLOCKED in first.
-    const DistributionSpec_t & dist = DistributionSpec_t(),
+    const distribution_spec & dist = distribution_spec(),
     /// Team containing units to which this pattern maps its elements
-    Team &                     team = dash::Team::All())
+    Team &                    team = dash::Team::All())
   : _size(sizespec.size()),
     _memory_layout(std::array<SizeType, 1> { _size }),
     _distspec(dist),
@@ -1010,7 +1008,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  const DistributionSpec_t & distspec() const {
+  const distribution_spec & distspec() const {
     return _distspec;
   }
 
@@ -1019,8 +1017,8 @@ public:
    *
    * \see DashPatternConcept
    */
-  SizeSpec_t sizespec() const {
-    return SizeSpec_t(std::array<SizeType, 1> {{ _size }});
+  size_spec sizespec() const {
+    return size_spec(std::array<SizeType, 1> {{ _size }});
   }
 
   /**
@@ -1038,7 +1036,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  const TeamSpec_t & teamspec() const {
+  const team_spec & teamspec() const {
     return _teamspec;
   }
 
@@ -1111,7 +1109,7 @@ private:
    */
   SizeType initialize_blocksize(
     SizeType                   size,
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     SizeType                   nunits) const {
     DASH_LOG_TRACE_VAR("ShiftTilePattern<1>.init_blocksize", nunits);
     if (nunits == 0) {

--- a/dash/include/dash/pattern/ShiftTilePattern1D.h
+++ b/dash/include/dash/pattern/ShiftTilePattern1D.h
@@ -510,10 +510,10 @@ public:
    * \see  DashPatternConcept
    */
   std::array<SizeType, NumDimensions> local_extents(
-      team_unit_t unit) const {
+      team_unit_t unit = UNDEFINED_TEAM_UNIT_ID) const {
     DASH_LOG_DEBUG_VAR("ShiftTilePattern<1>.local_extents()", unit);
     DASH_LOG_DEBUG_VAR("ShiftTilePattern<1>.local_extents >", _local_size);
-    return std::array<SizeType, 1> { _local_size };
+    return std::array<SizeType, 1> {{ _local_size }};
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -909,8 +909,7 @@ public:
    * Cartesian arrangement of pattern blocks.
    */
   BlockSpec_t blockspec() const {
-    BlockSpec_t bspec({{ dash::math::div_ceil(_size, _blocksize) }});
-    return bspec;
+    return BlockSpec_t({ _nblocks });
   }
 
   /**
@@ -1026,8 +1025,8 @@ public:
    *
    * \see DashPatternConcept
    */
-  const std::array<SizeType, NumDimensions> & extents() const {
-    return std::array<SizeType, 1> { _size };
+  const std::array<SizeType, NumDimensions> extents() const {
+    return std::array<SizeType, 1> {{ _size }};
   }
 
   /**

--- a/dash/include/dash/pattern/TilePattern.h
+++ b/dash/include/dash/pattern/TilePattern.h
@@ -89,12 +89,6 @@ private:
     BlockSpec_t;
   typedef CartesianIndexSpace<NumDimensions, Arrangement, IndexType>
     BlockSizeSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -113,17 +107,21 @@ public:
     std::array<index_type, NumDimensions> coords{};
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 private:
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
   /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
   /// dimensions
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team                * _team            = nullptr;
   /// The active unit's id.
   team_unit_t                 _myid;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// The global layout of the pattern's elements in memory respective to
   /// memory order. Also specifies the extents of the pattern space.
   MemoryLayout_t              _memory_layout;
@@ -232,12 +230,12 @@ public:
    */
   TilePattern(
       /// TilePattern size (extent, number of elements) in every dimension
-      const SizeSpec_t &sizespec,
+      const size_spec &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
       /// all dimensions.
-      DistributionSpec_t dist,
+      distribution_spec dist,
       /// Cartesian arrangement of units within the team
-      const TeamSpec_t &teamspec,
+      const team_spec &teamspec,
       /// Team containing units to which this pattern maps its elements
       dash::Team &team = dash::Team::All())
     : _distspec(std::move(dist))
@@ -293,11 +291,11 @@ public:
    */
   TilePattern(
       /// TilePattern size (extent, number of elements) in every dimension
-      const SizeSpec_t &sizespec,
+      const size_spec &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE) of
       /// all dimensions. Defaults to BLOCKED in first, and NONE in higher
       /// dimensions
-      DistributionSpec_t dist = DistributionSpec_t(),
+      distribution_spec dist = distribution_spec(),
       /// Team containing units to which this pattern maps its elements
       Team &team = dash::Team::All())
     : _distspec(std::move(dist))
@@ -1395,7 +1393,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  constexpr const DistributionSpec_t & distspec() const {
+  constexpr const distribution_spec & distspec() const {
     return _distspec;
   }
 
@@ -1404,8 +1402,8 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr SizeSpec_t sizespec() const {
-    return SizeSpec_t(_memory_layout.extents());
+  constexpr size_spec sizespec() const {
+    return size_spec(_memory_layout.extents());
   }
 
   /**
@@ -1423,7 +1421,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr const TeamSpec_t & teamspec() const {
+  constexpr const team_spec & teamspec() const {
     return _teamspec;
   }
 
@@ -1516,9 +1514,9 @@ private:
    * distribution spec.
    */
   BlockSizeSpec_t initialize_blocksizespec(
-    const SizeSpec_t         & sizespec,
-    const DistributionSpec_t & distspec,
-    const TeamSpec_t         & teamspec) const {
+    const size_spec          & sizespec,
+    const distribution_spec  & distspec,
+    const team_spec          & teamspec) const {
     DASH_LOG_TRACE("TilePattern.init_blocksizespec()",
                    "sizespec:", sizespec.extents(),
                    "distspec:", distspec.values(),
@@ -1559,9 +1557,9 @@ private:
    * spec.
    */
   BlockSpec_t initialize_blockspec(
-    const SizeSpec_t         & sizespec,
+    const size_spec          & sizespec,
     const BlockSizeSpec_t    & blocksizespec,
-    const TeamSpec_t         & teamspec) const
+    const team_spec          & teamspec) const
   {
     DASH_LOG_TRACE("TilePattern.init_blockspec()",
                    "pattern size:", sizespec.extents(),
@@ -1594,7 +1592,7 @@ private:
   BlockSpec_t initialize_local_blockspec(
     const BlockSpec_t     & blockspec,
     const BlockSizeSpec_t & blocksizespec,
-    const TeamSpec_t      & teamspec,
+    const team_spec       & teamspec,
     team_unit_t              unit_id = UNDEFINED_TEAM_UNIT_ID) const
   {
     DASH_LOG_TRACE_VAR("TilePattern.init_local_blockspec()",

--- a/dash/include/dash/pattern/TilePattern1D.h
+++ b/dash/include/dash/pattern/TilePattern1D.h
@@ -507,10 +507,10 @@ public:
    */
   constexpr local_coords_t local(
     const std::array<IndexType, NumDimensions> & global_coords) const {
-    return local_coords_t {{
+    return local_coords_t {
              unit_at(global_coords),
              local_coords(global_coords)
-           }};
+           };
   }
 
   /**

--- a/dash/include/dash/pattern/TilePattern1D.h
+++ b/dash/include/dash/pattern/TilePattern1D.h
@@ -80,12 +80,6 @@ private:
     LocalMemoryLayout_t;
   typedef CartesianSpace<NumDimensions, SizeType>
     BlockSpec_t;
-  typedef DistributionSpec<NumDimensions>
-    DistributionSpec_t;
-  typedef TeamSpec<NumDimensions, IndexType>
-    TeamSpec_t;
-  typedef SizeSpec<NumDimensions, SizeType>
-    SizeSpec_t;
   typedef ViewSpec<NumDimensions, IndexType>
     ViewSpec_t;
   typedef internal::PatternArguments<NumDimensions, IndexType>
@@ -104,6 +98,10 @@ public:
     std::array<index_type, NumDimensions> coords;
   } local_coords_t;
 
+  typedef DistributionSpec<NumDimensions>     distribution_spec;
+  typedef TeamSpec<NumDimensions, IndexType>  team_spec;
+  typedef SizeSpec<NumDimensions, SizeType>   size_spec;
+
 private:
   /// Extent of the linear pattern.
   SizeType                    _size;
@@ -111,11 +109,11 @@ private:
   MemoryLayout_t              _memory_layout;
   /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE) of
   /// all dimensions. Defaults to BLOCKED.
-  DistributionSpec_t          _distspec;
+  distribution_spec           _distspec;
   /// Team containing the units to which the patterns element are mapped
   dash::Team *                _team            = nullptr;
   /// Cartesian arrangement of units within the team
-  TeamSpec_t                  _teamspec;
+  team_spec                   _teamspec;
   /// Total amount of units to which this pattern's elements are mapped
   SizeType                    _nunits          = 0;
   /// Maximum extents of a block in this pattern
@@ -199,11 +197,11 @@ public:
    */
   TilePattern(
     /// Pattern size (extent, number of elements) in every dimension
-    const SizeSpec_t         sizespec,
+    const size_spec          sizespec,
     /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC or NONE).
-    const DistributionSpec_t dist,
+    const distribution_spec  dist,
     /// Cartesian arrangement of units within the team
-    const TeamSpec_t         teamspec,
+    const team_spec          teamspec,
     /// Team containing units to which this pattern maps its elements
     dash::Team &             team     = dash::Team::All())
   : _size(sizespec.size()),
@@ -262,10 +260,10 @@ public:
    */
   TilePattern(
       /// Pattern size (extent, number of elements) in every dimension
-      const SizeSpec_t &sizespec,
+      const size_spec  &sizespec,
       /// Distribution type (BLOCKED, CYCLIC, BLOCKCYCLIC, TILE or NONE).
       /// Defaults to BLOCKED in first.
-      DistributionSpec_t dist = DistributionSpec_t(),
+      distribution_spec dist = distribution_spec(),
       /// Team containing units to which this pattern maps its elements
       Team &team = dash::Team::All())
     : _size(sizespec.size())
@@ -969,7 +967,7 @@ public:
   /**
    * Distribution specification of this pattern.
    */
-  constexpr const DistributionSpec_t & distspec() const {
+  constexpr const distribution_spec & distspec() const {
     return _distspec;
   }
 
@@ -978,8 +976,8 @@ public:
    *
    * \see DashPatternConcept
    */
-  constexpr SizeSpec_t sizespec() const {
-    return SizeSpec_t(std::array<SizeType, 1> {{ _size }});
+  constexpr size_spec sizespec() const {
+    return size_spec(std::array<SizeType, 1> {{ _size }});
   }
 
   /**
@@ -997,7 +995,7 @@ public:
    *
    * \see DashPatternConcept
    */
-  const TeamSpec_t & teamspec() const {
+  const team_spec & teamspec() const {
     return _teamspec;
   }
 
@@ -1069,7 +1067,7 @@ private:
    */
   SizeType initialize_blocksize(
     SizeType                   size,
-    const DistributionSpec_t & distspec,
+    const distribution_spec  & distspec,
     SizeType                   nunits) const {
     DASH_LOG_TRACE_VAR("TilePattern<1>.init_blocksize", nunits);
     if (nunits == 0) {

--- a/dash/test/pattern/BlockPatternTest.cc
+++ b/dash/test/pattern/BlockPatternTest.cc
@@ -1203,3 +1203,29 @@ TEST_F(BlockPatternTest, UnderfilledPatternExtent1Dim)
 
   EXPECT_EQ_U(bextent, desired);
 }
+
+TEST_F(BlockPatternTest, BlockPattern1DFunctionalCheck)
+{
+  auto num_units = dash::Team::All().size();
+
+  //series of default test
+  typedef dash::BlockPattern<1> pattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<pattern_t>(i);
+
+  // series of unsigned COLUMN MAJOR test
+  typedef dash::BlockPattern<1, dash::COL_MAJOR, unsigned long> upattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<upattern_t>(i);
+}
+
+TEST_F(BlockPatternTest, BlockPatternFunctionalCheck)
+{
+  auto num_units = dash::Team::All().size();
+
+  //series of default 2D test
+  typedef dash::BlockPattern<2> pattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<pattern_t>(i, i);
+
+  // series of unsigned COLUMN MAJOR 2D test
+  typedef dash::BlockPattern<2, dash::COL_MAJOR, unsigned long> upattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<upattern_t>(i, i);
+}

--- a/dash/test/pattern/BlockPatternTest.h
+++ b/dash/test/pattern/BlockPatternTest.h
@@ -2,7 +2,7 @@
 #define DASH__TEST__BLOCK_PATTERN_TEST_H_
 
 #include "../TestBase.h"
-
+#include "PatternTest.h" 
 
 /**
  * Test fixture for class dash::Pattern

--- a/dash/test/pattern/PatternTest.h
+++ b/dash/test/pattern/PatternTest.h
@@ -28,7 +28,7 @@ void test_pattern(typename PatternType::size_type array_size, Args &&... args) /
   std::array<IndexType, dims> coord = {0, static_cast<IndexType>(!(bool) args)...}; // test coordinate {0, 0...}
 
   // test constructors
-  PatternType pattern1(array_size, args...); // check compiling, not check equality with other constructor due to the difference in DistributionSpec
+  //PatternType pattern1(array_size, args...); // check compiling, not check equality with other constructor due to the difference in DistributionSpec
 
   PatternType pattern2(SizeSpecType(array_size, args...),
                        DistributionSpecType(dash::TILE(array_size / num_units), dash::TILE(args / num_units)...));
@@ -72,10 +72,10 @@ void test_pattern(typename PatternType::size_type array_size, Args &&... args) /
 
   //test .block, .block_at, .local_block, .has_local_elements
   auto g_blockid = pattern2.block_at(coord);
-  auto l_blockid = pattern2.local_block_at(coord);
+  //auto l_blockid = pattern2.local_block_at(coord);
 
   auto g_view = pattern2.block(g_blockid);
-  auto l_view = pattern2.local_block(l_blockid.index);
+  //auto l_view = pattern2.local_block(l_blockid.index);
 
   // member function .includes_index is still currently TODO, it is not implemented yet in CartesianIndexSpace class
   //ASSERT_EQ_U(pattern2.has_local_elements(static_cast<dash::dim_t>(0), static_cast<IndexType>(0), unit_at_coord, g_view), unit_id == 0);

--- a/dash/test/pattern/PatternTest.h
+++ b/dash/test/pattern/PatternTest.h
@@ -1,0 +1,111 @@
+#ifndef DASH__TEST__PATTERN_TEST_H_
+#define DASH__TEST__PATTERN_TEST_H_
+
+#include "../TestBase.h"
+
+/**
+ * Template test function for pattern functionalities
+ */
+
+
+template<typename PatternType, typename ... Args>
+void test_pattern(typename PatternType::size_type array_size, Args &&... args) // array_size is first dim size 
+{
+  using namespace std;
+
+  typedef typename PatternType::size_type          SizeType;
+  typedef typename PatternType::index_type         IndexType;
+
+  typedef typename PatternType::distribution_spec  DistributionSpecType; 
+  typedef typename PatternType::team_spec          TeamSpecType;
+  typedef typename PatternType::size_spec          SizeSpecType;
+
+  const SizeType dims = PatternType::ndim();
+
+  auto num_units = dash::Team::All().size();
+  auto unit_id   = dash::myid();
+
+  std::array<IndexType, dims> coord = {0, static_cast<IndexType>(!(bool) args)...}; // test coordinate {0, 0...}
+
+  // test constructors
+  PatternType pattern1(array_size, args...); // check compiling, not check equality with other constructor due to the difference in DistributionSpec
+
+  PatternType pattern2(SizeSpecType(array_size, args...),
+                       DistributionSpecType(dash::TILE(array_size / num_units), dash::TILE(args / num_units)...));
+  
+  PatternType pattern3(SizeSpecType(array_size, args...),
+                       DistributionSpecType(dash::TILE(array_size / num_units), dash::TILE(args / num_units)...),
+                       TeamSpecType(num_units, static_cast<int>((bool) args)...)); // a hack to input default 1 for higher dims depended on number of args
+
+  PatternType pattern4 = pattern3;
+
+  ASSERT_EQ_U(pattern2 == pattern3, true);
+  ASSERT_EQ_U(pattern3 == pattern4, true);
+
+  //test .extents
+  ASSERT_EQ_U(pattern2.extent(0), array_size);
+
+  auto l_extents = pattern2.local_extents();
+  ASSERT_EQ_U(accumulate(begin(l_extents), end(l_extents), 1, multiplies<SizeType>()), pattern2.local_size());
+
+  auto g_extents = pattern2.extents();
+  ASSERT_EQ_U(accumulate(begin(g_extents), end(g_extents), 1, multiplies<SizeType>()), pattern2.size());
+
+  ASSERT_EQ_U(pattern2.local_size(), pattern2.local_capacity()); //assumed balanced extents
+  ASSERT_EQ_U(pattern2.size(), pattern2.capacity());
+
+  //test .at
+  ASSERT_EQ_U(pattern2.at(coord), 0);
+
+  //test .unit_at, .local, .local_index, local_at, .global, .global_index, , global_at, .is_local
+  auto unit_at_coord = pattern2.unit_at(coord);
+  auto l_pos = pattern2.local(coord);
+  auto l_index = pattern2.local_index(coord);
+  auto g_index = pattern2.global_index(unit_at_coord, l_pos.coords); // unit_at({0, 0}) is unit 0
+
+  ASSERT_EQ_U(pattern2.local_at(l_pos.coords), l_index.index);
+
+  ASSERT_EQ_U(pattern2.global(unit_at_coord, l_pos.coords), coord);
+  ASSERT_EQ_U(pattern2.global_at(coord), g_index);
+
+  ASSERT_EQ_U(pattern2.is_local(g_index), unit_id == 0);
+
+  //test .block, .block_at, .local_block, .has_local_elements
+  auto g_blockid = pattern2.block_at(coord);
+  auto l_blockid = pattern2.local_block_at(coord);
+
+  auto g_view = pattern2.block(g_blockid);
+  auto l_view = pattern2.local_block(l_blockid.index);
+
+  // member function .includes_index is still currently TODO, it is not implemented yet in CartesianIndexSpace class
+  //ASSERT_EQ_U(pattern2.has_local_elements(static_cast<dash::dim_t>(0), static_cast<IndexType>(0), unit_at_coord, g_view), unit_id == 0);
+
+  //test BlockSpec, Local BlockSpec, .blocksize, .max_blocksize
+  auto block_spec = pattern2.blockspec();
+  auto l_block_spec = pattern2.local_blockspec();
+
+  int nblocks =  static_cast<int>(pow(num_units, dims));
+
+  ASSERT_EQ_U(block_spec.size(), nblocks);
+  ASSERT_EQ_U(l_block_spec.size(), nblocks / num_units); //assumed balanced extents
+
+  int blocksize = 1;
+  for (int dim = 0; dim < dims; dim++) 
+    blocksize *= pattern2.blocksize(dim);
+  ASSERT_EQ_U(blocksize, pattern2.max_blocksize());
+
+  //test .coords
+  IndexType idx = 0;
+  ASSERT_EQ_U(pattern2.coords(idx), coord);
+
+
+  //test .sizespec, .teamspec
+  auto size_spec = pattern2.sizespec();
+  auto team_spec = pattern2.teamspec();
+
+  ASSERT_EQ_U(size_spec.extent(0), array_size);
+  ASSERT_EQ_U(team_spec.size(), num_units);
+}
+
+
+#endif // DASH__TEST__PATTERN_TEST_H_

--- a/dash/test/pattern/SeqTilePatternTest.cc
+++ b/dash/test/pattern/SeqTilePatternTest.cc
@@ -91,3 +91,29 @@ TEST_F(SeqTilePatternTest, Distribute2DimTile)
     }
   }
 }
+
+TEST_F(SeqTilePatternTest, SeqTilePattern1DFunctionalCheck)
+{
+  auto num_units = dash::Team::All().size();
+
+  //series of default test
+  typedef dash::SeqTilePattern<1> pattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<pattern_t>(i);
+
+  // series of unsigned COLUMN MAJOR test
+  typedef dash::SeqTilePattern<1, dash::COL_MAJOR, unsigned long> upattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<upattern_t>(i);
+}
+
+TEST_F(SeqTilePatternTest, SeqTilePatternFunctionalCheck)
+{
+  auto num_units = dash::Team::All().size();
+
+  //series of default 2D test
+  typedef dash::SeqTilePattern<2> pattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<pattern_t>(i, i);
+
+  // series of unsigned COLUMN MAJOR 2D test
+  typedef dash::SeqTilePattern<2, dash::COL_MAJOR, unsigned long> upattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<upattern_t>(i, i);
+}

--- a/dash/test/pattern/SeqTilePatternTest.h
+++ b/dash/test/pattern/SeqTilePatternTest.h
@@ -2,6 +2,7 @@
 #define DASH__TEST__SEQ_TILE_PATTERN_TEST_H_
 
 #include "../TestBase.h"
+#include "PatternTest.h" 
 
 /**
  * Test fixture for class dash::Pattern

--- a/dash/test/pattern/ShiftTilePatternTest.cc
+++ b/dash/test/pattern/ShiftTilePatternTest.cc
@@ -304,3 +304,29 @@ TEST_F(ShiftTilePatternTest, Tile2DimTeam1Dim)
     DASH_LOG_DEBUG_VAR("ShiftTilePatternTest.Tile2DimTeam1Dim", row_units);
   }
 }
+
+TEST_F(ShiftTilePatternTest, ShiftTilePattern1DFunctionalCheck)
+{
+  auto num_units = dash::Team::All().size();
+
+  //series of default test
+  typedef dash::ShiftTilePattern<1> pattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<pattern_t>(i);
+
+  // series of unsigned COLUMN MAJOR test
+  typedef dash::ShiftTilePattern<1, dash::COL_MAJOR, unsigned long> upattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<upattern_t>(i);
+}
+
+TEST_F(ShiftTilePatternTest, ShiftTilePatternFunctionalCheck)
+{
+  auto num_units = dash::Team::All().size();
+
+  //series of default 2D test
+  typedef dash::ShiftTilePattern<2> pattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<pattern_t>(i, i);
+
+  // series of unsigned COLUMN MAJOR 2D test
+  typedef dash::ShiftTilePattern<2, dash::COL_MAJOR, unsigned long> upattern_t;
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_pattern<upattern_t>(i, i);
+}

--- a/dash/test/pattern/ShiftTilePatternTest.h
+++ b/dash/test/pattern/ShiftTilePatternTest.h
@@ -2,6 +2,7 @@
 #define DASH__TEST__SHIFT_TILE_PATTERN_TEST_H_
 
 #include "../TestBase.h"
+#include "PatternTest.h" 
 
 /**
  * Test fixture for class dash::ShiftTilePattern

--- a/dash/test/pattern/TilePatternTest.cc
+++ b/dash/test/pattern/TilePatternTest.cc
@@ -302,8 +302,9 @@ TEST_F(TilePatternTest, Tile4Dim)
 }
 
 template<dash::dim_t NumDimensions = 1, dash::MemArrange Arangement = dash::ROW_MAJOR, typename IndexType = dash::default_index_t, typename ... Args>
-void test_tile_pattern_constructors(typename std::make_unsigned<IndexType>::type array_size, Args &&... args) // array_size is first dim size 
+void test_tile_pattern(typename std::make_unsigned<IndexType>::type array_size, Args &&... args) // array_size is first dim size 
 {
+  using namespace std;
   typedef typename std::make_unsigned<IndexType>::type                     SizeType;
   typedef typename dash::TilePattern<NumDimensions, Arangement, IndexType> pattern_t;
 
@@ -311,7 +312,12 @@ void test_tile_pattern_constructors(typename std::make_unsigned<IndexType>::type
   typedef typename dash::DistributionSpec<NumDimensions>                   DistributionSpec_t;
   typedef typename dash::TeamSpec<NumDimensions, IndexType>                TeamSpec_t;
 
+  typedef typename std::array<IndexType, NumDimensions>                    coords_t;
+
   auto num_units = dash::Team::All().size();
+  auto unit_id   = dash::myid();
+
+  coords_t coord = {0, static_cast<IndexType>(!(bool) args)...};
 
   // test constructors
   pattern_t pattern1(array_size, args...); // check compiling, not check equality with other constructor due to the difference in DistributionSpec
@@ -323,12 +329,55 @@ void test_tile_pattern_constructors(typename std::make_unsigned<IndexType>::type
                      DistributionSpec_t(dash::TILE(array_size / num_units), dash::TILE(args / num_units)...),
                      TeamSpec_t(num_units, static_cast<int>((bool) args)...)); // a hack to input default 1 for higher dims depended on number of args
 
-  //copy constructor
   pattern_t pattern4 = pattern3;
 
   ASSERT_EQ_U(pattern2 == pattern3, true);
   ASSERT_EQ_U(pattern3 == pattern4, true);
-  
+
+  //test .extents
+  ASSERT_EQ_U(pattern2.extent(0), array_size);
+
+  auto l_extents = pattern2.local_extents();
+  ASSERT_EQ_U(accumulate(begin(l_extents), end(l_extents), 1, multiplies<SizeType>()), pattern2.local_size());
+
+  auto g_extents = pattern2.extents();
+  ASSERT_EQ_U(accumulate(begin(g_extents), end(g_extents), 1, multiplies<SizeType>()), pattern2.size());
+
+  ASSERT_EQ_U(pattern2.local_size(), pattern2.local_capacity()); //assumed balanced extents
+  ASSERT_EQ_U(pattern2.size(), pattern2.capacity());
+
+  //test .at
+  ASSERT_EQ_U(pattern2.at(coord), 0);
+
+  //test .is_local
+  auto l_pos = pattern2.local(coord);
+  ASSERT_EQ_U(pattern2.is_local(pattern2.global_index(pattern2.unit_at(coord), l_pos.coords)), unit_id == 0);
+
+  //test BlockSpec, Local BlockSpec, .blocksize, .max_blocksize
+  auto block_spec = pattern2.blockspec();
+  auto l_block_spec = pattern2.local_blockspec();
+
+  int nblocks =  static_cast<int>(pow(num_units, NumDimensions));
+
+  ASSERT_EQ_U(block_spec.size(), nblocks);
+  ASSERT_EQ_U(l_block_spec.size(), nblocks / num_units); //assumed balanced extents
+
+  int blocksize = 1;
+  for (int dim = 0; dim < NumDimensions; dim++) 
+    blocksize *= pattern2.blocksize(dim);
+  ASSERT_EQ_U(blocksize, pattern2.max_blocksize());
+
+  //test .coords
+  IndexType idx = 0;
+  ASSERT_EQ_U(pattern2.coords(idx), coord);
+
+
+  //test .sizespec, .teamspec
+  auto size_spec = pattern2.sizespec();
+  auto team_spec = pattern2.teamspec();
+
+  ASSERT_EQ_U(size_spec.extent(0), array_size);
+  ASSERT_EQ_U(team_spec.size(), num_units);
 }
 
 TEST_F(TilePatternTest, TilePattern1DFunctionalCheck)
@@ -337,12 +386,12 @@ TEST_F(TilePatternTest, TilePattern1DFunctionalCheck)
 
   //series of default test
   typedef std::make_unsigned<dash::default_index_t>::type size_t;
-  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_tile_pattern_constructors(i);
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_tile_pattern(i);
 
   // series of unsigned COLUMN MAJOR test
   typedef unsigned long                                   index_t;
   typedef std::make_unsigned<index_t>::type               usize_t;
-  for (usize_t i = num_units; i <= 1000 * num_units; i *= 10) test_tile_pattern_constructors<1, dash::COL_MAJOR, index_t>(i);
+  for (usize_t i = num_units; i <= 1000 * num_units; i *= 10) test_tile_pattern<1, dash::COL_MAJOR, index_t>(i);
 }
 
 TEST_F(TilePatternTest, TilePatternFunctionalCheck)
@@ -351,10 +400,10 @@ TEST_F(TilePatternTest, TilePatternFunctionalCheck)
 
   //series of default 2D test
   typedef std::make_unsigned<dash::default_index_t>::type size_t;
-  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_tile_pattern_constructors<2>(i, i);
+  for (size_t i = num_units; i <= 1000 * num_units; i *= 10) test_tile_pattern<2>(i, i);
 
   // series of unsigned COLUMN MAJOR 2D test
   typedef unsigned long                                   index_t;
   typedef std::make_unsigned<index_t>::type               usize_t;
-  for (usize_t i = num_units; i <= 1000 * num_units; i *= 10) test_tile_pattern_constructors<2, dash::COL_MAJOR, index_t>(i, i);
+  for (usize_t i = num_units; i <= 1000 * num_units; i *= 10) test_tile_pattern<2, dash::COL_MAJOR, index_t>(i, i);
 }

--- a/dash/test/pattern/TilePatternTest.cc
+++ b/dash/test/pattern/TilePatternTest.cc
@@ -1,6 +1,5 @@
 
 #include "TilePatternTest.h"
-#include "PatternTest.h" 
 
 #include <dash/pattern/TilePattern.h>
 #include <dash/TeamSpec.h>

--- a/dash/test/pattern/TilePatternTest.h
+++ b/dash/test/pattern/TilePatternTest.h
@@ -2,6 +2,7 @@
 #define DASH__TEST__TILE_PATTERN_TEST_H_
 
 #include "../TestBase.h"
+#include "PatternTest.h" 
 
 /**
  * Test fixture for class dash::Pattern


### PR DESCRIPTION
This PR includes the followings:
- Functionality test for TilePattern, BlockPattern, ShiftedTilePattern, SeqTilePattern (excluding .has_local_elements() because it requires CartesianIndexSpace::includes_index(), which is not yet implemented)
- Make `typedef` of `DistributionSpec, TeamSpec, SizeSpec` public for TilePattern, BlockPattern, ShiftedTilePattern, SeqTilePattern, CSRPattern, DynamicPattern and LoadBalancePattern.
- Various bug fixes


