### PR TITLE
dart.h: Remove `extern "C"`

### DIFF
--- a/dart-if/include/dash/dart/if/dart.h
+++ b/dart-if/include/dash/dart/if/dart.h
@@ -129,9 +129,6 @@ for( auto i=0; i<arr.local.size(); i++ ) [
  *                             information on the internal state of DART.
  *
  */
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /*
    --- DART version and build date ---
@@ -177,10 +174,6 @@ extern "C" {
 */
 #include "dart_synchronization.h"
 
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
 
 #endif /* DART_DART_H_ */
 


### PR DESCRIPTION
All headers include have this already and it is error prone to include
system headers inside such a scope

Reported-by: S.Schueller@itc.rwth-aachen.de