### PR TITLE
fixes compile and linking errors for gcc 10 and clang 10

### DIFF
--- a/dart-impl/base/include/dash/dart/base/logging.h
+++ b/dart-impl/base/include/dash/dart/base/logging.h
@@ -31,9 +31,9 @@ enum dart__base__term_color_code {
 extern "C" {
 #endif
 
-const int dart__base__term_colors[DART_LOG_TCOL_NUM_CODES];
+extern const int dart__base__term_colors[DART_LOG_TCOL_NUM_CODES];
 
-const int dart__base__unit_term_colors[DART_LOG_TCOL_NUM_CODES-1];
+extern const int dart__base__unit_term_colors[DART_LOG_TCOL_NUM_CODES-1];
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -121,6 +121,15 @@ public:
    */
   self_t &operator=(const self_t &rhs) = default;
 
+  /**
+   * Assignment operator.
+   */
+  self_t &operator=(std::nullptr_t) {
+    m_dart_pointer = DART_GPTR_NULL;
+
+    return *this;
+  }
+
   //clang-format off
   /**
    * Implicit Converting Constructor, only allowed if one of the following

--- a/dash/include/dash/GlobPtr.h
+++ b/dash/include/dash/GlobPtr.h
@@ -122,7 +122,7 @@ public:
   self_t &operator=(const self_t &rhs) = default;
 
   /**
-   * Assignment operator.
+   * nullptr assignment operator.
    */
   self_t &operator=(std::nullptr_t) {
     m_dart_pointer = DART_GPTR_NULL;


### PR DESCRIPTION
- added overloaded assignment operator for nullptr in GlobPtr
- declared two variables extern in dart base to avoid linking errors